### PR TITLE
feat: dynamic sprint status computation and future sprint task constraints

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -391,6 +391,19 @@ Windows PowerShell
     - Name and description are copied from the pattern item
     - Start and end datetime are copied from the pattern
     - Tasks can only be assigned to sprints that belong to the same project
+    - **Status is computed dynamically** via `Sprint.getEffectiveStatus()`:
+      - If manually set to CLOSED → always CLOSED (manual close sticks)
+      - Before startDate → DRAFT (future sprint)
+      - Between startDate and endDate → ACTIVE
+      - After endDate → CLOSED
+    - Use `getEffectiveStatus()` (not `getStatus()`) when checking sprint state in business logic
+    - The stored `status` field is only for manual overrides (e.g., force-close)
+    - No scheduled job needed for status transitions
+
+- Task status in future sprints:
+    - Tasks can be moved from backlog to a future sprint (status becomes TODO)
+    - Tasks in a future sprint (DRAFT status) cannot change from TODO until the sprint becomes ACTIVE
+    - Once at least one sprint containing the task is ACTIVE, status changes are allowed
 
 - Relationship between tasks and sprints:
     - A USER_STORY will belong to any sprint where at least one of its subtasks is assigned. So a USER_STORY can belong to more than 1 sprint

--- a/src/main/java/org/trackdev/api/mapper/SprintMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/SprintMapper.java
@@ -19,20 +19,20 @@ import java.util.List;
 public interface SprintMapper {
 
     @Named("sprintToBasicDTO")
-    @Mapping(target = "status", source = "status", qualifiedByName = "sprintStatusToString")
-    @Mapping(target = "statusText", source = "statusText")
+    @Mapping(target = "status", expression = "java(statusToString(sprint.getEffectiveStatus()))")
+    @Mapping(target = "statusText", expression = "java(sprint.getStatusText())")
     SprintBasicDTO toBasicDTO(Sprint sprint);
 
     @Named("sprintToCompleteDTO")
-    @Mapping(target = "status", source = "status", qualifiedByName = "sprintStatusToString")
-    @Mapping(target = "statusText", source = "statusText")
+    @Mapping(target = "status", expression = "java(statusToString(sprint.getEffectiveStatus()))")
+    @Mapping(target = "statusText", expression = "java(sprint.getStatusText())")
     @Mapping(target = "project", source = "project", qualifiedByName = "projectToBasicDTOSimple")
     @Mapping(target = "activeTasks", ignore = true)
     SprintCompleteDTO toCompleteDTO(Sprint sprint);
 
     @Named("sprintToBoardDTO")
-    @Mapping(target = "status", source = "status", qualifiedByName = "sprintStatusToString")
-    @Mapping(target = "statusText", source = "statusText")
+    @Mapping(target = "status", expression = "java(statusToString(sprint.getEffectiveStatus()))")
+    @Mapping(target = "statusText", expression = "java(sprint.getStatusText())")
     @Mapping(target = "project", source = "project", qualifiedByName = "projectToBasicDTOSimple")
     @Mapping(target = "tasks", ignore = true)
     SprintBoardDTO toBoardDTO(Sprint sprint);

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.trackdev.api.controller.exceptions.ServiceException;
@@ -27,8 +26,6 @@ import java.util.List;
 
 @Service
 public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
-
-    private static final int SPRINT_STATUS_CHANGE_RATE = 1000 * 2 * 30; //1 second
 
     private static final Logger logger = LoggerFactory.getLogger(SprintService.class);
 
@@ -167,37 +164,16 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
         return repo.findAllById(sprintIds);
     }
 
