### PR TITLE
Add task existence check and update project member handling in ProjectService

### DIFF
--- a/src/main/java/org/trackdev/api/repository/GroupRepository.java
+++ b/src/main/java/org/trackdev/api/repository/GroupRepository.java
@@ -3,8 +3,12 @@ package org.trackdev.api.repository;
 import org.springframework.stereotype.Component;
 import org.trackdev.api.entity.Project;
 
+import java.util.List;
+
 @Component
 public interface GroupRepository extends BaseRepositoryLong<Project> {
     
     boolean existsBySlug(String slug);
+    
+    List<Project> findByCourseIdOrderByNameAsc(Long courseId);
 }

--- a/src/main/java/org/trackdev/api/repository/TaskRepository.java
+++ b/src/main/java/org/trackdev/api/repository/TaskRepository.java
@@ -48,4 +48,9 @@ public interface TaskRepository extends BaseRepositoryLong<Task> {
      * Find latest N tasks in the given projects
      */
     List<Task> findTop5ByProjectInOrderByCreatedAtDesc(Collection<Project> projects);
+
+    /**
+     * Check if a project has any tasks
+     */
+    boolean existsByProjectId(Long projectId);
 }

--- a/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
+++ b/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
@@ -564,8 +564,8 @@ public class DemoDataSeeder {
                                                       Course course, User professor,
                                                       SprintPattern sprintPattern) {
         // Create project
-        List<String> studentEmails = students.stream().map(User::getEmail).toList();
-        Project project = projectService.createProject(projectName, studentEmails, course.getId(), professor.getId());
+        List<String> studentIds = students.stream().map(User::getId).toList();
+        Project project = projectService.createProject(projectName, studentIds, course.getId(), professor.getId());
 
         // Apply sprint pattern to create sprints linked to pattern items
         project = projectService.applySprintPattern(project.getId(), sprintPattern.getId(), professor.getId());

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -93,6 +93,7 @@ public final class ErrorConstants {
     // Project errors
     public static final String CANNOT_GENERATE_UNIQUE_SLUG = "Unable to generate a unique project ID. Please try again.";
     public static final String CANNOT_REMOVE_MEMBER_HAS_ASSIGNED_TASKS = "Cannot remove member who has assigned tasks in this project";
+    public static final String PROJECT_HAS_TASKS = "Cannot delete project that has associated tasks";
     
     // Sprint validation errors
     public static final String SPRINT_END_DATE_BEFORE_START = "Sprint end date must be after start date";


### PR DESCRIPTION
Introduce a check to prevent project deletion if associated tasks exist. Update project member handling to use member IDs instead of emails for better consistency and functionality.