### PR TITLE
Implement token-based password reset functionality

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
@@ -42,6 +42,8 @@ public class SecurityConfiguration {
             .cors(withDefaults())
             .authorizeHttpRequests(requests -> requests
                 .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/recovery/**").permitAll()
+                .requestMatchers(HttpMethod.POST, "/auth/forgot-password", "/auth/reset-password").permitAll()
+                .requestMatchers(HttpMethod.GET, "/auth/reset-password/validate").permitAll()
                 .requestMatchers(HttpMethod.GET, "/invites/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/invites/*/accept").permitAll()
                 .requestMatchers("/hooks/**").permitAll()  // GitHub webhooks (unauthenticated, validated via signature)

--- a/src/main/java/org/trackdev/api/entity/PasswordResetToken.java
+++ b/src/main/java/org/trackdev/api/entity/PasswordResetToken.java
@@ -1,0 +1,95 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.ZonedDateTime;
+
+/**
+ * Entity to store password reset tokens.
+ * Tokens are single-use and expire after a configurable time period.
+ */
+@Entity
+@Table(name = "password_reset_tokens")
+public class PasswordResetToken extends BaseEntityUUID {
+
+    public static final int TOKEN_LENGTH = 64;
+    public static final int TOKEN_VALIDITY_HOURS = 24;
+
+    @NotNull
+    @Column(unique = true, length = TOKEN_LENGTH)
+    private String token;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull
+    @Column(columnDefinition = "TIMESTAMP")
+    private ZonedDateTime expiresAt;
+
+    @NotNull
+    @Column(columnDefinition = "TIMESTAMP")
+    private ZonedDateTime createdAt;
+
+    @NotNull
+    private Boolean used = false;
+
+    public PasswordResetToken() {}
+
+    public PasswordResetToken(String token, User user, ZonedDateTime expiresAt) {
+        this.token = token;
+        this.user = user;
+        this.expiresAt = expiresAt;
+        this.createdAt = ZonedDateTime.now();
+        this.used = false;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public ZonedDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(ZonedDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public ZonedDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getUsed() {
+        return used;
+    }
+
+    public void setUsed(Boolean used) {
+        this.used = used;
+    }
+
+    public boolean isExpired() {
+        return ZonedDateTime.now().isAfter(expiresAt);
+    }
+
+    public boolean isValid() {
+        return !used && !isExpired();
+    }
+}

--- a/src/main/java/org/trackdev/api/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/org/trackdev/api/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,21 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.PasswordResetToken;
+import org.trackdev.api.entity.User;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends BaseRepositoryUUID<PasswordResetToken> {
+    
+    Optional<PasswordResetToken> findByToken(String token);
+    
+    Optional<PasswordResetToken> findByTokenAndUsedFalse(String token);
+    
+    List<PasswordResetToken> findByUserAndUsedFalse(User user);
+    
+    void deleteByExpiresAtBefore(ZonedDateTime dateTime);
+    
+    void deleteByUser(User user);
+}

--- a/src/main/java/org/trackdev/api/service/EmailSenderService.java
+++ b/src/main/java/org/trackdev/api/service/EmailSenderService.java
@@ -59,7 +59,9 @@ public class EmailSenderService extends BaseServiceUUID<Email, EmailRepository> 
     /**
      * Send password recovery email with recovery code.
      * Runs asynchronously - caller will not wait for email to be sent.
+     * @deprecated Use sendPasswordResetEmail instead for token-based reset
      */
+    @Deprecated
     @Async
     public void sendRecoveryEmail(String email, String tempCode, String language) {
         Locale locale = Locale.forLanguageTag(language != null ? language : "en");
@@ -69,6 +71,25 @@ public class EmailSenderService extends BaseServiceUUID<Email, EmailRepository> 
             new Object[]{tempCode, recoveryLink}, locale);
 
         sendEmail(email, subject, body, "recovery");
+    }
+
+    /**
+     * Send password reset email with secure token link.
+     * Runs asynchronously - caller will not wait for email to be sent.
+     * 
+     * @param email The recipient email address
+     * @param token The secure reset token
+     * @param language The language for email content
+     */
+    @Async
+    public void sendPasswordResetEmail(String email, String token, String language) {
+        Locale locale = Locale.forLanguageTag(language != null ? language : "en");
+        String resetLink = frontendUrl + "/reset-password?token=" + token;
+        String subject = messageSource.getMessage("email.passwordReset.subject", null, locale);
+        String body = messageSource.getMessage("email.passwordReset.body", 
+            new Object[]{resetLink, 24}, locale); // 24 hours validity
+
+        sendEmail(email, subject, body, "password-reset");
     }
 
     /**

--- a/src/main/java/org/trackdev/api/service/PasswordResetService.java
+++ b/src/main/java/org/trackdev/api/service/PasswordResetService.java
@@ -1,0 +1,155 @@
+package org.trackdev.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.entity.PasswordResetToken;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.repository.PasswordResetTokenRepository;
+import org.trackdev.api.utils.ErrorConstants;
+
+import java.security.SecureRandom;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * Service for managing password reset tokens and password recovery.
+ */
+@Service
+public class PasswordResetService extends BaseServiceUUID<PasswordResetToken, PasswordResetTokenRepository> {
+
+    private static final Logger log = LoggerFactory.getLogger(PasswordResetService.class);
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private EmailSenderService emailSenderService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    /**
+     * Generate a secure random token for password reset.
+     * Uses URL-safe Base64 encoding.
+     */
+    private String generateSecureToken() {
+        byte[] randomBytes = new byte[48]; // 384 bits of randomness
+        secureRandom.nextBytes(randomBytes);
+        return base64Encoder.encodeToString(randomBytes);
+    }
+
+    /**
+     * Request a password reset for the given email.
+     * Creates a token and sends an email with a reset link.
+     * Always returns silently (for security - don't reveal if email exists).
+     * 
+     * @param email The email address to send the reset link to
+     * @param language The language for the email content
+     */
+    @Transactional
+    public void requestPasswordReset(String email, String language) {
+        User user = userService.getByEmail(email);
+        
+        if (user == null) {
+            // Don't reveal if email exists - just log and return silently
+            log.info("Password reset requested for non-existent email: {}", email);
+            return;
+        }
+        
+        if (!user.getEnabled()) {
+            // Don't reveal account status - just log and return silently
+            log.info("Password reset requested for disabled account: {}", email);
+            return;
+        }
+
+        // Invalidate any existing unused tokens for this user
+        invalidateExistingTokens(user);
+
+        // Create new token
+        String token = generateSecureToken();
+        ZonedDateTime expiresAt = ZonedDateTime.now(ZoneId.of("UTC"))
+            .plusHours(PasswordResetToken.TOKEN_VALIDITY_HOURS);
+        
+        PasswordResetToken resetToken = new PasswordResetToken(token, user, expiresAt);
+        repo().save(resetToken);
+
+        // Send email with reset link
+        emailSenderService.sendPasswordResetEmail(email, token, language);
+        
+        log.info("Password reset token created for user: {}", user.getId());
+    }
+
+    /**
+     * Validate a password reset token.
+     * 
+     * @param token The token to validate
+     * @return true if the token is valid, false otherwise
+     */
+    public boolean validateToken(String token) {
+        Optional<PasswordResetToken> resetToken = repo().findByTokenAndUsedFalse(token);
+        return resetToken.isPresent() && resetToken.get().isValid();
+    }
+
+    /**
+     * Reset the password using a valid token.
+     * 
+     * @param token The reset token
+     * @param newPassword The new password to set
+     * @throws ServiceException if the token is invalid or expired
+     */
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        PasswordResetToken resetToken = repo().findByTokenAndUsedFalse(token)
+            .orElseThrow(() -> new ServiceException(ErrorConstants.INVALID_RESET_TOKEN));
+
+        if (!resetToken.isValid()) {
+            throw new ServiceException(ErrorConstants.EXPIRED_RESET_TOKEN);
+        }
+
+        User user = resetToken.getUser();
+        
+        // Update password
+        user.setPassword(passwordEncoder.encode(newPassword));
+        user.setChangePassword(false);
+        user.setRecoveryCode(null); // Clear old recovery code if any
+        userService.repo().save(user);
+
+        // Mark token as used
+        resetToken.setUsed(true);
+        repo().save(resetToken);
+
+        // Invalidate any other unused tokens for this user
+        invalidateExistingTokens(user);
+
+        log.info("Password reset successful for user: {}", user.getId());
+    }
+
+    /**
+     * Invalidate all existing unused tokens for a user.
+     */
+    @Transactional
+    private void invalidateExistingTokens(User user) {
+        repo().findByUserAndUsedFalse(user).forEach(token -> {
+            token.setUsed(true);
+            repo().save(token);
+        });
+    }
+
+    /**
+     * Clean up expired tokens (can be called by a scheduled job).
+     */
+    @Transactional
+    public void cleanupExpiredTokens() {
+        repo().deleteByExpiresAtBefore(ZonedDateTime.now(ZoneId.of("UTC")));
+        log.info("Cleaned up expired password reset tokens");
+    }
+}

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -109,5 +109,9 @@ public final class ErrorConstants {
     public static final String CANNOT_DELETE_USER_HAS_OWNED_COURSES = "Cannot delete user who owns courses";
     public static final String CANNOT_MANAGE_SELF = "You cannot delete or edit your own account from this interface";
     
+    // Password reset errors
+    public static final String INVALID_RESET_TOKEN = "The password reset link is invalid";
+    public static final String EXPIRED_RESET_TOKEN = "The password reset link has expired";
+    
     public static final String EMPTY = "";
 }

--- a/src/main/resources/db/migration/V3__password_forgot.sql
+++ b/src/main/resources/db/migration/V3__password_forgot.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS `password_reset_tokens` (
+	`used` bit(1) NOT NULL,
+	`created_at` timestamp NOT NULL,
+	`expires_at` timestamp NOT NULL,
+	`id` varchar(36) NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`token` varchar(64) NOT NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `UK71lqwbwtklmljk3qlsugr1mig` (`token`),
+	KEY `FKk3ndxg5xp6v7wd4gjyusp15gq` (`user_id`),
+	CONSTRAINT `FKk3ndxg5xp6v7wd4gjyusp15gq` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -31,6 +31,10 @@ email.invite.body=Hello!<br><br><b>{0}</b> has invited you to join the course <b
 email.register.subject=TRACKDEV - Welcome to TrackDev, {0}!
 email.register.body=Welcome to TrackDev, <b>{0}</b>!<br><br>As a student in the Software Project course at UdG, you have been registered on the platform with the following credentials:<br>Username: <b>{1}</b><br>Password: <b>{2}</b><br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>
 
-# Email messages - Password Recovery
+# Email messages - Password Recovery (deprecated - using code)
 email.recovery.subject=TRACKDEV - Password Recovery
 email.recovery.body=Hello!<br><br>You have requested to recover your <b>TrackDev</b> password. If this wasn't you, please ignore this message.<br><br>If it was you, you can reset your password by entering the following code on the password recovery page:<br>Recovery code: <b>{0}</b><br>Access the following <a href="{1}">link</a><br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>
+
+# Email messages - Password Reset (token-based)
+email.passwordReset.subject=TRACKDEV - Reset Your Password
+email.passwordReset.body=Hello!<br><br>You have requested to reset your <b>TrackDev</b> password. If this wasn't you, please ignore this message.<br><br>Click the link below to reset your password:<br><a href="{0}">Reset Password</a><br><br>This link will expire in {1} hours.<br><br>If the button doesn't work, copy and paste this URL into your browser:<br>{0}<br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -31,6 +31,10 @@ email.invite.body=Hola!<br><br><b>{0}</b> t'ha convidat a unir-te al curs <b>{1}
 email.register.subject=TRACKDEV - Benvingut a TrackDev, {0}!
 email.register.body=Benvingut a TrackDev, <b>{0}</b>!<br><br>Com a estudiant de l'assignatura de Projecte de Software de la UdG has estat donat d'alta a la plataforma amb les següents credencials:<br>Usuari: <b>{1}</b><br>Contrasenya: <b>{2}</b><br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>
 
-# Email messages - Password Recovery
+# Email messages - Password Recovery (deprecated - using code)
 email.recovery.subject=TRACKDEV - Recuperació de Contrasenya
 email.recovery.body=Hola!<br><br>Has demanat recuperar la teva contrasenya de <b>TrackDev</b>. Si no has estat tu, ignora aquest missatge.<br><br>Si has estat tu, pots restaurar la teva contrasenya introduint el següent codi a la pàgina de recuperació de contrasenya:<br>Codi de recuperació: <b>{0}</b><br>Accedeix al següent <a href="{1}">enllaç</a><br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>
+
+# Email messages - Password Reset (token-based)
+email.passwordReset.subject=TRACKDEV - Restableix la Contrasenya
+email.passwordReset.body=Hola!<br><br>Has demanat restablir la teva contrasenya de <b>TrackDev</b>. Si no has estat tu, si us plau ignora aquest missatge.<br><br>Fes clic al següent enllaç per restablir la teva contrasenya:<br><a href="{0}">Restablir Contrasenya</a><br><br>Aquest enllaç expirarà en {1} hores.<br><br>Si el botó no funciona, copia i enganxa aquesta URL al teu navegador:<br>{0}<br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -31,6 +31,10 @@ email.invite.body=¡Hola!<br><br><b>{0}</b> te ha invitado a unirte al curso <b>
 email.register.subject=TRACKDEV - ¡Bienvenido a TrackDev, {0}!
 email.register.body=¡Bienvenido a TrackDev, <b>{0}</b>!<br><br>Como estudiante del curso de Proyecto de Software en la UdG, has sido dado de alta en la plataforma con las siguientes credenciales:<br>Usuario: <b>{1}</b><br>Contraseña: <b>{2}</b><br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>
 
-# Email messages - Password Recovery
+# Email messages - Password Recovery (deprecated - using code)
 email.recovery.subject=TRACKDEV - Recuperación de Contraseña
 email.recovery.body=¡Hola!<br><br>Has solicitado recuperar tu contraseña de <b>TrackDev</b>. Si no fuiste tú, ignora este mensaje.<br><br>Si fuiste tú, puedes restablecer tu contraseña introduciendo el siguiente código en la página de recuperación de contraseña:<br>Código de recuperación: <b>{0}</b><br>Accede al siguiente <a href="{1}">enlace</a><br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>
+
+# Email messages - Password Reset (token-based)
+email.passwordReset.subject=TRACKDEV - Restablecer Contraseña
+email.passwordReset.body=¡Hola!<br><br>Has solicitado restablecer tu contraseña de <b>TrackDev</b>. Si no fuiste tú, por favor ignora este mensaje.<br><br>Haz clic en el siguiente enlace para restablecer tu contraseña:<br><a href="{0}">Restablecer Contraseña</a><br><br>Este enlace expirará en {1} horas.<br><br>Si el botón no funciona, copia y pega esta URL en tu navegador:<br>{0}<br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>


### PR DESCRIPTION
Introduce a token-based approach for password recovery and reset, allowing public access to relevant endpoints. This update includes the creation of a new `password_reset_tokens` table, a dedicated service for managing password reset operations, and updated email templates for password reset notifications. Additionally, deprecated the previous recovery email method in favor of the new token-based system.