### PR TITLE
fix(repository): include enrolled students in course membership query

### DIFF
--- a/src/main/java/org/trackdev/api/repository/CourseRepository.java
+++ b/src/main/java/org/trackdev/api/repository/CourseRepository.java
@@ -14,7 +14,7 @@ public interface CourseRepository extends BaseRepositoryLong<Course> {
     @Query("SELECT DISTINCT c FROM Course c LEFT JOIN FETCH c.projects LEFT JOIN FETCH c.students WHERE c.ownerId = :userId OR c.subject.ownerId = :userId")
     Collection<Course> findByOwnerIdOrSubjectOwnerId(@Param("userId") String userId);
 
-    @Query("SELECT DISTINCT c FROM Course c JOIN c.projects p JOIN p.members m WHERE m.id = :userId")
+    @Query("SELECT DISTINCT c FROM Course c LEFT JOIN c.students s LEFT JOIN c.projects p LEFT JOIN p.members m WHERE s.id = :userId OR m.id = :userId")
     Collection<Course> findByStudentMembership(@Param("userId") String userId);
 
     Course findBySubject_IdAndStartYear(Long subjectId, Integer startYear);


### PR DESCRIPTION
## Summary
Fixed `CourseRepository.findByStudentMembership()` to return courses where the user is enrolled as a student, not just courses where they are a project member.

## Changes
- Updated the JPQL query in `findByStudentMembership()` to add `LEFT JOIN c.students s` and check `s.id = :userId` in addition to the existing project membership check
- Students can now see courses they're enrolled in even if they haven't joined any projects yet

## Why
The previous query only checked if a student was a member of a project (`JOIN p.members m WHERE m.id = :userId`), which meant enrolled students without project assignments couldn't see their courses. This fixes the authorization logic to properly include all enrolled students.

## Testing
- Verify students enrolled in a course can view it in the API
- Verify students who are project members continue to see their courses
- Test with students who are enrolled but not yet assigned to any project