### PR TITLE
feat(i18n): internationalize profile validation error messages

### DIFF
--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -119,8 +119,8 @@ public final class ErrorConstants {
     public static final String STUDENT_ALREADY_ENROLLED = "error.student.already.enrolled";
     
     // Profile validation errors
-    public static final String PROFILE_ALREADY_APPLIED = "A profile has already been applied to this project";
-    public static final String PROFILE_NOT_IN_COURSE = "Profile does not belong to the project's course";
+    public static final String PROFILE_ALREADY_APPLIED = "error.profile.already.applied";
+    public static final String PROFILE_NOT_IN_COURSE = "error.profile.not.in.course";
     
     // User deletion errors
     public static final String CANNOT_DELETE_USER_HAS_SUBJECTS = "error.user.delete.has.subjects";
@@ -136,16 +136,13 @@ public final class ErrorConstants {
     public static final String EXPIRED_RESET_TOKEN = "error.password.reset.token.expired";
     
     // Profile errors
-    public static final String PROFILE_ALREADY_APPLIED = "error.profile.already.applied";
-    
-    // Profile errors
-    public static final String PROFILE_NOT_EXIST = "Profile does not exist";
-    public static final String PROFILE_NAME_ALREADY_EXISTS = "A profile with this name already exists";
-    public static final String INVALID_PROFILE_NAME_LENGTH = "Profile name must be between 1 and 100 characters";
-    public static final String PROFILE_ENUM_NAME_ALREADY_EXISTS = "An enum with this name already exists in the profile";
-    public static final String PROFILE_ATTRIBUTE_NAME_ALREADY_EXISTS = "An attribute with this name already exists in the profile";
-    public static final String PROFILE_ENUM_REF_NOT_FOUND = "Referenced enum not found in profile";
-    public static final String PROFILE_ENUM_REF_REQUIRED = "Enum reference is required when attribute type is ENUM";
+    public static final String PROFILE_NOT_EXIST = "error.profile.not.found";
+    public static final String PROFILE_NAME_ALREADY_EXISTS = "error.profile.name.exists";
+    public static final String INVALID_PROFILE_NAME_LENGTH = "error.profile.name.length";
+    public static final String PROFILE_ENUM_NAME_ALREADY_EXISTS = "error.profile.enum.name.exists";
+    public static final String PROFILE_ATTRIBUTE_NAME_ALREADY_EXISTS = "error.profile.attribute.name.exists";
+    public static final String PROFILE_ENUM_REF_NOT_FOUND = "error.profile.enum.ref.not.found";
+    public static final String PROFILE_ENUM_REF_REQUIRED = "error.profile.enum.ref.required";
     
     public static final String EMPTY = "";
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -170,3 +170,11 @@ error.password.reset.token.expired=The password reset link has expired
 
 # Profile errors
 error.profile.already.applied=A profile has already been applied to this course
+error.profile.not.in.course=Profile does not belong to the project's course
+error.profile.not.found=Profile does not exist
+error.profile.name.exists=A profile with this name already exists
+error.profile.name.length=Profile name must be between 1 and 100 characters
+error.profile.enum.name.exists=An enum with this name already exists in the profile
+error.profile.attribute.name.exists=An attribute with this name already exists in the profile
+error.profile.enum.ref.not.found=Referenced enum not found in profile
+error.profile.enum.ref.required=Enum reference is required when attribute type is ENUM

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -170,3 +170,11 @@ error.password.reset.token.expired=L'enllaç de restabliment de contrasenya ha e
 
 # Errors de perfils
 error.profile.already.applied=Ja s'ha aplicat un perfil a aquest curs
+error.profile.not.in.course=El perfil no pertany al curs del projecte
+error.profile.not.found=El perfil no existeix
+error.profile.name.exists=Ja existeix un perfil amb aquest nom
+error.profile.name.length=El nom del perfil ha de tenir entre 1 i 100 caràcters
+error.profile.enum.name.exists=Ja existeix una enumeració amb aquest nom al perfil
+error.profile.attribute.name.exists=Ja existeix un atribut amb aquest nom al perfil
+error.profile.enum.ref.not.found=No s'ha trobat la referència a l'enumeració al perfil
+error.profile.enum.ref.required=La referència a l'enumeració és obligatòria quan el tipus d'atribut és ENUM

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -170,3 +170,11 @@ error.password.reset.token.expired=El enlace de restablecimiento de contraseña 
 
 # Errores de perfiles
 error.profile.already.applied=Ya se ha aplicado un perfil a este curso
+error.profile.not.in.course=El perfil no pertenece al curso del proyecto
+error.profile.not.found=El perfil no existe
+error.profile.name.exists=Ya existe un perfil con este nombre
+error.profile.name.length=El nombre del perfil debe tener entre 1 y 100 caracteres
+error.profile.enum.name.exists=Ya existe una enumeración con este nombre en el perfil
+error.profile.attribute.name.exists=Ya existe un atributo con este nombre en el perfil
+error.profile.enum.ref.not.found=No se encontró la referencia a la enumeración en el perfil
+error.profile.enum.ref.required=La referencia a la enumeración es obligatoria cuando el tipo de atributo es ENUM


### PR DESCRIPTION
## Summary
This PR adds comprehensive internationalization support for profile validation error messages across all supported languages (English, Spanish, Catalan).

## Changes Made
- Added 8 new profile validation error messages to `messages.properties` (English)
- Added corresponding Spanish translations to `messages_es.properties`
- Added corresponding Catalan translations to `messages_ca.properties`
- Refactored `ErrorConstants.java` to use i18n message keys instead of hardcoded English strings

## New Error Messages
The following profile validation errors are now internationalized:
- `error.profile.not.in.course` - Profile doesn't belong to project's course
- `error.profile.not.found` - Profile doesn't exist
- `error.profile.name.exists` - Duplicate profile name
- `error.profile.name.length` - Invalid profile name length (1-100 chars)
- `error.profile.enum.name.exists` - Duplicate enum name in profile
- `error.profile.attribute.name.exists` - Duplicate attribute name in profile
- `error.profile.enum.ref.not.found` - Referenced enum not found
- `error.profile.enum.ref.required` - Missing enum reference for ENUM type attribute

## Technical Details
- Converted hardcoded error messages in `ErrorConstants.java` to use message keys
- Removed duplicate `PROFILE_ALREADY_APPLIED` constant definition
- All error messages now support the application's three-language localization system

## Breaking Changes
None. The `ErrorConstants` values changed from English strings to message keys, but this is transparent to callers since the error handling system resolves these keys automatically.