### PR TITLE
Add missing table name (avoid problem with case sentitive queries)

### DIFF
--- a/src/main/java/org/trackdev/api/entity/Role.java
+++ b/src/main/java/org/trackdev/api/entity/Role.java
@@ -5,9 +5,11 @@ import org.trackdev.api.configuration.UserType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity
+@Table(name = "role")
 public class Role extends BaseEntityLong implements GrantedAuthority {
 
   public Role() {


### PR DESCRIPTION
Add missing table name. Avoids problems with case sentitive queries when mixing Lilnux/WIndows