### PR TITLE
Show group in task

### DIFF
--- a/src/main/java/org/udg/trackdev/spring/controller/exceptions/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/udg/trackdev/spring/controller/exceptions/RestResponseEntityExceptionHandler.java
@@ -1,5 +1,7 @@
 package org.udg.trackdev.spring.controller.exceptions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -22,6 +24,8 @@ import java.util.Date;
 @ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(RestResponseEntityExceptionHandler.class);
 
     public RestResponseEntityExceptionHandler() {
         super();
@@ -53,6 +57,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
                             "Error parsing search parameter"),
                     new HttpHeaders(), HttpStatus.NOT_FOUND, request);
         } else
+            logger.warn("Unknown error occurred", ex);
             return handleExceptionInternal(ex,
                     buildErrorEntity("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR, ex),
                     new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
@@ -62,6 +67,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     protected ResponseEntity<Object> handleExceptionInternal(
             Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
 
+        logger.warn("Unknown error occurred", ex);
         if (HttpStatus.INTERNAL_SERVER_ERROR.equals(status)) {
             request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST);
         }

--- a/src/main/java/org/udg/trackdev/spring/entity/Backlog.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Backlog.java
@@ -1,5 +1,10 @@
 package org.udg.trackdev.spring.entity;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.udg.trackdev.spring.entity.views.EntityLevelViews;
+import org.udg.trackdev.spring.serializer.JsonHierarchyViewSerializer;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,6 +19,8 @@ public class Backlog extends BaseEntityLong {
     @OneToMany(mappedBy = "backlog", cascade = CascadeType.ALL)
     private Collection<Task> tasks = new ArrayList<>();
 
+    @JsonView(EntityLevelViews.Hierarchy.class)
+    @JsonSerialize(using = JsonHierarchyViewSerializer.class)
     public Group getGroup() {
         return this.group;
     }

--- a/src/main/java/org/udg/trackdev/spring/entity/BaseEntityLong.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/BaseEntityLong.java
@@ -11,6 +11,6 @@ public abstract class BaseEntityLong {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JsonView(EntityLevelViews.Basic.class)
+    @JsonView({ EntityLevelViews.Basic.class, EntityLevelViews.Hierarchy.class })
     public Long getId() { return id; }
 }

--- a/src/main/java/org/udg/trackdev/spring/entity/Task.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Task.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.springframework.lang.NonNull;
 import org.udg.trackdev.spring.entity.views.EntityLevelViews;
 import org.udg.trackdev.spring.serializer.JsonDateSerializer;
+import org.udg.trackdev.spring.serializer.JsonHierarchyViewSerializer;
 
 import javax.persistence.*;
 import java.util.Collection;
@@ -78,6 +79,8 @@ public class Task extends BaseEntityLong {
     @JsonView(EntityLevelViews.Basic.class)
     public User getReporter() { return reporter; }
 
+    @JsonView({ EntityLevelViews.Basic.class, EntityLevelViews.Hierarchy.class } )
+    @JsonSerialize(using = JsonHierarchyViewSerializer.class)
     public Backlog getBacklog() {
         return backlog;
     }

--- a/src/main/java/org/udg/trackdev/spring/entity/views/EntityLevelViews.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/views/EntityLevelViews.java
@@ -3,6 +3,7 @@ package org.udg.trackdev.spring.entity.views;
 // Views for use by Json serialization
 // to solve problems of recursion in entities with bidirectional relationships
 public class EntityLevelViews {
+  static public class Hierarchy { }
   static public class Basic { }
   static public class CourseComplete extends Basic { }
   static public class CourseYearComplete extends Basic { }

--- a/src/main/java/org/udg/trackdev/spring/serializer/JsonHierarchyViewSerializer.java
+++ b/src/main/java/org/udg/trackdev/spring/serializer/JsonHierarchyViewSerializer.java
@@ -1,0 +1,22 @@
+package org.udg.trackdev.spring.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.udg.trackdev.spring.entity.views.EntityLevelViews;
+
+import java.io.IOException;
+
+public class JsonHierarchyViewSerializer extends JsonSerializer<Object> {
+
+    @Override
+    public void serialize(Object object, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        ObjectMapper mapper = (ObjectMapper) gen.getCodec();
+        ObjectWriter writer = mapper.writerWithView(EntityLevelViews.Hierarchy.class);
+        String serializedObject = writer.writeValueAsString(object);
+        gen.writeRawValue(serializedObject);
+    }
+}

--- a/src/main/java/org/udg/trackdev/spring/service/DemoDataSeeder.java
+++ b/src/main/java/org/udg/trackdev/spring/service/DemoDataSeeder.java
@@ -14,7 +14,7 @@ import java.util.*;
 public class DemoDataSeeder {
 
     private final Logger logger = LoggerFactory.getLogger(Global.class);
-    private final List<Integer> possibleEstimationPoints = Arrays.asList(1, 2, 3, 4, 5, 8, 13, 20, 40, 100);
+    private final List<Integer> possibleEstimationPoints = Arrays.asList(1, 2, 3, 5, 8, 13, 20, 40, 100);
 
     @Autowired
     Global global;


### PR DESCRIPTION
My aim is to know the group in order to fetch "/groups/{groupId}" in task to get group members for the select to change assignee. I guess in the future we can include the group name to build the breadcrumb. Other option would be to create a new enpoint similar to "/tasks/{taskId}/possibleAssignees" or a new property in Task with "possibleAssignees".

I had problems again with the recursive serialization. I tested another approached different than before with the EntityLevelView.CompleteCourse.class and EntityLevelView.CourseYearComplete.class as here I need two levels up in the hierarchy. Solution is inspired by this article: https://www.baeldung.com/jackson-call-default-serializer-from-custom-serializer . I access the ObjectMapper with a cast, which isn't nice but works.