### PR TITLE
refactor: extract intermediate variables in TaskController endpoints

### DIFF
--- a/src/main/java/org/trackdev/api/controller/TaskController.java
+++ b/src/main/java/org/trackdev/api/controller/TaskController.java
@@ -116,7 +116,8 @@ public class TaskController extends CrudController<Task, TaskService> {
             }
         }
         String userId = super.getUserId(principal);
-        return taskMapper.toCompleteDTO(service.editTask(id, taskRequest, userId));
+        Task task = service.editTask(id, taskRequest, userId);
+        return taskMapper.toCompleteDTO(task);
     }
 
     @Operation(summary = "Get history of logs of the task", description = "Get history of logs of the task")
@@ -169,14 +170,16 @@ public class TaskController extends CrudController<Task, TaskService> {
     @PostMapping("/{id}/assign")
     public TaskCompleteDTO selfAssignTask(Principal principal, @PathVariable(name = "id") Long id) {
         String userId = super.getUserId(principal);
-        return taskMapper.toCompleteDTO(service.selfAssignTask(id, userId));
+        Task task = service.selfAssignTask(id, userId);
+        return taskMapper.toCompleteDTO(task);
     }
 
     @Operation(summary = "Unassign task from current user", description = "Allows the assigned user to unassign themselves from a task")
     @DeleteMapping("/{id}/assign")
     public TaskCompleteDTO unassignTask(Principal principal, @PathVariable(name = "id") Long id) {
         String userId = super.getUserId(principal);
-        return taskMapper.toCompleteDTO(service.unassignTask(id, userId));
+        Task task = service.unassignTask(id, userId);
+        return taskMapper.toCompleteDTO(task);
     }
 
     @Operation(summary = "Get list of tasks status", description = "Get list of tasks status")
@@ -246,6 +249,7 @@ public class TaskController extends CrudController<Task, TaskService> {
         Task task = service.unfreezeTask(taskId, userId);
         return taskMapper.toBasicDTO(task);
     }
+
 
     static class NewSubTask {
         @NotBlank


### PR DESCRIPTION
## Summary
Refactored three task assignment endpoints in `TaskController` to improve code readability by extracting intermediate `Task` variables before DTO mapping.

## Changes Made
- Modified `editTask()`, `selfAssignTask()`, and `unassignTask()` methods
- Extracted service call results into intermediate `Task` variables before passing to `taskMapper.toCompleteDTO()`
- Changed from single-line chained calls to two-line assignments for better clarity

## Motivation
This refactoring improves code readability and debuggability by making the intermediate Task entity explicit, making it easier to inspect values or add logging if needed in the future.

## Impact
- **Breaking Changes**: None
- **Functional Changes**: None - purely cosmetic refactoring
- **Testing**: No additional testing required as behavior is unchanged