### PR TITLE
Remove forcing IdentityReference always for childTasks

### DIFF
--- a/src/main/java/org/udg/trackdev/spring/entity/Task.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Task.java
@@ -132,7 +132,6 @@ public class Task extends BaseEntityLong {
     }
 
     @JsonView(EntityLevelViews.Basic.class)
-    @JsonIdentityReference(alwaysAsId = true)
     public Collection<Task> getChildTasks() {
         return childTasks;
     }


### PR DESCRIPTION
This hides the tasks when getting only 1 task for page /tasks/{id}