### PR TITLE
Allow moving from Created to Todo even if task is not in sprint

### DIFF
--- a/src/main/java/org/udg/trackdev/spring/entity/Task.java
+++ b/src/main/java/org/udg/trackdev/spring/entity/Task.java
@@ -174,8 +174,7 @@ public class Task extends BaseEntityLong {
     }
 
     private void checkCanMoveToStatus(TaskStatus status) {
-        boolean canBeMovedToTodo = this.activeSprint != null;
-        if(this.status == TaskStatus.CREATED && !(status == TaskStatus.TODO && canBeMovedToTodo || status == TaskStatus.DELETED)) {
+        if(this.status == TaskStatus.CREATED && !(status == TaskStatus.TODO || status == TaskStatus.DELETED)) {
             throw new EntityException(String.format("Cannot change status from CREATED to new status <%s>", status));
         }
         if(this.status == TaskStatus.DELETED) {


### PR DESCRIPTION
This is a workaround for be able to move the status of a subtask. Proper solution needs more work. Subtasks are not added to the sprint now, they follow the parent.