### PR TITLE
Add bidireccional association.

### DIFF
--- a/src/main/java/org/udg/trackdev/spring/entity/Sprint.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Sprint.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.springframework.lang.NonNull;
 import org.udg.trackdev.spring.controller.exceptions.EntityException;
+import org.udg.trackdev.spring.entity.sprintchanges.SprintChange;
 import org.udg.trackdev.spring.entity.views.EntityLevelViews;
 import org.udg.trackdev.spring.service.Global;
 
@@ -42,6 +43,9 @@ public class Sprint extends BaseEntityLong {
 
     @OneToMany(mappedBy = "activeSprint")
     private Collection<Task> activeTasks;
+
+    @OneToMany(mappedBy = "entity", cascade = CascadeType.ALL)
+    private Collection<SprintChange> sprintChanges;
 
     @NonNull
     @JsonView(EntityLevelViews.Basic.class)

--- a/src/main/java/org/udg/trackdev/spring/entity/Task.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Task.java
@@ -1,12 +1,12 @@
 package org.udg.trackdev.spring.entity;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.springframework.lang.NonNull;
 import org.udg.trackdev.spring.controller.exceptions.EntityException;
+import org.udg.trackdev.spring.entity.taskchanges.TaskChange;
 import org.udg.trackdev.spring.entity.views.EntityLevelViews;
 import org.udg.trackdev.spring.serializer.JsonDateSerializer;
 import org.udg.trackdev.spring.serializer.JsonHierarchyViewSerializer;
@@ -80,6 +80,9 @@ public class Task extends BaseEntityLong {
 
     @Column(name = "activeSprintId", insertable = false, updatable = false)
     private Long activeSprintId;
+
+    @OneToMany(mappedBy = "entity", cascade = CascadeType.ALL)
+    private Collection<TaskChange> taskChanges;
 
     @NonNull
     @JsonView(EntityLevelViews.Basic.class)


### PR DESCRIPTION
This enables cascade delete to delete sprint/task changes when group or course is deleted.