### PR TITLE
feat: add activity filtering and fix sprint-related issues

### DIFF
--- a/src/main/java/org/trackdev/api/controller/ActivityController.java
+++ b/src/main/java/org/trackdev/api/controller/ActivityController.java
@@ -36,16 +36,19 @@ public class ActivityController extends BaseController {
     ActivityMapper activityMapper;
 
     @Operation(summary = "Get activity feed", 
-               description = "Get paginated list of activities for the logged-in user's projects")
+               description = "Get paginated list of activities for the logged-in user's projects with optional filters")
     @GetMapping
     public ActivitiesResponseDTO getActivities(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "projectId", required = false) Long projectId,
+            @RequestParam(name = "sprintId", required = false) Long sprintId,
+            @RequestParam(name = "actorId", required = false) String actorId,
             Principal principal) {
         String userId = getUserId(principal);
         Pageable pageable = PageRequest.of(page, Math.min(size, 100)); // Cap at 100
         
-        Page<Activity> activityPage = activityService.getActivitiesForUser(userId, pageable);
+        Page<Activity> activityPage = activityService.getActivitiesForUserWithFilters(userId, projectId, sprintId, actorId, pageable);
         List<ActivityDTO> activityDTOs = activityMapper.toDTOList(activityPage.getContent());
         
         return new ActivitiesResponseDTO(

--- a/src/main/java/org/trackdev/api/repository/ActivityRepository.java
+++ b/src/main/java/org/trackdev/api/repository/ActivityRepository.java
@@ -2,9 +2,13 @@ package org.trackdev.api.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.trackdev.api.entity.Activity;
 import org.trackdev.api.entity.Project;
+import org.trackdev.api.entity.Sprint;
+import org.trackdev.api.entity.User;
 
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -40,6 +44,23 @@ public interface ActivityRepository extends BaseRepositoryLong<Activity> {
      * Find activities for a specific project
      */
     Page<Activity> findByProjectOrderByCreatedAtDesc(Project project, Pageable pageable);
+
+    /**
+     * Find activities for a specific project and actor
+     */
+    Page<Activity> findByProjectAndActorOrderByCreatedAtDesc(Project project, User actor, Pageable pageable);
+
+    /**
+     * Find activities for a specific project and sprint (via task.activeSprints collection)
+     */
+    @Query("SELECT a FROM Activity a WHERE a.project = :project AND :sprint MEMBER OF a.task.activeSprints ORDER BY a.createdAt DESC")
+    Page<Activity> findByProjectAndSprintOrderByCreatedAtDesc(@Param("project") Project project, @Param("sprint") Sprint sprint, Pageable pageable);
+
+    /**
+     * Find activities for a specific project, sprint, and actor
+     */
+    @Query("SELECT a FROM Activity a WHERE a.project = :project AND :sprint MEMBER OF a.task.activeSprints AND a.actor = :actor ORDER BY a.createdAt DESC")
+    Page<Activity> findByProjectAndSprintAndActorOrderByCreatedAtDesc(@Param("project") Project project, @Param("sprint") Sprint sprint, @Param("actor") User actor, Pageable pageable);
 
     /**
      * Delete all activities for a specific project

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -163,41 +163,41 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
     }
 
 
-    public Collection<Sprint> getSpritnsByIds(Collection<Long> sprintIds) {
+    public Collection<Sprint> getSprintsByIds(Collection<Long> sprintIds) {
         return repo.findAllById(sprintIds);
     }
 
-    @Transactional
-    @Scheduled(fixedRate = SPRINT_STATUS_CHANGE_RATE)
-    public void triggerSprintStatusChange() {
-        logger.info("--- Start triggering sprint status change");
-        Collection<Sprint> sprintsToClose = repo().sprintsToClose();
-        if (sprintsToClose.size() > 0) {
-            logger.info("-- Sprints to CLOSE status: " + sprintsToClose.size());
-            for (Sprint sprint : sprintsToClose) {
-                sprint.setStatus(SprintStatus.CLOSED);
-            }
-            repo.saveAll(sprintsToClose);
-            logger.info("-- Sprints to CLOSED status changed");
-        }
-        Collection<Sprint> sprintsToDraft = repo().sprintsToDraft();
-        if(sprintsToDraft.size() > 0) {
-            logger.info("-- Sprints to DRAFT status: " + sprintsToDraft.size());
-            for(Sprint sprint : sprintsToDraft) {
-                sprint.setStatus(SprintStatus.DRAFT);
-            }
-            repo.saveAll(sprintsToDraft);
-            logger.info("-- Sprints to DRAFT status changed");
-        }
-        Collection<Sprint> sprintsToActive = repo().sprintsToActive();
-        if(sprintsToActive.size() > 0) {
-            logger.info("-- Sprints to ACTIVE status: " + sprintsToActive.size());
-            for (Sprint sprint : sprintsToActive) {
-                sprint.setStatus(SprintStatus.ACTIVE);
-            }
-            repo.saveAll(sprintsToActive);
-            logger.info("-- Sprints to ACTIVE status changed");
-        }
-        logger.info("--- Done triggering sprint status change");
-    }
+    // @Transactional
+    // @Scheduled(fixedRate = SPRINT_STATUS_CHANGE_RATE)
+    // public void triggerSprintStatusChange() {
+    //     logger.info("--- Start triggering sprint status change");
+    //     Collection<Sprint> sprintsToClose = repo().sprintsToClose();
+    //     if (sprintsToClose.size() > 0) {
+    //         logger.info("-- Sprints to CLOSE status: " + sprintsToClose.size());
+    //         for (Sprint sprint : sprintsToClose) {
+    //             sprint.setStatus(SprintStatus.CLOSED);
+    //         }
+    //         repo.saveAll(sprintsToClose);
+    //         logger.info("-- Sprints to CLOSED status changed");
+    //     }
+    //     Collection<Sprint> sprintsToDraft = repo().sprintsToDraft();
+    //     if(sprintsToDraft.size() > 0) {
+    //         logger.info("-- Sprints to DRAFT status: " + sprintsToDraft.size());
+    //         for(Sprint sprint : sprintsToDraft) {
+    //             sprint.setStatus(SprintStatus.DRAFT);
+    //         }
+    //         repo.saveAll(sprintsToDraft);
+    //         logger.info("-- Sprints to DRAFT status changed");
+    //     }
+    //     Collection<Sprint> sprintsToActive = repo().sprintsToActive();
+    //     if(sprintsToActive.size() > 0) {
+    //         logger.info("-- Sprints to ACTIVE status: " + sprintsToActive.size());
+    //         for (Sprint sprint : sprintsToActive) {
+    //             sprint.setStatus(SprintStatus.ACTIVE);
+    //         }
+    //         repo.saveAll(sprintsToActive);
+    //         logger.info("-- Sprints to ACTIVE status changed");
+    //     }
+    //     logger.info("--- Done triggering sprint status change");
+    // }
 }

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -397,7 +397,7 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             }
             
             // Validate sprint is active or future (DRAFT status = future)
-            Collection<Sprint> sprints = sprintService.getSpritnsByIds(sprintsIds);
+            Collection<Sprint> sprints = sprintService.getSprintsByIds(sprintsIds);
             for (Sprint sprint : sprints) {
                 if (sprint.getStatus() == SprintStatus.CLOSED) {
                     throw new ServiceException(ErrorConstants.SPRINT_NOT_ACTIVE_OR_FUTURE);
@@ -562,7 +562,7 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         }
         if(editTask.activeSprints != null) {
             Collection<Long> sprintIds = editTask.activeSprints.orElse(new ArrayList<>());
-            Collection<Sprint> sprints = sprintService.getSpritnsByIds(sprintIds);
+            Collection<Sprint> sprints = sprintService.getSprintsByIds(sprintIds);
             task.getActiveSprints().stream().forEach(sprint -> sprint.removeTask(task));
             task.setActiveSprints(sprints);
             sprints.stream().forEach(sprint -> sprint.addTask(task, user));


### PR DESCRIPTION
## Summary
This PR enhances the activity feed with optional filtering capabilities and includes several fixes and improvements to sprint-related functionality.

## Changes

### Activity Feed Filtering (New Feature)
- **Controller**: Added optional query parameters to `/activities` endpoint for filtering by `projectId`, `sprintId`, and `actorId`
- **Service Layer**: Implemented `getActivitiesForUserWithFilters()` method with authorization checks and flexible filter combinations
- **Repository Layer**: Added new query methods including JPQL queries for sprint-based filtering using `MEMBER OF` operator

The filtering supports:
- Single project view
- Activities within a specific sprint
- Activities by a specific user (actor)
- Any combination of the above filters

### Bug Fixes
- Fixed typo in method name: `getSpritnsByIds` → `getSprintsByIds` in `TaskService.java`

### Maintenance
- Temporarily disabled automatic sprint status change scheduler to prevent unintended background updates during development/testing

## API Changes
**Non-breaking**: New optional query parameters added to `GET /activities`:
- `?projectId={id}` - Filter by specific project
- `?sprintId={id}` - Filter by sprint (tasks associated with that sprint)
- `?actorId={id}` - Filter by user who performed the activity

Existing calls without filters continue to work as before.

## Testing Notes
- Test activity feed with various filter combinations
- Verify authorization: users should only see activities for projects they have access to
- Confirm sprint filtering correctly identifies tasks associated with the specified sprint