### PR TITLE
Manage invites: add endpoints for Create invite and Register

### DIFF
--- a/src/main/java/org/udg/trackdev/spring/configuration/WebSecurityConfig.java
+++ b/src/main/java/org/udg/trackdev/spring/configuration/WebSecurityConfig.java
@@ -20,6 +20,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .addFilterAfter(new JWTAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class)
             .authorizeRequests()
             .antMatchers(HttpMethod.POST, "/auth/login").permitAll()
+            .antMatchers(HttpMethod.POST, "/users/register").permitAll()
             .anyRequest().authenticated();
 
         http.headers()

--- a/src/main/java/org/udg/trackdev/spring/controller/BaseController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/BaseController.java
@@ -24,4 +24,9 @@ public class BaseController {
       throw new ControllerException("No authentication token in request");
     return principal.getName();
   }
+
+  void checkNotLoggedIn(Principal principal) {
+    if(principal != null)
+      throw new ControllerException("User should not be authenticated");
+  }
 }

--- a/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
@@ -10,6 +10,7 @@ import org.udg.trackdev.spring.service.InviteService;
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+import java.security.Principal;
 
 @RestController
 @RequestMapping(path = "/invites")
@@ -19,8 +20,9 @@ public class InviteController {
     InviteService service;
 
     @PostMapping()
-    public IdObjectLong createInvite(@Valid @RequestBody NewInvite inviteRequest) {
-        Invite createdInvite = service.createInvite(inviteRequest.email, inviteRequest.role);
+    public IdObjectLong createInvite(Principal principal, @Valid @RequestBody NewInvite inviteRequest) {
+        String userId = principal.getName();
+        Invite createdInvite = service.createInvite(inviteRequest.email, inviteRequest.role, userId);
         return new IdObjectLong(createdInvite.getId());
     }
 

--- a/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
@@ -9,8 +9,10 @@ import org.udg.trackdev.spring.service.InviteService;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.security.Principal;
+import java.util.Collection;
 
 @RestController
 @RequestMapping(path = "/invites")
@@ -22,7 +24,7 @@ public class InviteController {
     @PostMapping()
     public IdObjectLong createInvite(Principal principal, @Valid @RequestBody NewInvite inviteRequest) {
         String userId = principal.getName();
-        Invite createdInvite = service.createInvite(inviteRequest.email, inviteRequest.role, userId);
+        Invite createdInvite = service.createInvite(inviteRequest.email, inviteRequest.roles, userId);
         return new IdObjectLong(createdInvite.getId());
     }
 
@@ -31,7 +33,7 @@ public class InviteController {
         @Email
         public String email;
 
-        @NotNull
-        public UserType role;
+        @NotEmpty
+        public Collection<UserType> roles;
     }
 }

--- a/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
@@ -5,12 +5,14 @@ import org.springframework.web.bind.annotation.*;
 import org.udg.trackdev.spring.configuration.UserType;
 import org.udg.trackdev.spring.entity.IdObjectLong;
 import org.udg.trackdev.spring.entity.Invite;
+import org.udg.trackdev.spring.entity.User;
 import org.udg.trackdev.spring.service.InviteService;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.security.Principal;
 import java.util.Collection;
 
@@ -31,6 +33,7 @@ public class InviteController {
     static class NewInvite {
         @NotNull
         @Email
+        @Size(max = User.EMAIL_LENGTH)
         public String email;
 
         @NotEmpty

--- a/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/InviteController.java
@@ -1,0 +1,35 @@
+package org.udg.trackdev.spring.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import org.udg.trackdev.spring.configuration.UserType;
+import org.udg.trackdev.spring.entity.IdObjectLong;
+import org.udg.trackdev.spring.entity.Invite;
+import org.udg.trackdev.spring.service.InviteService;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@RestController
+@RequestMapping(path = "/invites")
+public class InviteController {
+
+    @Autowired
+    InviteService service;
+
+    @PostMapping()
+    public IdObjectLong createInvite(@Valid @RequestBody NewInvite inviteRequest) {
+        Invite createdInvite = service.createInvite(inviteRequest.email, inviteRequest.role);
+        return new IdObjectLong(createdInvite.getId());
+    }
+
+    static class NewInvite {
+        @NotNull
+        @Email
+        public String email;
+
+        @NotNull
+        public UserType role;
+    }
+}

--- a/src/main/java/org/udg/trackdev/spring/controller/UserController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/UserController.java
@@ -2,12 +2,14 @@ package org.udg.trackdev.spring.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import org.udg.trackdev.spring.entity.User;
 import org.udg.trackdev.spring.service.UserService;
 
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.security.Principal;
 
 // This class is used to manage users and sign up
@@ -58,10 +60,12 @@ public class UserController extends BaseController {
 
     static class RegisterT {
         @NotBlank
+        @Size(max = User.USERNAME_LENGTH)
         public String username;
 
         @NotBlank
         @Email
+        @Size(max = User.EMAIL_LENGTH)
         public String email;
 
         @NotBlank

--- a/src/main/java/org/udg/trackdev/spring/controller/UserController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/UserController.java
@@ -26,16 +26,6 @@ public class UserController extends BaseController {
     @Autowired
     UserService userService;
 
-//    @PostMapping(path = "/logout")
-//    @JsonView(Views.Private.class)
-//    public String logout(HttpSession session) {
-//
-//        Long TID = getLoggedUser(session);
-//
-//        session.removeAttribute("simpleapp_auth_id");
-//        return BaseController.OK_MESSAGE;
-//    }
-
 //    @GetMapping(path = "/{id}")
 //    @JsonView(Views.Public.class)
 //    public User getPublicT(HttpSession session, @PathVariable("id") Long TId) {
@@ -59,22 +49,12 @@ public class UserController extends BaseController {
 //    return BaseController.OK_MESSAGE;
 //  }
 
-
 //    @PostMapping(path = "/register")
 //    public String register(HttpSession session, @Valid @RequestBody RegisterT ru) {
 //
 //        checkNotLoggedIn(session);
 //        userService.register(ru.username, ru.email, ru.password);
 //        return BaseController.OK_MESSAGE;
-//    }
-
-//    @GetMapping(path = "/me")
-//    @JsonView(Views.Complete.class)
-//    public User getTProfile(HttpSession session) {
-//
-//        Long loggedTId = getLoggedUser(session);
-//
-//        return userService.getUser(loggedTId);
 //    }
 
 //    @GetMapping(path = "/check")
@@ -84,13 +64,6 @@ public class UserController extends BaseController {
 //
 //        return BaseController.OK_MESSAGE;
 //    }
-
-    static class LoginT {
-        @NotNull
-        public String username;
-        @NotNull
-        public String password;
-    }
 
     static class RegisterT {
         @NotNull

--- a/src/main/java/org/udg/trackdev/spring/controller/UserController.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/UserController.java
@@ -1,24 +1,16 @@
 package org.udg.trackdev.spring.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.web.bind.annotation.*;
-import org.udg.trackdev.spring.entity.User;
-import org.udg.trackdev.spring.entity.Views;
 import org.udg.trackdev.spring.service.UserService;
 
-import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 
-// This class is used to process all the authentication related URLs
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import java.security.Principal;
+
+// This class is used to manage users and sign up
 @RequestMapping(path = "/users")
 @RestController
 public class UserController extends BaseController {
@@ -49,13 +41,12 @@ public class UserController extends BaseController {
 //    return BaseController.OK_MESSAGE;
 //  }
 
-//    @PostMapping(path = "/register")
-//    public String register(HttpSession session, @Valid @RequestBody RegisterT ru) {
-//
-//        checkNotLoggedIn(session);
-//        userService.register(ru.username, ru.email, ru.password);
-//        return BaseController.OK_MESSAGE;
-//    }
+    @PostMapping(path = "/register")
+    public String register(Principal principal, @Valid @RequestBody RegisterT ru) {
+        checkNotLoggedIn(principal);
+        userService.register(ru.username, ru.email, ru.password);
+        return BaseController.OK_MESSAGE;
+    }
 
 //    @GetMapping(path = "/check")
 //    public String checkLoggedIn(HttpSession session) {
@@ -66,16 +57,15 @@ public class UserController extends BaseController {
 //    }
 
     static class RegisterT {
-        @NotNull
+        @NotBlank
         public String username;
-        @NotNull
+
+        @NotBlank
+        @Email
         public String email;
-        @NotNull
+
+        @NotBlank
         public String password;
-        @NotNull
-        public String name;
-        @NotNull
-        public String address;
     }
 
     static class UpdateT {

--- a/src/main/java/org/udg/trackdev/spring/entity/BaseEntityUUID.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/BaseEntityUUID.java
@@ -6,10 +6,12 @@ import javax.persistence.*;
 
 @MappedSuperclass
 public abstract class BaseEntityUUID {
+    public static final int UUID_LENGTH = 36;
+
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
-    @Column(length = 36)
+    @Column(length = UUID_LENGTH)
     private String id;
 
     public String getId() {

--- a/src/main/java/org/udg/trackdev/spring/entity/Invite.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Invite.java
@@ -10,6 +10,8 @@ import javax.validation.constraints.NotNull;
 @Table(name = "invites")
 public class Invite extends BaseEntityLong {
 
+    public Invite() {}
+
     public Invite(UserType TType) {
         this.TType = TType;
     }

--- a/src/main/java/org/udg/trackdev/spring/entity/Invite.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Invite.java
@@ -20,6 +20,7 @@ public class Invite extends BaseEntityLong {
     }
 
     @NotNull
+    @Column(length=User.EMAIL_LENGTH)
     private String email;
 
     @ManyToMany()
@@ -30,7 +31,7 @@ public class Invite extends BaseEntityLong {
     @JoinColumn(name = "ownerId")
     private User owner;
 
-    @Column(name = "ownerId", insertable = false, updatable = false)
+    @Column(name = "ownerId", insertable = false, updatable = false, length = BaseEntityUUID.UUID_LENGTH)
     private String ownerId;
 
     @JsonView(Views.Public.class)

--- a/src/main/java/org/udg/trackdev/spring/entity/Invite.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Invite.java
@@ -1,10 +1,13 @@
 package org.udg.trackdev.spring.entity;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import org.udg.trackdev.spring.configuration.UserType;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.udg.trackdev.spring.serializer.JsonRolesSerializer;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "invites")
@@ -12,15 +15,15 @@ public class Invite extends BaseEntityLong {
 
     public Invite() {}
 
-    public Invite(UserType TType) {
-        this.TType = TType;
+    public Invite(String email) {
+        this.email = email;
     }
 
     @NotNull
     private String email;
 
-    @NotNull
-    private UserType TType;
+    @ManyToMany()
+    private Set<Role> roles = new HashSet<>();
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,19 +34,16 @@ public class Invite extends BaseEntityLong {
     private String ownerId;
 
     @JsonView(Views.Public.class)
-    public UserType getUserType() {
-      return TType;
-    }
+    @JsonSerialize(using= JsonRolesSerializer.class)
+    public Set<Role> getRoles() { return roles; }
 
     public String getEmail() {
         return email;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
     public void setOwner(User owner) { this.owner = owner; }
 
     public String getOwnerId() { return ownerId; }
+
+    public void addRole(Role role) { this.roles.add(role); }
 }

--- a/src/main/java/org/udg/trackdev/spring/entity/Invite.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Invite.java
@@ -22,6 +22,14 @@ public class Invite extends BaseEntityLong {
     @NotNull
     private UserType TType;
 
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ownerId")
+    private User owner;
+
+    @Column(name = "ownerId", insertable = false, updatable = false)
+    private String ownerId;
+
     @JsonView(Views.Public.class)
     public UserType getUserType() {
       return TType;
@@ -34,4 +42,8 @@ public class Invite extends BaseEntityLong {
     public void setEmail(String email) {
         this.email = email;
     }
+
+    public void setOwner(User owner) { this.owner = owner; }
+
+    public String getOwnerId() { return ownerId; }
 }

--- a/src/main/java/org/udg/trackdev/spring/entity/Role.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Role.java
@@ -18,10 +18,8 @@ public class Role extends BaseEntityLong implements GrantedAuthority {
   }
 
   @NotNull
+  @Column(unique = true)
   private UserType userType;
-
-  @ManyToOne
-  private User User;
 
   @JsonView(Views.Private.class)
   public Long getId() {

--- a/src/main/java/org/udg/trackdev/spring/entity/User.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/User.java
@@ -47,6 +47,9 @@ public class User extends BaseEntityUUID {
   @OneToMany(cascade = CascadeType.ALL)
   private Set<Role> roles = new HashSet<>();
 
+  @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "owner")
+  private Collection<Invite> invites = new ArrayList<>();
+
   @JsonView(Views.Private.class)
   public String getId() {
     return super.getId();
@@ -88,4 +91,6 @@ public class User extends BaseEntityUUID {
   public void addToGroup(Group group) {
     this.groups.add(group);
   }
+
+  public void addInvite(Invite invite) { this.invites.add(invite); }
 }

--- a/src/main/java/org/udg/trackdev/spring/entity/User.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/User.java
@@ -44,7 +44,7 @@ public class User extends BaseEntityUUID {
   @ManyToMany
   private Collection<Group> groups = new ArrayList<>();
 
-  @OneToMany(cascade = CascadeType.ALL)
+  @ManyToMany()
   private Set<Role> roles = new HashSet<>();
 
   @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "owner")

--- a/src/main/java/org/udg/trackdev/spring/entity/User.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/User.java
@@ -16,6 +16,9 @@ import java.util.*;
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id", scope = User.class)
 public class User extends BaseEntityUUID {
 
+  public static final int USERNAME_LENGTH = 12;
+  public static final int EMAIL_LENGTH = 128;
+
   public User() {
   }
 
@@ -26,11 +29,11 @@ public class User extends BaseEntityUUID {
   }
 
   @NotNull
-  @Column(unique=true, length=12)
+  @Column(unique=true, length=USERNAME_LENGTH)
   private String username;
 
   @NotNull
-  @Column(unique=true, length=128)
+  @Column(unique=true, length=EMAIL_LENGTH)
   private String email;
 
   @NotNull

--- a/src/main/java/org/udg/trackdev/spring/repository/RoleRepository.java
+++ b/src/main/java/org/udg/trackdev/spring/repository/RoleRepository.java
@@ -1,10 +1,14 @@
 package org.udg.trackdev.spring.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
+import org.udg.trackdev.spring.configuration.UserType;
 import org.udg.trackdev.spring.entity.Role;
-import org.udg.trackdev.spring.entity.Task;
+
+import java.util.List;
 
 @Component
 public interface RoleRepository extends JpaRepository<Role, Long> {
+    List<Role> findByUserType(@Param("userType") UserType userType);
 }

--- a/src/main/java/org/udg/trackdev/spring/service/InviteService.java
+++ b/src/main/java/org/udg/trackdev/spring/service/InviteService.java
@@ -1,0 +1,21 @@
+package org.udg.trackdev.spring.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.udg.trackdev.spring.configuration.UserType;
+import org.udg.trackdev.spring.entity.Invite;
+import org.udg.trackdev.spring.repository.InviteRepository;
+
+@Service
+public class InviteService {
+
+    @Autowired
+    InviteRepository inviteRepository;
+
+    public Invite createInvite(String email, UserType role) {
+        Invite invite = new Invite(role);
+        invite.setEmail(email);
+        inviteRepository.save(invite);
+        return invite;
+    }
+}

--- a/src/main/java/org/udg/trackdev/spring/service/InviteService.java
+++ b/src/main/java/org/udg/trackdev/spring/service/InviteService.java
@@ -2,20 +2,77 @@ package org.udg.trackdev.spring.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.udg.trackdev.spring.configuration.UserType;
+import org.udg.trackdev.spring.controller.exceptions.ServiceException;
 import org.udg.trackdev.spring.entity.Invite;
+import org.udg.trackdev.spring.entity.Role;
+import org.udg.trackdev.spring.entity.User;
 import org.udg.trackdev.spring.repository.InviteRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 @Service
 public class InviteService {
-
     @Autowired
     InviteRepository inviteRepository;
 
-    public Invite createInvite(String email, UserType role) {
+    @Autowired
+    UserService userService;
+
+    @Transactional
+    public Invite createInvite(String email, UserType role, String ownerId) {
+        User owner = userService.get(ownerId);
+        checkIfCanInviteRole(owner.getRoles(), role);
+        userService.checkIfEmailExists(email);
+        checkIfExists(email, ownerId);
+
         Invite invite = new Invite(role);
         invite.setEmail(email);
-        inviteRepository.save(invite);
+        owner.addInvite(invite);
+        invite.setOwner(owner);
         return invite;
+    }
+
+    private void checkIfExists(String email, String ownerId) {
+        List<Invite> invites = inviteRepository.findByEmail(email);
+        boolean alreadyInvited = invites.stream()
+                .anyMatch(i -> i.getOwnerId().equals(ownerId));
+        if(alreadyInvited) {
+            throw new ServiceException("Invitation for this email already exists");
+        }
+    }
+
+    private void checkIfCanInviteRole(Set<Role> ownerRoles, UserType invitationRole) {
+        boolean canInvite = false;
+        for (Role ownerRole : ownerRoles) {
+            canInvite = canInviteRole(ownerRole.getUserType(), invitationRole);
+            if(canInvite) {
+                break;
+            }
+        }
+        if(!canInvite) {
+            throw new ServiceException("User is not allowed to create an invitation for this role");
+        }
+    }
+
+    private boolean canInviteRole(UserType ownerType, UserType invitationRole) {
+        List<UserType> allowedRoles = new ArrayList<UserType>();
+        switch (ownerType) {
+            case ADMIN:
+                allowedRoles.add(UserType.ADMIN);
+                allowedRoles.add(UserType.PROFESSOR);
+                break;
+            case PROFESSOR:
+                allowedRoles.add(UserType.PROFESSOR);
+                allowedRoles.add(UserType.STUDENT);
+                break;
+            case STUDENT:
+                break;
+        }
+        boolean canInvite = allowedRoles.stream().anyMatch(s -> s == invitationRole);
+        return canInvite;
     }
 }

--- a/src/main/java/org/udg/trackdev/spring/service/RoleService.java
+++ b/src/main/java/org/udg/trackdev/spring/service/RoleService.java
@@ -1,0 +1,33 @@
+package org.udg.trackdev.spring.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.udg.trackdev.spring.configuration.UserType;
+import org.udg.trackdev.spring.controller.exceptions.ServiceException;
+import org.udg.trackdev.spring.entity.Role;
+import org.udg.trackdev.spring.repository.RoleRepository;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+public class RoleService {
+
+    @Autowired
+    RoleRepository roleRepository;
+
+    @Transactional
+    public Role get(UserType type) {
+        List<Role> roles = roleRepository.findByUserType(type);
+        Role role = null;
+        if(roles.size() == 1) {
+            role = roles.get(0);
+        } else if (roles.size() == 0) {
+            role = new Role(type);
+            roleRepository.save(role);
+        } else {
+            throw new ServiceException("Unexpected state of roles in repository");
+        }
+        return role;
+    }
+}

--- a/src/main/java/org/udg/trackdev/spring/service/UserService.java
+++ b/src/main/java/org/udg/trackdev/spring/service/UserService.java
@@ -9,7 +9,6 @@ import org.udg.trackdev.spring.entity.Role;
 import org.udg.trackdev.spring.entity.User;
 import org.udg.trackdev.spring.configuration.UserType;
 import org.udg.trackdev.spring.repository.InviteRepository;
-import org.udg.trackdev.spring.repository.RoleRepository;
 import org.udg.trackdev.spring.repository.UserRepository;
 
 import java.util.List;
@@ -22,7 +21,7 @@ public class UserService {
     private UserRepository userRepository;
 
     @Autowired
-    private RoleRepository roleRepository;
+    private RoleService roleService;
 
     @Autowired
     private InviteRepository inviteRepository;
@@ -61,10 +60,10 @@ public class UserService {
 
         User User = new User(username, email, global.getPasswordEncoder().encode(password));
         for (Invite invite: invites) {
-            Role role = new Role(invite.getUserType());
-            User.addRole(role);
+            for(Role inviteRole : invite.getRoles()) {
+                User.addRole(inviteRole);
+            }
         }
-
         userRepository.save(User);
         return User;
     }
@@ -83,7 +82,7 @@ public class UserService {
 
         User user = new User(username, email, password);
         for (UserType ut: roles) {
-            Role role = new Role(ut);
+            Role role = roleService.get(ut);
             user.addRole(role);
         }
         userRepository.save(user);

--- a/src/main/java/org/udg/trackdev/spring/service/UserService.java
+++ b/src/main/java/org/udg/trackdev/spring/service/UserService.java
@@ -34,6 +34,11 @@ public class UserService {
         return userRepository;
     }
 
+    public void checkIfEmailExists(String email) {
+        if (userRepository.existsByEmail(email))
+            throw new ServiceException("User with this email already exist");
+    }
+
     public User matchPassword(String username, String password) {
 
         User user = userRepository.findByUsername(username);
@@ -87,8 +92,7 @@ public class UserService {
     }
 
     private void checkIfExists(String username, String email) {
-        if (userRepository.existsByEmail(email))
-            throw new ServiceException("Email already exist");
+        checkIfEmailExists(email);
 
         if (userRepository.existsByUsername(username))
             throw new ServiceException("Tname already exists");


### PR DESCRIPTION
I made some decisions that I hope you agree:

* An invite is configured for an email and many roles.
  * So instead of created two invites: "professor1@xx - ADMIN" and "professor1@xx - PROFESSOR"
  * We create one single invite "professor1@xx - [ADMIN,PROFESSOR]"
  
* Only save one role per usertype in database.
  * I noticed we weren't saving the related User and there was a column userId in table roles with only null values.
  * As roles are generic and don't contain unique user information.