### PR TITLE
feat: add custom profile attributes for tasks and report magnitude

### DIFF
--- a/src/main/java/org/trackdev/api/controller/CourseController.java
+++ b/src/main/java/org/trackdev/api/controller/CourseController.java
@@ -223,6 +223,16 @@ public class CourseController extends BaseController {
         return new CourseReportsResponse(reportMapper.toBasicDTOList(reports), courseId);
     }
 
+    @Operation(summary = "Get numeric profile attributes for report magnitude", 
+               description = "Get TASK-targeted INTEGER and FLOAT attributes from the course's profile for use as report magnitude")
+    @GetMapping(path = "/{courseId}/report-magnitude-attributes")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PROFESSOR')")
+    public List<ProfileAttributeDTO> getReportMagnitudeAttributes(Principal principal,
+                                                                    @PathVariable(name = "courseId") Long courseId) {
+        String userId = super.getUserId(principal);
+        return service.getNumericTaskAttributes(courseId, userId);
+    }
+
     @Operation(summary = "Apply a profile to a course", description = "Apply a profile to a course, enabling custom attribute tracking for all projects (professors only)")
     @PostMapping(path = "/{courseId}/apply-profile/{profileId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'PROFESSOR')")

--- a/src/main/java/org/trackdev/api/dto/ProfileAttributeDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ProfileAttributeDTO.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import org.trackdev.api.entity.AttributeTarget;
 import org.trackdev.api.entity.AttributeType;
 
+import java.util.List;
+
 /**
  * DTO for ProfileAttribute
  */
@@ -15,4 +17,6 @@ public class ProfileAttributeDTO {
     private AttributeTarget target;
     private Long enumRefId;
     private String enumRefName;
+    private List<String> enumValues;
+    private String defaultValue;
 }

--- a/src/main/java/org/trackdev/api/dto/ReportBasicDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ReportBasicDTO.java
@@ -18,4 +18,14 @@ public class ReportBasicDTO {
     private ReportElement element;
     private ReportMagnitude magnitude;
     private CourseBasicDTO course;
+    /**
+     * ID of the profile attribute used as custom magnitude source.
+     * Null when using built-in magnitude (ESTIMATION_POINTS, PULL_REQUESTS).
+     */
+    private Long profileAttributeId;
+    /**
+     * Name of the profile attribute used as custom magnitude source.
+     * Null when using built-in magnitude.
+     */
+    private String profileAttributeName;
 }

