### PR TITLE
feat: add edit and delete operations for task comments

### DIFF
--- a/src/main/java/org/trackdev/api/service/CommentService.java
+++ b/src/main/java/org/trackdev/api/service/CommentService.java
@@ -1,16 +1,27 @@
 package org.trackdev.api.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.configuration.UserType;
+import org.trackdev.api.controller.exceptions.EntityNotFound;
+import org.trackdev.api.controller.exceptions.ServiceException;
 import org.trackdev.api.entity.Comment;
+import org.trackdev.api.entity.Course;
+import org.trackdev.api.entity.Project;
 import org.trackdev.api.entity.Task;
 import org.trackdev.api.entity.User;
 import org.trackdev.api.repository.CommentRepository;
+import org.trackdev.api.utils.ErrorConstants;
 import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.Collection;
 
 @Service
 public class CommentService extends BaseServiceLong<Comment, CommentRepository>{
+
+    @Autowired
+    private UserService userService;
 
     public Comment addComment(String content, User author, Task task) {
         // Sanitize HTML content to prevent XSS attacks
@@ -24,4 +35,102 @@ public class CommentService extends BaseServiceLong<Comment, CommentRepository>{
         return repo().findByTaskId(taskId);
     }
 
+    /**
+     * Edit a comment. 
+     * - Students can only edit their own comments
+     * - Professors owning the project can edit any comment
+     */
+    @Transactional
+    public Comment editComment(Long commentId, String newContent, String userId) {
+        Comment comment = repo.findById(commentId)
+                .orElseThrow(() -> new EntityNotFound(ErrorConstants.COMMENT_NOT_FOUND));
+        
+        User user = userService.get(userId);
+        
+        // Check authorization
+        if (!canEditComment(comment, user)) {
+            throw new ServiceException(ErrorConstants.CANNOT_EDIT_OTHERS_COMMENT);
+        }
+        
+        // Sanitize and update content
+        String sanitizedContent = HtmlSanitizer.sanitize(newContent);
+        comment.setContent(sanitizedContent);
+        return repo.save(comment);
+    }
+
+    /**
+     * Delete a comment.
+     * - Students CANNOT delete any comment
+     * - Professors owning the project can delete any comment
+     */
+    @Transactional
+    public void deleteComment(Long commentId, String userId) {
+        Comment comment = repo.findById(commentId)
+                .orElseThrow(() -> new EntityNotFound(ErrorConstants.COMMENT_NOT_FOUND));
+        
+        User user = userService.get(userId);
+        
+        // Check authorization - only professors can delete
+        if (!canDeleteComment(comment, user)) {
+            throw new ServiceException(ErrorConstants.CANNOT_DELETE_COMMENT);
+        }
+        
+        repo.delete(comment);
+    }
+
+    /**
+     * Check if user can edit a comment.
+     * - Author can edit their own comment
+     * - Course owner (professor) can edit any comment in their project
+     * - Admin can edit any comment
+     */
+    public boolean canEditComment(Comment comment, User user) {
+        // Author can always edit their own comment
+        if (comment.getAuthor() != null && comment.getAuthor().getId().equals(user.getId())) {
+            return true;
+        }
+        
+        // Admin can edit any comment
+        if (user.isUserType(UserType.ADMIN)) {
+            return true;
+        }
+        
+        // Professor who owns the course can edit any comment
+        Task task = comment.getTask();
+        if (task != null && task.getProject() != null) {
+            Project project = task.getProject();
+            Course course = project.getCourse();
+            if (course != null && course.getOwnerId().equals(user.getId())) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Check if user can delete a comment.
+     * - Students CANNOT delete any comment
+     * - Course owner (professor) can delete any comment in their project
+     * - Admin can delete any comment
+     */
+    public boolean canDeleteComment(Comment comment, User user) {
+        // Admin can delete any comment
+        if (user.isUserType(UserType.ADMIN)) {
+            return true;
+        }
+        
+        // Professor who owns the course can delete any comment
+        Task task = comment.getTask();
+        if (task != null && task.getProject() != null) {
+            Project project = task.getProject();
+            Course course = project.getCourse();
+            if (course != null && course.getOwnerId().equals(user.getId())) {
+                return true;
+            }
+        }
+        
+        // Students cannot delete any comment
+        return false;
+    }
 }

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -150,5 +150,10 @@ public final class ErrorConstants {
     public static final String USER_STORY_SUBTASKS_NOT_TODO = "error.userstory.subtasks.not.todo";
     public static final String SUBTASK_CANNOT_MOVE_TO_BACKLOG = "error.subtask.cannot.move.to.backlog";
     
+    // Comment errors
+    public static final String COMMENT_NOT_FOUND = "error.comment.not.found";
+    public static final String CANNOT_EDIT_OTHERS_COMMENT = "error.comment.edit.not.author";
+    public static final String CANNOT_DELETE_COMMENT = "error.comment.delete.not.allowed";
+    
     public static final String EMPTY = "";
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -184,3 +184,8 @@ error.profile.enum.ref.required=Enum reference is required when attribute type i
 error.task.begun.cannot.move.to.backlog=A task that has begun cannot go back to the backlog
 error.userstory.subtasks.not.todo=Cannot move User Story to backlog: all subtasks must be in TODO status
 error.subtask.cannot.move.to.backlog=Subtasks cannot be moved to backlog individually. Move the parent User Story instead.
+
+# Comment errors
+error.comment.not.found=Comment does not exist
+error.comment.edit.not.author=You can only edit your own comments
+error.comment.delete.not.allowed=You do not have permission to delete comments

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -184,3 +184,9 @@ error.profile.enum.ref.required=La referència a l'enumeració és obligatòria 
 error.task.begun.cannot.move.to.backlog=Una tasca que ha començat no pot tornar al backlog
 error.userstory.subtasks.not.todo=No es pot moure la User Story al backlog: totes les subtasques han d'estar en estat TODO
 error.subtask.cannot.move.to.backlog=Les subtasques no es poden moure al backlog individualment. Mou la User Story pare.
+
+# Errors de comentaris
+error.comment.not.found=El comentari no existeix
+error.comment.edit.not.author=Només pots editar els teus propis comentaris
+error.comment.delete.not.allowed=No tens permís per eliminar comentaris
+

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -184,3 +184,8 @@ error.profile.enum.ref.required=La referencia a la enumeración es obligatoria c
 error.task.begun.cannot.move.to.backlog=Una tarea que ha comenzado no puede volver al backlog
 error.userstory.subtasks.not.todo=No se puede mover la User Story al backlog: todas las subtareas deben estar en estado TODO
 error.subtask.cannot.move.to.backlog=Las subtareas no se pueden mover al backlog individualmente. Mueve la User Story padre.
+
+# Errores de comentarios
+error.comment.not.found=El comentario no existe
+error.comment.edit.not.author=Solo puedes editar tus propios comentarios
+error.comment.delete.not.allowed=No tienes permiso para eliminar comentarios


### PR DESCRIPTION
## Summary
Implements edit and delete functionality for task comments with role-based authorization controls.

## Changes Made
- **New REST Endpoints** (`TaskController`)
  - `PATCH /tasks/{taskId}/comments/{commentId}` - Edit a comment
  - `DELETE /tasks/{taskId}/comments/{commentId}` - Delete a comment

- **Service Layer** (`CommentService`)
  - `editComment()` - Validates authorization and updates comment content with HTML sanitization
  - `deleteComment()` - Validates authorization and removes comment
  - Authorization helpers: `canEditComment()` and `canDeleteComment()`

- **Authorization Rules**
  - **Edit Comments:**
    - Students can only edit their own comments
    - Professors owning the course can edit any comment in their projects
  - **Delete Comments:**
    - Students CANNOT delete any comments
    - Only professors owning the course can delete comments

- **Error Handling**
  - Added 3 new error constants in `ErrorConstants.java`
  - Localized error messages in English, Spanish (es), and Catalan (ca)

## Technical Notes
- Comment content is sanitized using `HtmlSanitizer` to prevent XSS attacks
- Authorization checks verify task access before allowing comment operations
- Follows existing project patterns (BaseServiceLong, error constant usage, i18n)

## Testing
Test the following scenarios:
- Students can edit their own comments
- Students cannot edit others' comments
- Students cannot delete any comments
- Professors can edit and delete any comments in their courses
- Proper error messages are returned for unauthorized operations