### PR TITLE
refactor(auth): improve JWT token generation with unique JTI

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
@@ -106,17 +106,15 @@ public class JWTTokenRefreshFilter extends OncePerRequestFilter {
         List<String> userRoles = userService.getRoles(userId).stream()
                 .map(roleName -> "ROLE_" + roleName)
                 .collect(Collectors.toList());
-        String userEmail = userService.getEmail(userId);
 
         int durationInMinutes = authorizationConfiguration.getTokenLifetimeInMinutes();
         int durationInMilliseconds = durationInMinutes * 60 * 1000;
 
         String token = Jwts
                 .builder()
-                .setId(COOKIE_NAME)
-                .setSubject(userId)
+                .setId(java.util.UUID.randomUUID().toString())  // Unique JTI for each token
+                .setSubject(userId)  // User UUID as subject
                 .claim("authorities", userRoles)
-                .claim("email", userEmail)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + durationInMilliseconds))
                 .signWith(authorizationConfiguration.getKey())

--- a/src/main/java/org/trackdev/api/controller/AuthController.java
+++ b/src/main/java/org/trackdev/api/controller/AuthController.java
@@ -275,10 +275,9 @@ public class AuthController extends BaseController {
 
         String token = Jwts
                 .builder()
-                .setId(COOKIE_NAME)
-                .setSubject(user.getId())
+                .setId(java.util.UUID.randomUUID().toString())  // Unique JTI for each token
+                .setSubject(user.getId())  // User UUID as subject
                 .claim("authorities", userRoles)
-                .claim("email", user.getEmail())  // Include email for audit purposes
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + durationInMilliseconds))
                 .signWith(authorizationConfiguration.getKey())


### PR DESCRIPTION
## Summary
Refactors JWT token generation in both login and token refresh flows to use unique identifiers and reduce token payload size.

## Changes Made
- **Use unique UUID for JWT ID (JTI)**: Changed from using a static `COOKIE_NAME` to generating a unique UUID for each token's JTI claim. This ensures each token has a globally unique identifier, which is important for token revocation and audit trails.
- **Remove email claim from JWT payload**: Eliminated the `email` claim from both initial authentication and token refresh. The user ID (subject) is sufficient for authentication, and reducing payload size improves performance and reduces token size.

## Files Modified
- `AuthController.java`: Updated token generation during login
- `JWTTokenRefreshFilter.java`: Updated token generation during sliding session refresh

## Technical Details
Both the initial authentication flow and the token refresh filter now generate tokens with:
- `jti` (JWT ID): Unique UUID per token instead of static cookie name
- `sub` (Subject): User UUID (unchanged)
- `authorities`: User roles (unchanged)
- Removed: `email` claim

## Impact
- No breaking changes to API consumers - tokens remain compatible with existing validation logic
- Improved token uniqueness for better tracking and potential revocation mechanisms
- Slightly smaller token size due to removed email claim