-    // @Transactional
-    // @Scheduled(fixedRate = SPRINT_STATUS_CHANGE_RATE)
-    // public void triggerSprintStatusChange() {
-    //     logger.info("--- Start triggering sprint status change");
-    //     Collection<Sprint> sprintsToClose = repo().sprintsToClose();
-    //     if (sprintsToClose.size() > 0) {
-    //         logger.info("-- Sprints to CLOSE status: " + sprintsToClose.size());
-    //         for (Sprint sprint : sprintsToClose) {
-    //             sprint.setStatus(SprintStatus.CLOSED);
-    //         }
-    //         repo.saveAll(sprintsToClose);
-    //         logger.info("-- Sprints to CLOSED status changed");
-    //     }
-    //     Collection<Sprint> sprintsToDraft = repo().sprintsToDraft();
-    //     if(sprintsToDraft.size() > 0) {
-    //         logger.info("-- Sprints to DRAFT status: " + sprintsToDraft.size());
-    //         for(Sprint sprint : sprintsToDraft) {
-    //             sprint.setStatus(SprintStatus.DRAFT);
-    //         }
-    //         repo.saveAll(sprintsToDraft);
-    //         logger.info("-- Sprints to DRAFT status changed");
-    //     }
-    //     Collection<Sprint> sprintsToActive = repo().sprintsToActive();
-    //     if(sprintsToActive.size() > 0) {
-    //         logger.info("-- Sprints to ACTIVE status: " + sprintsToActive.size());
-    //         for (Sprint sprint : sprintsToActive) {
-    //             sprint.setStatus(SprintStatus.ACTIVE);
-    //         }
-    //         repo.saveAll(sprintsToActive);
-    //         logger.info("-- Sprints to ACTIVE status changed");
-    //     }
-    //     logger.info("--- Done triggering sprint status change");
-    // }
+    /*
+     * NOTE: Sprint status is now computed dynamically via Sprint.getEffectiveStatus()
+     * based on startDate/endDate. No scheduled job is needed.
+     * 
+     * The rules are:
+     * 1. If manually set to CLOSED → always CLOSED (manual close sticks)
+     * 2. Before startDate → DRAFT
+     * 3. Between startDate and endDate → ACTIVE
+     * 4. After endDate → CLOSED
+     * 
+     * The stored status field is only used for manual overrides (e.g., force-close).
+     */
 }

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -55,6 +55,7 @@ public final class ErrorConstants {
     public static final String SUBTASK_MUST_BE_TASK_OR_BUG = "error.task.subtask.type.invalid";
     public static final String TASK_IS_FROZEN = "error.task.frozen";
     public static final String ONLY_PROFESSOR_CAN_FREEZE_TASK = "error.task.freeze.professor.only";
+    public static final String TASK_STATUS_CHANGE_IN_FUTURE_SPRINT = "error.task.status.future.sprint";
     
     // Project errors
     public static final String PRJ_WITHOUT_MEMBERS = "error.project.no.members";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -92,6 +92,7 @@ error.task.estimation.verify.or.done=Estimation points can only be set when task
 error.task.subtask.type.invalid=A subtask can only be of type TASK or BUG
 error.task.frozen=This task is frozen and cannot be modified
 error.task.freeze.professor.only=Only professors can freeze or unfreeze tasks
+error.task.status.future.sprint=Task status cannot be changed from TODO while in a sprint that has not started yet
 
 # Project errors
 error.project.no.members=Project must have at least one member

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -92,6 +92,7 @@ error.task.estimation.verify.or.done=Els punts d'estimació només es poden esta
 error.task.subtask.type.invalid=Una subtasca només pot ser de tipus TASK o BUG
 error.task.frozen=Aquesta tasca està congelada i no es pot modificar
 error.task.freeze.professor.only=Només els professors poden congelar o descongelar tasques
+error.task.status.future.sprint=L'estat de la tasca no es pot canviar des de TODO mentre estigui en un sprint que encara no ha començat
 
 # Errors de projectes
 error.project.no.members=El projecte ha de tenir almenys un membre

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -92,6 +92,7 @@ error.task.estimation.verify.or.done=Los puntos de estimación solo se pueden es
 error.task.subtask.type.invalid=Una subtarea solo puede ser de tipo TASK o BUG
 error.task.frozen=Esta tarea está congelada y no se puede modificar
 error.task.freeze.professor.only=Solo los profesores pueden congelar o descongelar tareas
+error.task.status.future.sprint=El estado de la tarea no se puede cambiar desde TODO mientras esté en un sprint que aún no ha comenzado
 
 # Errores de proyectos
 error.project.no.members=El proyecto debe tener al menos un miembro


### PR DESCRIPTION
## Summary
This PR implements dynamic sprint status computation based on dates and adds validation to prevent task status changes in future sprints.

## Changes Made

### Sprint Status Computation
- **Added `Sprint.getEffectiveStatus()` method** that dynamically computes status based on dates:
  - `DRAFT` - before start date (future sprint)
  - `ACTIVE` - between start and end date
  - `CLOSED` - after end date or manually closed
- **Removed scheduled job** (`SprintService.triggerSprintStatusChange()`) that periodically updated sprint status in the database
- **Updated `SprintMapper`** to use `getEffectiveStatus()` in all DTO mappings instead of stored status field
- The stored `status` field now only serves as a manual override (e.g., force-close a sprint)

### Task Status Validation
- **Prevent status changes in future sprints**: Tasks in sprints with `DRAFT` status (not yet started) cannot change status from `TODO` until at least one of their sprints becomes `ACTIVE`
- **Fixed sprint status checks** in `TaskService.updateTaskSprints()` to use `getEffectiveStatus()` instead of stored status

### Internationalization
- Added error message `error.task.status.future.sprint` in English, Catalan, and Spanish
- Added `TASK_STATUS_CHANGE_IN_FUTURE_SPRINT` constant to `ErrorConstants`

### Documentation
- Updated `.github/copilot-instructions.md` with sprint status computation rules and task constraints for future sprints

## Why These Changes
- **Eliminates scheduled job complexity**: No need for periodic database updates to manage sprint status transitions
- **Real-time accuracy**: Sprint status is always current based on system time
- **Prevents premature work**: Students cannot mark tasks as in-progress or done before the sprint actually starts
- **Simpler architecture**: Status computation is centralized in the entity method

## Breaking Changes
⚠️ **Important**: Code that directly uses `Sprint.getStatus()` for business logic should be updated to use `Sprint.getEffectiveStatus()` instead. The stored `status` field is now primarily for manual overrides only.

## Testing Notes
- Verify tasks in future sprints (before start date) cannot change from TODO status
- Verify tasks can change status once sprint becomes active (current date >= start date)
- Verify sprint status appears correctly as DRAFT/ACTIVE/CLOSED in API responses based on dates
- Verify manually closed sprints remain CLOSED regardless of dates