--- a/src/main/java/org/trackdev/api/dto/ReportResultDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ReportResultDTO.java
@@ -18,7 +18,11 @@ public class ReportResultDTO {
     private String rowType;    // "STUDENTS" or "SPRINTS"
     private String columnType; // "STUDENTS" or "SPRINTS"
     private String element;    // "TASK"
-    private String magnitude;  // "ESTIMATION_POINTS" or "PULL_REQUESTS"
+    private String magnitude;  // "ESTIMATION_POINTS", "PULL_REQUESTS", or "PROFILE_ATTRIBUTE"
+    
+    // Profile attribute info (when magnitude is PROFILE_ATTRIBUTE)
+    private Long profileAttributeId;
+    private String profileAttributeName;
     
     // Headers for rows and columns
     private List<AxisHeader> rowHeaders;    // List of {id, name}
@@ -102,6 +106,22 @@ public class ReportResultDTO {
 
     public void setMagnitude(String magnitude) {
         this.magnitude = magnitude;
+    }
+
+    public Long getProfileAttributeId() {
+        return profileAttributeId;
+    }
+
+    public void setProfileAttributeId(Long profileAttributeId) {
+        this.profileAttributeId = profileAttributeId;
+    }
+
+    public String getProfileAttributeName() {
+        return profileAttributeName;
+    }
+
+    public void setProfileAttributeName(String profileAttributeName) {
+        this.profileAttributeName = profileAttributeName;
     }
 
     public List<AxisHeader> getRowHeaders() {

--- a/src/main/java/org/trackdev/api/dto/TaskAttributeValueDTO.java
+++ b/src/main/java/org/trackdev/api/dto/TaskAttributeValueDTO.java
@@ -1,0 +1,20 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+import org.trackdev.api.entity.AttributeType;
+
+/**
+ * DTO for TaskAttributeValue - represents the value of a profile attribute for a task
+ */
+@Data
+public class TaskAttributeValueDTO {
+    private Long id;
+    private Long taskId;
+    private Long attributeId;
+    private String attributeName;
+    private AttributeType attributeType;
+    private String value;
+    
+    // For ENUM type, include the possible values
+    private String[] enumValues;
+}

--- a/src/main/java/org/trackdev/api/entity/ProfileAttribute.java
+++ b/src/main/java/org/trackdev/api/entity/ProfileAttribute.java
@@ -48,6 +48,13 @@ public class ProfileAttribute extends BaseEntityLong {
     @Column(name = "enum_ref_id", insertable = false, updatable = false)
     private Long enumRefId;
 
+    /**
+     * Default value for this attribute when not explicitly set.
+     * For INTEGER/FLOAT types, this is used as fallback in reports.
+     */
+    @Column(length = 255)
+    private String defaultValue;
+
     public ProfileAttribute() {}
 
     public ProfileAttribute(String name, AttributeType type, AttributeTarget target, Profile profile) {
@@ -103,5 +110,13 @@ public class ProfileAttribute extends BaseEntityLong {
 
     public Long getEnumRefId() {
         return enumRefId;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 }

--- a/src/main/java/org/trackdev/api/entity/Report.java
+++ b/src/main/java/org/trackdev/api/entity/Report.java
@@ -50,6 +50,16 @@ public class Report extends BaseEntityLong {
     @JoinColumn(name = "course_id")
     private Course course;
 
+    /**
+     * Optional reference to a profile attribute for custom magnitude.
+     * When set, the report uses this attribute's values from TaskAttributeValue
+     * instead of the built-in magnitude (ESTIMATION_POINTS, PULL_REQUESTS).
+     * Only numeric attributes (INTEGER, FLOAT) with target=TASK are valid.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_attribute_id")
+    private ProfileAttribute profileAttribute;
+
     // Constructors
     public Report() {
         this.element = ReportElement.TASK; // Default to TASK
@@ -125,5 +135,13 @@ public class Report extends BaseEntityLong {
 
     public void setCourse(Course course) {
         this.course = course;
+    }
+
+    public ProfileAttribute getProfileAttribute() {
+        return profileAttribute;
+    }
+
+    public void setProfileAttribute(ProfileAttribute profileAttribute) {
+        this.profileAttribute = profileAttribute;
     }
 }

--- a/src/main/java/org/trackdev/api/entity/TaskAttributeValue.java
+++ b/src/main/java/org/trackdev/api/entity/TaskAttributeValue.java
@@ -1,0 +1,83 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import org.springframework.lang.NonNull;
+
+/**
+ * Stores the actual value of a profile attribute for a specific task.
+ * Only applies to attributes with target = TASK.
+ */
+@Entity
+@Table(name = "task_attribute_values", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"task_id", "attribute_id"})
+})
+public class TaskAttributeValue extends BaseEntityLong {
+
+    public static final int VALUE_LENGTH = 500;
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @Column(name = "task_id", insertable = false, updatable = false)
+    private Long taskId;
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attribute_id")
+    private ProfileAttribute attribute;
+
+    @Column(name = "attribute_id", insertable = false, updatable = false)
+    private Long attributeId;
+
+    /**
+     * The actual value stored as a string.
+     * For ENUM type: stores the enum value name
+     * For STRING type: stores the string value
+     * For INTEGER type: stores the integer as string
+     * For FLOAT type: stores the float as string
+     */
+    @Column(length = VALUE_LENGTH)
+    private String value;
+
+    public TaskAttributeValue() {}
+
+    public TaskAttributeValue(Task task, ProfileAttribute attribute, String value) {
+        this.task = task;
+        this.attribute = attribute;
+        this.value = value;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    public Long getTaskId() {
+        return taskId;
+    }
+
+    public ProfileAttribute getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(ProfileAttribute attribute) {
+        this.attribute = attribute;
+    }
+
+    public Long getAttributeId() {
+        return attributeId;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/org/trackdev/api/mapper/ProfileMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/ProfileMapper.java
@@ -12,6 +12,7 @@ import org.trackdev.api.entity.Profile;
 import org.trackdev.api.entity.ProfileAttribute;
 import org.trackdev.api.entity.ProfileEnum;
 
+import java.util.Collections;
 import java.util.List;
 
 @Mapper(componentModel = "spring")
@@ -37,9 +38,18 @@ public interface ProfileMapper {
 
     @Named("attributeToDTO")
     @Mapping(target = "enumRefName", source = "enumRef.name")
+    @Mapping(target = "enumValues", source = "attribute", qualifiedByName = "getEnumValuesFromAttribute")
     ProfileAttributeDTO attributeToDTO(ProfileAttribute attribute);
 
     @Named("attributesToDTO")
     @IterableMapping(qualifiedByName = "attributeToDTO")
     List<ProfileAttributeDTO> attributesToDTO(List<ProfileAttribute> attributes);
+
+    @Named("getEnumValuesFromAttribute")
+    default List<String> getEnumValuesFromAttribute(ProfileAttribute attribute) {
+        if (attribute.getEnumRef() != null) {
+            return attribute.getEnumRef().getValues();
+        }
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/org/trackdev/api/mapper/ReportMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/ReportMapper.java
@@ -1,5 +1,6 @@
 package org.trackdev.api.mapper;
 
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -14,7 +15,10 @@ public interface ReportMapper {
     @Named("reportToBasicDTO")
     @Mapping(target = "owner", source = "owner", qualifiedByName = "userToSummaryDTO")
     @Mapping(target = "course", source = "course", qualifiedByName = "courseToBasicDTO")
+    @Mapping(target = "profileAttributeId", source = "profileAttribute.id")
+    @Mapping(target = "profileAttributeName", source = "profileAttribute.name")
     ReportBasicDTO toBasicDTO(Report report);
 
+    @IterableMapping(qualifiedByName = "reportToBasicDTO")
     List<ReportBasicDTO> toBasicDTOList(List<Report> reports);
 }

--- a/src/main/java/org/trackdev/api/mapper/TaskAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/TaskAttributeValueMapper.java
@@ -1,0 +1,31 @@
+package org.trackdev.api.mapper;
+
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.trackdev.api.dto.TaskAttributeValueDTO;
+import org.trackdev.api.entity.TaskAttributeValue;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface TaskAttributeValueMapper {
+
+    @Named("toDTO")
+    @Mapping(target = "attributeName", source = "attribute.name")
+    @Mapping(target = "attributeType", source = "attribute.type")
+    @Mapping(target = "enumValues", expression = "java(getEnumValues(entity))")
+    TaskAttributeValueDTO toDTO(TaskAttributeValue entity);
+
+    @IterableMapping(qualifiedByName = "toDTO")
+    List<TaskAttributeValueDTO> toDTOList(List<TaskAttributeValue> entities);
+
+    default String[] getEnumValues(TaskAttributeValue entity) {
+        if (entity.getAttribute() != null && 
+            entity.getAttribute().getEnumRef() != null) {
+            return entity.getAttribute().getEnumRef().getValues().toArray(new String[0]);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/trackdev/api/model/MergePatchReport.java
+++ b/src/main/java/org/trackdev/api/model/MergePatchReport.java
@@ -24,4 +24,10 @@ public class MergePatchReport {
     public Optional<ReportElement> element;
     public Optional<ReportMagnitude> magnitude;
     public Optional<Long> courseId;
+    /**
+     * Optional reference to a profile attribute for custom magnitude.
+     * When set, the report uses this attribute's values instead of built-in magnitudes.
+     * Set to null to clear the profile attribute (use built-in magnitude instead).
+     */
+    public Optional<Long> profileAttributeId;
 }

--- a/src/main/java/org/trackdev/api/model/ProfileRequest.java
+++ b/src/main/java/org/trackdev/api/model/ProfileRequest.java
@@ -60,5 +60,11 @@ public class ProfileRequest {
          * Reference to enum by name (required when type is ENUM)
          */
         public String enumRefName;
+
+        /**
+         * Default value for this attribute when not explicitly set on a task.
+         * For INTEGER/FLOAT types, this is used as fallback in reports.
+         */
+        public String defaultValue;
     }
 }

--- a/src/main/java/org/trackdev/api/repository/TaskAttributeValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/TaskAttributeValueRepository.java
@@ -1,0 +1,17 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.TaskAttributeValue;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TaskAttributeValueRepository extends BaseRepositoryLong<TaskAttributeValue> {
+    
+    List<TaskAttributeValue> findByTaskId(Long taskId);
+    
+    Optional<TaskAttributeValue> findByTaskIdAndAttributeId(Long taskId, Long attributeId);
+    
+    void deleteByTaskIdAndAttributeId(Long taskId, Long attributeId);
+    
+    void deleteByTaskId(Long taskId);
+}

--- a/src/main/java/org/trackdev/api/service/ProfileService.java
+++ b/src/main/java/org/trackdev/api/service/ProfileService.java
@@ -143,6 +143,9 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
             attribute.setEnumRef(enumRef);
         }
 
+        // Set default value if provided
+        attribute.setDefaultValue(attrRequest.defaultValue);
+
         profile.addAttribute(attribute);
     }
 
@@ -210,6 +213,9 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                 } else {
                     existing.setEnumRef(null);
                 }
+                
+                // Update default value
+                existing.setDefaultValue(attrRequest.defaultValue);
             } else {
                 // Add new attribute
                 addAttributeToProfile(profile, attrRequest);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,7 +13,7 @@ spring:
   flyway:
     # Enable Flyway
     enabled: true
-    baseline-on-migrate: false
+    baseline-on-migrate: true
     validate-on-migrate: true
     clean-disabled: true
   mvc:

--- a/src/main/resources/db/migration/V6__profiles_reports.sql
+++ b/src/main/resources/db/migration/V6__profiles_reports.sql
@@ -1,0 +1,49 @@
+-- Schema migration V6
+-- Organized for proper execution order
+-- Generated with Copilot (Claude Sonnet 4.5)
+
+-- ============================================
+-- CREATE TABLES (without foreign keys)
+-- ============================================
+
+CREATE TABLE `task_attribute_values` (
+	`attribute_id` bigint,
+	`id` bigint NOT NULL AUTO_INCREMENT,
+	`task_id` bigint,
+	`value` varchar(500),
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `UKsiru5j9flfs8iw3639room8r4` (`task_id`, `attribute_id`),
+	KEY `FKaim80jexh57hatffubn80702t` (`attribute_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+-- ============================================  
+-- ADD COLUMNS
+-- ============================================
+
+ALTER TABLE `profile_attributes` ADD COLUMN `default_value` varchar(255) AFTER `name`;
+
+ALTER TABLE `reports` ADD COLUMN `profile_attribute_id` bigint AFTER `id`;
+
+-- ============================================
+-- ADD INDEXES/KEYS
+-- ============================================
+
+ALTER TABLE `reports` ADD KEY `FKqt366n1fou1iauscfm2k3njyb` (`profile_attribute_id`);
+
+-- ============================================
+-- ADD FOREIGN KEY CONSTRAINTS
+-- ============================================
+
+ALTER TABLE `profiles` ADD CONSTRAINT `FK3bc2496crlurjp4hd5qe480py` FOREIGN KEY (`owner_id`) REFERENCES `users` (`id`);
+
+ALTER TABLE `reports` ADD CONSTRAINT `FKqt366n1fou1iauscfm2k3njyb` FOREIGN KEY (`profile_attribute_id`) REFERENCES `profile_attributes` (`id`);
+
+ALTER TABLE `task_attribute_values` ADD CONSTRAINT `FKaim80jexh57hatffubn80702t` FOREIGN KEY (`attribute_id`) REFERENCES `profile_attributes` (`id`);
+
+ALTER TABLE `task_attribute_values` ADD CONSTRAINT `FKnoecagfx9038fx8xj2k5lmv5b` FOREIGN KEY (`task_id`) REFERENCES `tasks` (`id`);
+
+-- ============================================
+-- DROP STATEMENTS
+-- ============================================


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive custom attributes system that allows courses to define and track custom metrics on tasks, and use those metrics in reports. This extends the existing profile system with task-specific attribute values and custom report magnitudes.

## Key Features

### 1. Task Attribute Values
- **New entity**: `TaskAttributeValue` to store custom attribute values per task
- **REST endpoints**: Get/set/delete attribute values for tasks (`/tasks/{id}/attributes`)
- Tasks can now have custom attributes (STRING, INTEGER, FLOAT, ENUM) defined by the course profile
- Only attributes with `target = TASK` can be applied to tasks
- Unique constraint ensures one value per task-attribute pair

### 2. Profile Attribute Default Values
- Profile attributes now support a `defaultValue` field
- Used as fallback when a task doesn't have an explicit value set
- Critical for numeric attributes (INTEGER/FLOAT) used in report calculations

### 3. Custom Report Magnitude
- Reports can now use profile attributes as custom magnitude metrics
- New `profileAttributeId` field on `Report` entity and DTOs
- When set, reports compute data using the custom attribute values instead of built-in magnitudes (ESTIMATION_POINTS, PULL_REQUESTS)
- Only numeric attributes (INTEGER/FLOAT) with `target = TASK` are valid
- New endpoint: `GET /courses/{id}/report-magnitude-attributes` to retrieve available attributes

## Database Changes

**Migration V6** adds:
- `task_attribute_values` table with foreign keys to tasks and profile attributes
- `default_value` column on `profile_attributes`
- `profile_attribute_id` column on `reports`

## API Changes

### New Endpoints
- `GET /tasks/{taskId}/attributes` - Get attribute values for a task
- `GET /tasks/{taskId}/available-attributes` - Get applicable attributes from course profile
- `POST /tasks/{taskId}/attributes/{attributeId}` - Set attribute value (professors only)
- `DELETE /tasks/{taskId}/attributes/{attributeId}` - Remove attribute value (professors only)
- `GET /courses/{courseId}/report-magnitude-attributes` - Get numeric task attributes for reports

### Modified Endpoints
- `PATCH /reports/{id}` - Now accepts optional `profileAttributeId` field
- Profile attribute endpoints now include `defaultValue` in requests/responses

## Authorization
- Only professors can set/delete task attribute values
- Students can view attribute values for tasks in their projects
- Custom magnitude attributes respect existing report access controls

## Configuration
- Enabled `flyway.baseline-on-migrate` in production config to support existing databases

## Testing Notes
- Ensure course has a profile with TASK-targeted attributes before testing
- Test report computation with both built-in and custom magnitudes
- Verify default values are used when task has no explicit value set
- Confirm only numeric attributes appear in magnitude selection