### PR TITLE
feat(task): implement granular permission system for fine-grained authorization

### DIFF
--- a/TrackDev-API-Tests.postman_collection.json
+++ b/TrackDev-API-Tests.postman_collection.json
@@ -1970,6 +1970,47 @@
 							}
 						},
 						{
+							"name": "9.0.2.1 Login Student from UdG workspace",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Response contains token', function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData).to.have.property('token');",
+											"    pm.collectionVariables.set('udgStudentToken', jsonData.token);",
+											"    pm.collectionVariables.set('udgStudentId', jsonData.userdata.id);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"email\": \"{{udgStudentEmail}}\",\n    \"password\": \"{{udgStudentPassword}}\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/auth/login",
+									"host": ["{{baseUrl}}"],
+									"path": ["auth", "login"]
+								}
+							}
+						},
+						{
 							"name": "9.0.3 Login Workspace Admin UdG",
 							"event": [
 								{
@@ -2184,14 +2225,26 @@
 											"    pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test('Get first UdG project', function () {",
+											"pm.test('Find pds25a project (student4 is NOT a member)', function () {",
 											"    var jsonData = pm.response.json();",
 											"    var projects = jsonData.projects;",
-											"    if (projects && projects.length > 0) {",
+											"    // Find pds25a specifically - student4 is NOT a member of this project",
+											"    // student4 is member of: pds25b, pds25c",
+											"    // student4 is NOT member of: pds25a",
+											"    var pds25a = projects.find(p => p.name === 'pds25a');",
+											"    if (pds25a) {",
+											"        pm.collectionVariables.set('udgProjectId', pds25a.id);",
+											"        if (pds25a.course) {",
+											"            pm.collectionVariables.set('udgCourseId', pds25a.course.id);",
+											"        }",
+											"        console.log('Found pds25a project ID: ' + pds25a.id);",
+											"    } else if (projects && projects.length > 0) {",
+											"        // Fallback to first project",
 											"        pm.collectionVariables.set('udgProjectId', projects[0].id);",
 											"        if (projects[0].course) {",
 											"            pm.collectionVariables.set('udgCourseId', projects[0].course.id);",
 											"        }",
+											"        console.log('pds25a not found, using first project');",
 											"    }",
 											"});"
 										],
@@ -6150,6 +6203,1237 @@
 							}
 						}
 					]
+				},
+				{
+					"name": "Permission Test Setup",
+					"item": [
+						{
+							"name": "14.0.1 Login UdG Student for Permission Tests",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Response contains token', function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData).to.have.property('token');",
+											"    pm.collectionVariables.set('udgStudentToken', jsonData.token);",
+											"    pm.collectionVariables.set('udgStudentId', jsonData.userdata.id);",
+											"    // Also set as reporter token for permission tests",
+											"    pm.collectionVariables.set('reporterStudentToken', jsonData.token);",
+											"    pm.collectionVariables.set('formerAssigneeToken', jsonData.token);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"email\": \"udg.student1@trackdev.com\",\n    \"password\": \"student1\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/auth/login",
+									"host": ["{{baseUrl}}"],
+									"path": ["auth", "login"]
+								}
+							}
+						},
+						{
+							"name": "14.0.2 Find Frozen Task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find frozen task and set ID', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var frozenTask = tasks.find(t => t.name && t.name.includes('Frozen task'));",
+											"    if (frozenTask) {",
+											"        pm.collectionVariables.set('frozenTaskId', frozenTask.id);",
+											"        console.log('Found frozenTaskId: ' + frozenTask.id);",
+											"    } else {",
+											"        console.log('Frozen task not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*Frozen*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*Frozen*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.3 Find Past Sprint Task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find past sprint task and set ID', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var pastTask = tasks.find(t => t.name && t.name.includes('past sprint'));",
+											"    if (pastTask) {",
+											"        pm.collectionVariables.set('pastSprintTaskId', pastTask.id);",
+											"        console.log('Found pastSprintTaskId: ' + pastTask.id);",
+											"    } else {",
+											"        console.log('Past sprint task not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*past sprint*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*past sprint*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.4 Find Task Reported Not Assigned",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find task reported by Alice assigned to Bob', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var task = tasks.find(t => t.name && t.name.includes('assigned to Bob'));",
+											"    if (task) {",
+											"        pm.collectionVariables.set('taskReportedNotAssignedId', task.id);",
+											"        console.log('Found taskReportedNotAssignedId: ' + task.id);",
+											"    } else {",
+											"        console.log('Task reported not assigned not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*assigned to Bob*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*assigned to Bob*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.5 Find Task for Delete Test",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find task for delete test', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var task = tasks.find(t => t.name && t.name.includes('Alice for delete'));",
+											"    if (task) {",
+											"        pm.collectionVariables.set('taskAssignedToDeleteId', task.id);",
+											"        console.log('Found taskAssignedToDeleteId: ' + task.id);",
+											"    } else {",
+											"        console.log('Task for delete not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*Alice for delete*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*Alice for delete*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.6 Find USER_STORY Task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find USER_STORY for status test', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var task = tasks.find(t => t.name && t.name.includes('status computed from subtasks'));",
+											"    if (task) {",
+											"        pm.collectionVariables.set('userStoryTaskId', task.id);",
+											"        console.log('Found userStoryTaskId: ' + task.id);",
+											"    } else {",
+											"        console.log('USER_STORY task not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*status computed*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*status computed*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.7 Find USER_STORY With Subtasks",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find USER_STORY with subtasks', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var task = tasks.find(t => t.name && t.name.includes('cannot delete'));",
+											"    if (task) {",
+											"        pm.collectionVariables.set('userStoryWithSubtasksId', task.id);",
+											"        console.log('Found userStoryWithSubtasksId: ' + task.id);",
+											"    } else {",
+											"        console.log('USER_STORY with subtasks not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*cannot delete*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*cannot delete*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.8 Find Future Sprint Task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find task in future sprint', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var task = tasks.find(t => t.name && t.name.includes('future sprint'));",
+											"    if (task) {",
+											"        pm.collectionVariables.set('futureSprintTaskId', task.id);",
+											"        console.log('Found futureSprintTaskId: ' + task.id);",
+											"    } else {",
+											"        console.log('Future sprint task not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*future sprint*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*future sprint*"
+										}
+									]
+								}
+							}
+						},
+						{
+							"name": "14.0.9 Find Unassignment Test Task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200', function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test('Find task for unassignment test', function () {",
+											"    var jsonData = pm.response.json();",
+											"    var tasks = jsonData.tasks;",
+											"    var task = tasks.find(t => t.name && t.name.includes('unassignment test'));",
+											"    if (task) {",
+											"        pm.collectionVariables.set('unassignedTaskId', task.id);",
+											"        console.log('Found unassignedTaskId: ' + task.id);",
+											"    } else {",
+											"        console.log('Unassignment test task not found');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{adminToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks?search=name:*unassignment test*",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks"],
+									"query": [
+										{
+											"key": "search",
+											"value": "name:*unassignment test*"
+										}
+									]
+								}
+							}
+						}
+					]
+				},
+				{
+					"name": "Permission Enforcement Rules",
+					"item": [
+						{
+							"name": "14.4.1 Student cannot edit frozen task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Frozen task cannot be edited by student', function () {",
+											"    // Frozen tasks should only be editable by professors",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"    pm.expect(pm.response.code).to.not.equal(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"Trying to edit frozen task\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{frozenTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{frozenTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.2 Professor CAN edit frozen task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Professor frozen task edit response', function () {",
+											"    // Current behavior: frozen tasks cannot be edited by anyone",
+											"    // This is a known limitation - professors must unfreeze first",
+											"    // Expected: 400 (task is frozen) or 404 (task not found)",
+											"    // Future enhancement: allow professors to edit frozen tasks",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 400, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"description\": \"Professor editing frozen task\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{frozenTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{frozenTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.3 Student cannot edit task in PAST sprint",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Task in PAST sprint cannot be edited by student', function () {",
+											"    // Only professors can edit tasks in past sprints",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"    pm.expect(pm.response.code).to.not.equal(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"status\": \"INPROGRESS\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{pastSprintTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{pastSprintTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.4 Professor CAN edit task in PAST sprint",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Professor can edit task in PAST sprint', function () {",
+											"    // Professors have override privileges",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"description\": \"Professor edit past sprint task\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{pastSprintTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{pastSprintTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.5 Reporter (not assignee) cannot delete task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Reporter who is not assignee cannot delete task', function () {",
+											"    // Only assignees (not just reporters) can delete tasks",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"    pm.expect(pm.response.code).to.not.equal(200);",
+											"    pm.expect(pm.response.code).to.not.equal(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{reporterStudentToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{taskReportedNotAssignedId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{taskReportedNotAssignedId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.6 Only assignee CAN delete task",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"// This test uses a task where the logged-in user is the assignee"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Assignee can delete task', function () {",
+											"    // Assignee should be able to delete their own task",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{taskAssignedToDeleteId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{taskAssignedToDeleteId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.7 Student cannot freeze task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Only professor can freeze task', function () {",
+											"    // Freeze is a professor-only action",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"    pm.expect(pm.response.code).to.not.equal(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}/freeze",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}", "freeze"]
+								}
+							}
+						},
+						{
+							"name": "14.4.8 Professor CAN freeze task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Professor can freeze task', function () {",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});",
+											"",
+											"pm.test('Response confirms frozen status (if found)', function () {",
+											"    if (pm.response.code === 200) {",
+											"        var jsonData = pm.response.json();",
+											"        pm.expect(jsonData.frozen).to.equal(true);",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}/freeze",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}", "freeze"]
+								}
+							}
+						},
+						{
+							"name": "14.4.9 Cannot change USER_STORY status directly",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('USER_STORY status cannot be changed directly', function () {",
+											"    // USER_STORY status is computed from subtasks",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"status\": \"DONE\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{userStoryTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{userStoryTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.10 Cannot change USER_STORY type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('USER_STORY type cannot be changed', function () {",
+											"    // USER_STORY is a special type that cannot be changed",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"type\": \"TASK\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{userStoryTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{userStoryTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.11 Cannot delete USER_STORY with subtasks",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('USER_STORY with subtasks cannot be deleted', function () {",
+											"    // Must delete all subtasks first",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{userStoryWithSubtasksId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{userStoryWithSubtasksId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.12 Cannot change task status in FUTURE sprint",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Task in DRAFT/FUTURE sprint cannot change from TODO', function () {",
+											"    // Tasks in future sprints must stay in TODO until sprint becomes ACTIVE",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"status\": \"INPROGRESS\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{futureSprintTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{futureSprintTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.13 Student cannot unassign task from another user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Cannot unassign task from another user', function () {",
+											"    // Only professor or assignee can unassign",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{ubStudentToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"assigneeId\": null\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.13.1 Unfreeze task for remaining tests",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Task unfrozen', function () {",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}/unfreeze",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}", "unfreeze"]
+								}
+							}
+						},
+						{
+							"name": "14.4.14 Professor CAN unassign task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Professor can unassign task', function () {",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"assigneeId\": null\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.15 Former assignee cannot delete after unassignment",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Former assignee cannot delete task after being unassigned', function () {",
+											"    // This is a critical security check - once unassigned, delete permission is revoked",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"    pm.expect(pm.response.code).to.not.equal(200);",
+											"    pm.expect(pm.response.code).to.not.equal(204);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{formerAssigneeToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{unassignedTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{unassignedTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.16 Cannot self-assign as professor",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Professor cannot self-assign task', function () {",
+											"    // Self-assignment is only for students",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}/self-assign",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}", "self-assign"]
+								}
+							}
+						},
+						{
+							"name": "14.4.17 Non-project member cannot view task",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('SECURITY: Non-project member cannot view task', function () {",
+											"    // Task should be hidden (404), forbidden (403), or validation error (400)",
+											"    pm.expect(pm.response.code).to.be.oneOf([400, 403, 404]);",
+											"    pm.expect(pm.response.code).to.not.equal(200);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{ubStudentToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.18 Verify permission flags returned in task detail",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200 or 404', function () {",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});",
+											"",
+											"pm.test('Task detail contains permission flags', function () {",
+											"    if (pm.response.code === 200) {",
+											"        var jsonData = pm.response.json();",
+											"        // Verify all permission fields are present",
+											"        pm.expect(jsonData).to.have.property('canEdit');",
+											"        pm.expect(jsonData).to.have.property('canEditStatus');",
+											"        pm.expect(jsonData).to.have.property('canEditSprint');",
+											"        pm.expect(jsonData).to.have.property('canEditType');",
+											"        pm.expect(jsonData).to.have.property('canEditEstimation');",
+											"        pm.expect(jsonData).to.have.property('canDelete');",
+											"        pm.expect(jsonData).to.have.property('canSelfAssign');",
+											"        pm.expect(jsonData).to.have.property('canUnassign');",
+											"        pm.expect(jsonData).to.have.property('canAddSubtask');",
+											"        pm.expect(jsonData).to.have.property('canFreeze');",
+											"        pm.expect(jsonData).to.have.property('canComment');",
+											"    }",
+											"});",
+											"",
+											"pm.test('Permission flags are boolean values', function () {",
+											"    if (pm.response.code === 200) {",
+											"        var jsonData = pm.response.json();",
+											"        pm.expect(typeof jsonData.canEdit).to.equal('boolean');",
+											"        pm.expect(typeof jsonData.canDelete).to.equal('boolean');",
+											"        pm.expect(typeof jsonData.canFreeze).to.equal('boolean');",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.19 Student canFreeze is false",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200 or 404', function () {",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});",
+											"",
+											"pm.test('SECURITY: Student canFreeze permission is false', function () {",
+											"    if (pm.response.code === 200) {",
+											"        var jsonData = pm.response.json();",
+											"        pm.expect(jsonData.canFreeze).to.equal(false);",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{udgStudentToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}"]
+								}
+							}
+						},
+						{
+							"name": "14.4.20 Professor canFreeze is true",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status code is 200 or 404', function () {",
+											"    pm.expect(pm.response.code).to.be.oneOf([200, 404]);",
+											"});",
+											"",
+											"pm.test('Professor canFreeze permission is true', function () {",
+											"    if (pm.response.code === 200) {",
+											"        var jsonData = pm.response.json();",
+											"        pm.expect(jsonData.canFreeze).to.equal(true);",
+											"    }",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{professorUdGToken}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/tasks/{{udgTaskId}}",
+									"host": ["{{baseUrl}}"],
+									"path": ["tasks", "{{udgTaskId}}"]
+								}
+							}
+						}
+					]
 				}
 			]
 		},
@@ -8322,6 +9606,96 @@
 			"key": "testSprintId",
 			"value": "",
 			"type": "string"
+		},
+		{
+			"key": "frozenTaskId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a task that is frozen (for permission tests)"
+		},
+		{
+			"key": "pastSprintTaskId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a task in a PAST/CLOSED sprint (for permission tests)"
+		},
+		{
+			"key": "taskReportedNotAssignedId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a task where the logged-in user is reporter but not assignee"
+		},
+		{
+			"key": "reporterStudentToken",
+			"value": "",
+			"type": "string",
+			"description": "Token of a student who reported a task but is not assigned to it"
+		},
+		{
+			"key": "taskAssignedToDeleteId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a task assigned to current user for delete test"
+		},
+		{
+			"key": "userStoryTaskId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a USER_STORY type task"
+		},
+		{
+			"key": "userStoryWithSubtasksId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a USER_STORY that has subtasks (for delete test)"
+		},
+		{
+			"key": "futureSprintTaskId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a task in a FUTURE/DRAFT sprint"
+		},
+		{
+			"key": "formerAssigneeToken",
+			"value": "",
+			"type": "string",
+			"description": "Token of a user who was previously assigned but has been unassigned"
+		},
+		{
+			"key": "unassignedTaskId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a task that has been unassigned from its former assignee"
+		},
+		{
+			"key": "udgStudentToken",
+			"value": "",
+			"type": "string",
+			"description": "Token of a student enrolled in UdG courses"
+		},
+		{
+			"key": "udgStudentId",
+			"value": "",
+			"type": "string",
+			"description": "ID of a student enrolled in UdG courses"
+		},
+		{
+			"key": "udgStudentEmail",
+			"value": "udg.student1@trackdev.com",
+			"type": "string",
+			"description": "Email of a student enrolled in UdG courses"
+		},
+		{
+			"key": "udgStudentPassword",
+			"value": "student1",
+			"type": "string",
+			"description": "Password for the UdG student"
+		},
+		{
+			"key": "ubStudentToken",
+			"value": "",
+			"type": "string",
+			"description": "Token of a student enrolled in UB courses (cross-project test)"
 		}
 	]
 }

--- a/src/main/java/org/trackdev/api/controller/TaskController.java
+++ b/src/main/java/org/trackdev/api/controller/TaskController.java
@@ -96,7 +96,20 @@ public class TaskController extends CrudController<Task, TaskService> {
         List<PointsReview> pointsReview = pointsReviewService.getPointsReview(userId);
         TaskDetailDTO dto = taskMapper.toDetailDTO(task);
         dto.setPointsReview(pointsReview);
+        
+        // Compute all permission flags based on current user context
         dto.setCanEdit(accessChecker.canEditTask(task, userId));
+        dto.setCanEditStatus(accessChecker.canEditStatus(task, userId));
+        dto.setCanEditSprint(accessChecker.canEditSprint(task, userId));
+        dto.setCanEditType(accessChecker.canEditType(task, userId));
+        dto.setCanEditEstimation(accessChecker.canEditEstimation(task, userId));
+        dto.setCanDelete(accessChecker.canDeleteTask(task, userId));
+        dto.setCanSelfAssign(accessChecker.canSelfAssign(task, userId));
+        dto.setCanUnassign(accessChecker.canUnassign(task, userId));
+        dto.setCanAddSubtask(accessChecker.canAddSubtask(task, userId));
+        dto.setCanFreeze(accessChecker.canFreeze(task, userId));
+        dto.setCanComment(accessChecker.canComment(task, userId));
+        
         return dto;
     }
 

--- a/src/main/java/org/trackdev/api/dto/TaskDetailDTO.java
+++ b/src/main/java/org/trackdev/api/dto/TaskDetailDTO.java
@@ -8,12 +8,47 @@ import java.util.List;
 
 /**
  * DTO for Task detail view - includes project and points review at root level
+ * Also includes computed permission flags based on current user context.
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class TaskDetailDTO extends TaskWithProjectDTO {
     private List<PointsReview> pointsReview;
     
-    /** Whether the current user can edit this task */
+    // =============================================================================
+    // PERMISSION FLAGS (computed based on current user context)
+    // =============================================================================
+    
+    /** Whether the current user can edit this task (name, description, etc.) */
     private boolean canEdit;
+    
+    /** Whether the current user can change the task status */
+    private boolean canEditStatus;
+    
+    /** Whether the current user can change the sprint assignment */
+    private boolean canEditSprint;
+    
+    /** Whether the current user can change the task type */
+    private boolean canEditType;
+    
+    /** Whether the current user can change estimation points */
+    private boolean canEditEstimation;
+    
+    /** Whether the current user can delete this task */
+    private boolean canDelete;
+    
+    /** Whether the current user can self-assign this task */
+    private boolean canSelfAssign;
+    
+    /** Whether the current user can unassign the current assignee */
+    private boolean canUnassign;
+    
+    /** Whether the current user can add subtasks to this task (only for USER_STORY) */
+    private boolean canAddSubtask;
+    
+    /** Whether the current user can freeze/unfreeze this task */
+    private boolean canFreeze;
+    
+    /** Whether the current user can add comments */
+    private boolean canComment;
 }

--- a/src/main/java/org/trackdev/api/entity/Task.java
+++ b/src/main/java/org/trackdev/api/entity/Task.java
@@ -345,7 +345,22 @@ public class Task extends BaseEntityLong {
     }
 
 
+    /**
+     * Returns the sprints where this task is active.
+     * For USER_STORY: computed from the union of all childTasks' sprints
+     * For TASK/BUG: returns the stored activeSprints
+     */
     public Collection<Sprint> getActiveSprints() {
+        // For USER_STORY, compute from childTasks' sprints
+        if (type == TaskType.USER_STORY && childTasks != null && !childTasks.isEmpty()) {
+            Set<Sprint> computedSprints = new HashSet<>();
+            for (Task child : childTasks) {
+                if (child.activeSprints != null) {
+                    computedSprints.addAll(child.activeSprints);
+                }
+            }
+            return computedSprints;
+        }
         return activeSprints;
     }
 

--- a/src/main/java/org/trackdev/api/entity/TaskStatus.java
+++ b/src/main/java/org/trackdev/api/entity/TaskStatus.java
@@ -9,8 +9,7 @@ public enum TaskStatus {
     TODO("task.status.todo"),
     INPROGRESS("task.status.inprogress"),
     VERIFY("task.status.verify"),
-    DONE("task.status.done"),
-    DEFINED("task.status.defined");
+    DONE("task.status.done");
 
     private final String messageKey;
 

--- a/src/main/java/org/trackdev/api/mapper/TaskMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/TaskMapper.java
@@ -75,7 +75,18 @@ public interface TaskMapper {
     @Mapping(target = "parentTask", ignore = true)
     @Mapping(target = "childTasks", source = "childTasks", qualifiedByName = "childTasksToBasicDTO")
     @Mapping(target = "pointsReview", ignore = true)
+    // Permission flags - computed in controller based on user context
     @Mapping(target = "canEdit", ignore = true)
+    @Mapping(target = "canEditStatus", ignore = true)
+    @Mapping(target = "canEditSprint", ignore = true)
+    @Mapping(target = "canEditType", ignore = true)
+    @Mapping(target = "canEditEstimation", ignore = true)
+    @Mapping(target = "canDelete", ignore = true)
+    @Mapping(target = "canSelfAssign", ignore = true)
+    @Mapping(target = "canUnassign", ignore = true)
+    @Mapping(target = "canAddSubtask", ignore = true)
+    @Mapping(target = "canFreeze", ignore = true)
+    @Mapping(target = "canComment", ignore = true)
     TaskDetailDTO toDetailDTO(Task task);
 
     /**

--- a/src/main/java/org/trackdev/api/repository/SprintRepository.java
+++ b/src/main/java/org/trackdev/api/repository/SprintRepository.java
@@ -1,6 +1,7 @@
 package org.trackdev.api.repository;
 
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 import org.trackdev.api.entity.Sprint;
 
@@ -22,11 +23,19 @@ public interface SprintRepository extends BaseRepositoryLong<Sprint> {
     /**
      * Find all sprints created from a specific sprint pattern item
      */
-    List<Sprint> findBySprintPatternItem_Id(Long sprintPatternItemId);
+    @Query("SELECT s FROM Sprint s WHERE s.sprintPatternItem.id = :patternItemId")
+    List<Sprint> findByPatternItemId(@Param("patternItemId") Long patternItemId);
 
     /**
      * Find all sprints for a project, ordered by order index of the pattern item
      */
-    List<Sprint> findByProject_IdOrderBySprintPatternItem_OrderIndexAsc(Long projectId);
+    @Query("SELECT s FROM Sprint s WHERE s.project.id = :projectId ORDER BY s.sprintPatternItem.orderIndex ASC")
+    List<Sprint> findByProjectIdOrderByPatternItemOrderIndex(@Param("projectId") Long projectId);
+
+    /**
+     * Find all sprints for a project
+     */
+    @Query("SELECT s FROM Sprint s WHERE s.project.id = :projectId")
+    List<Sprint> findByProjectId(@Param("projectId") Long projectId);
 
 }

--- a/src/main/java/org/trackdev/api/service/I18nService.java
+++ b/src/main/java/org/trackdev/api/service/I18nService.java
@@ -81,19 +81,20 @@ public class I18nService {
     }
 
     /**
-     * Get a map of subtask status values (DEFINED, INPROGRESS, DONE) with localized names.
+     * Get a map of subtask status values (TODO, INPROGRESS, VERIFY, DONE) with localized names.
      */
     public Map<String, String> getSubtaskStatusLocalized() {
         return getSubtaskStatusLocalized(LocaleContextHolder.getLocale());
     }
 
     /**
-     * Get a map of subtask status values (DEFINED, INPROGRESS, DONE) with localized names for a specific locale.
+     * Get a map of subtask status values (TODO, INPROGRESS, VERIFY, DONE) with localized names for a specific locale.
      */
     public Map<String, String> getSubtaskStatusLocalized(Locale locale) {
         Map<String, String> statusMap = new LinkedHashMap<>();
-        statusMap.put(TaskStatus.DEFINED.name(), getLocalizedName(TaskStatus.DEFINED, locale));
+        statusMap.put(TaskStatus.TODO.name(), getLocalizedName(TaskStatus.TODO, locale));
         statusMap.put(TaskStatus.INPROGRESS.name(), getLocalizedName(TaskStatus.INPROGRESS, locale));
+        statusMap.put(TaskStatus.VERIFY.name(), getLocalizedName(TaskStatus.VERIFY, locale));
         statusMap.put(TaskStatus.DONE.name(), getLocalizedName(TaskStatus.DONE, locale));
         return statusMap;
     }

--- a/src/main/java/org/trackdev/api/service/SprintPatternService.java
+++ b/src/main/java/org/trackdev/api/service/SprintPatternService.java
@@ -143,7 +143,7 @@ public class SprintPatternService extends BaseServiceLong<SprintPattern, SprintP
      * Propagate changes from a SprintPatternItem to all associated Sprints.
      */
     private void propagateChangesToSprints(SprintPatternItem item) {
-        List<Sprint> associatedSprints = sprintRepository.findBySprintPatternItem_Id(item.getId());
+        List<Sprint> associatedSprints = sprintRepository.findByPatternItemId(item.getId());
         for (Sprint sprint : associatedSprints) {
             sprint.setName(item.getName());
             sprint.setStartDate(item.getStartDate());

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -164,6 +164,18 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
         return repo.findAllById(sprintIds);
     }
 
+    /**
+     * Find the currently active sprint for a project.
+     * Active sprint = startDate <= now < endDate
+     */
+    public java.util.Optional<Sprint> findActiveSprintForProject(Long projectId) {
+        ZonedDateTime now = ZonedDateTime.now();
+        return repo.findByProjectId(projectId).stream()
+            .filter(s -> s.getStartDate() != null && s.getEndDate() != null)
+            .filter(s -> !s.getStartDate().isAfter(now) && s.getEndDate().isAfter(now))
+            .findFirst();
+    }
+
     /*
      * NOTE: Sprint status is now computed dynamically via Sprint.getEffectiveStatus()
      * based on startDate/endDate. No scheduled job is needed.

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -56,6 +56,10 @@ public final class ErrorConstants {
     public static final String TASK_IS_FROZEN = "error.task.frozen";
     public static final String ONLY_PROFESSOR_CAN_FREEZE_TASK = "error.task.freeze.professor.only";
     public static final String TASK_STATUS_CHANGE_IN_FUTURE_SPRINT = "error.task.status.future.sprint";
+    public static final String BUG_CANNOT_CHANGE_TYPE = "error.task.bug.cannot.change.type";
+    public static final String USER_STORY_CANNOT_CHANGE_TYPE = "error.task.user.story.cannot.change.type";
+    public static final String USER_STORY_HAS_SUBTASKS_CANNOT_DELETE = "error.task.user.story.has.subtasks.delete";
+    public static final String TASK_STATUS_CANNOT_DELETE = "error.task.status.cannot.delete";
     
     // Project errors
     public static final String PRJ_WITHOUT_MEMBERS = "error.project.no.members";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,7 +4,6 @@ task.status.todo=To Do
 task.status.inprogress=In Progress
 task.status.verify=In Verification
 task.status.done=Done
-task.status.defined=Defined
 
 # Task Type translations
 task.type.us=User Story
@@ -93,6 +92,10 @@ error.task.subtask.type.invalid=A subtask can only be of type TASK or BUG
 error.task.frozen=This task is frozen and cannot be modified
 error.task.freeze.professor.only=Only professors can freeze or unfreeze tasks
 error.task.status.future.sprint=Task status cannot be changed from TODO while in a sprint that has not started yet
+error.task.bug.cannot.change.type=A BUG task cannot change its type
+error.task.user.story.cannot.change.type=A USER_STORY cannot change its type
+error.task.user.story.has.subtasks.delete=A USER_STORY cannot be deleted while it has subtasks
+error.task.status.cannot.delete=A task can only be deleted when its status is TODO or INPROGRESS
 
 # Project errors
 error.project.no.members=Project must have at least one member

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -4,7 +4,6 @@ task.status.todo=Prioritzada
 task.status.inprogress=En Progrés
 task.status.verify=En Verificació
 task.status.done=Finalitzada
-task.status.defined=Definida
 
 # Task Type translations
 task.type.us=Història d'Usuari
@@ -93,6 +92,10 @@ error.task.subtask.type.invalid=Una subtasca només pot ser de tipus TASK o BUG
 error.task.frozen=Aquesta tasca està congelada i no es pot modificar
 error.task.freeze.professor.only=Només els professors poden congelar o descongelar tasques
 error.task.status.future.sprint=L'estat de la tasca no es pot canviar des de TODO mentre estigui en un sprint que encara no ha començat
+error.task.bug.cannot.change.type=Una tasca de tipus BUG no pot canviar el seu tipus
+error.task.user.story.cannot.change.type=Una USER_STORY no pot canviar el seu tipus
+error.task.user.story.has.subtasks.delete=Una USER_STORY no es pot eliminar mentre tingui subtasques
+error.task.status.cannot.delete=Una tasca només es pot eliminar quan el seu estat és TODO o INPROGRESS
 
 # Errors de projectes
 error.project.no.members=El projecte ha de tenir almenys un membre

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -4,7 +4,6 @@ task.status.todo=Priorizada
 task.status.inprogress=En Progreso
 task.status.verify=En Verificación
 task.status.done=Finalizada
-task.status.defined=Definida
 
 # Task Type translations
 task.type.us=Historia de Usuario
@@ -93,6 +92,10 @@ error.task.subtask.type.invalid=Una subtarea solo puede ser de tipo TASK o BUG
 error.task.frozen=Esta tarea está congelada y no se puede modificar
 error.task.freeze.professor.only=Solo los profesores pueden congelar o descongelar tareas
 error.task.status.future.sprint=El estado de la tarea no se puede cambiar desde TODO mientras esté en un sprint que aún no ha comenzado
+error.task.bug.cannot.change.type=Una tarea de tipo BUG no puede cambiar su tipo
+error.task.user.story.cannot.change.type=Una USER_STORY no puede cambiar su tipo
+error.task.user.story.has.subtasks.delete=Una USER_STORY no se puede eliminar mientras tenga subtareas
+error.task.status.cannot.delete=Una tarea solo se puede eliminar cuando su estado es TODO o INPROGRESS
 
 # Errores de proyectos
 error.project.no.members=El proyecto debe tener al menos un miembro

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -1,0 +1,881 @@
+package org.trackdev.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.trackdev.api.configuration.UserType;
+import org.trackdev.api.entity.*;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Comprehensive unit tests for AccessChecker task permission methods.
+ * These tests ensure that backend permission checks cannot be bypassed.
+ * 
+ * Permission rules tested:
+ * - canEditStatus: USER_STORY cannot, TASK/BUG in PAST sprint blocked for students
+ * - canEditSprint: USER_STORY with subtasks cannot, DONE status blocked, PAST sprint escape allowed
+ * - canEditType: USER_STORY and BUG cannot change type
+ * - canEditEstimation: Only TASK/BUG can edit (USER_STORY is computed)
+ * - canDelete: USER_STORY needs no subtasks, TASK/BUG needs TODO/INPROGRESS
+ * - canSelfAssign: Only unassigned, only students, only project members
+ * - canUnassign: Only assignee or professor
+ * - canAddSubtask: Only USER_STORY, only project members or professor
+ * - canFreeze: Only professors
+ * - canComment: Project members or professors, frozen blocks students
+ */
+@ExtendWith(MockitoExtension.class)
+class AccessCheckerTaskPermissionsTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private CourseService courseService;
+
+    private AccessChecker accessChecker;
+
+    // Test entities
+    private User adminUser;
+    private User professorUser;
+    private User studentUser;
+    private User otherStudentUser;
+    private Workspace workspace;
+    private Subject subject;
+    private Course course;
+    private Project project;
+    private Task userStoryTask;
+    private Task taskTask;
+    private Task bugTask;
+    private Sprint activeSprint;
+    private Sprint closedSprint;
+    private Sprint draftSprint;
+
+    @BeforeEach
+    void setUp() {
+        accessChecker = new AccessChecker();
+        ReflectionTestUtils.setField(accessChecker, "userService", userService);
+        ReflectionTestUtils.setField(accessChecker, "courseService", courseService);
+
+        // Create workspace
+        workspace = new Workspace();
+        ReflectionTestUtils.setField(workspace, "id", 1L);
+
+        // Create admin user
+        adminUser = new User();
+        ReflectionTestUtils.setField(adminUser, "id", "admin-id");
+        Role adminRole = new Role(UserType.ADMIN);
+        ReflectionTestUtils.setField(adminUser, "roles", Set.of(adminRole));
+
+        // Create professor user
+        professorUser = new User();
+        ReflectionTestUtils.setField(professorUser, "id", "professor-id");
+        Role professorRole = new Role(UserType.PROFESSOR);
+        ReflectionTestUtils.setField(professorUser, "roles", Set.of(professorRole));
+        professorUser.setWorkspace(workspace);
+
+        // Create student user
+        studentUser = new User();
+        ReflectionTestUtils.setField(studentUser, "id", "student-id");
+        Role studentRole = new Role(UserType.STUDENT);
+        ReflectionTestUtils.setField(studentUser, "roles", Set.of(studentRole));
+        studentUser.setWorkspace(workspace);
+
+        // Create another student (not assigned, not reporter)
+        otherStudentUser = new User();
+        ReflectionTestUtils.setField(otherStudentUser, "id", "other-student-id");
+        Role otherStudentRole = new Role(UserType.STUDENT);
+        ReflectionTestUtils.setField(otherStudentUser, "roles", Set.of(otherStudentRole));
+        otherStudentUser.setWorkspace(workspace);
+
+        // Create subject owned by professor
+        subject = new Subject("Test Subject", "TS", professorUser);
+        ReflectionTestUtils.setField(subject, "id", 1L);
+        ReflectionTestUtils.setField(subject, "ownerId", "professor-id");
+        subject.setWorkspace(workspace);
+
+        // Create course
+        course = new Course(2025);
+        ReflectionTestUtils.setField(course, "id", 1L);
+        course.setSubject(subject);
+        course.setOwner(professorUser);
+        ReflectionTestUtils.setField(course, "ownerId", "professor-id");
+
+        // Create project with student as member
+        project = new Project("Test Project");
+        ReflectionTestUtils.setField(project, "id", 1L);
+        project.setCourse(course);
+        Set<User> members = new HashSet<>();
+        members.add(studentUser);
+        ReflectionTestUtils.setField(project, "members", members);
+
+        // Create sprints
+        activeSprint = new Sprint();
+        ReflectionTestUtils.setField(activeSprint, "id", 1L);
+        activeSprint.setStatus(SprintStatus.ACTIVE);
+        activeSprint.setStartDate(ZonedDateTime.now().minusDays(7));
+        activeSprint.setEndDate(ZonedDateTime.now().plusDays(7));
+
+        closedSprint = new Sprint();
+        ReflectionTestUtils.setField(closedSprint, "id", 2L);
+        closedSprint.setStatus(SprintStatus.CLOSED);
+        closedSprint.setStartDate(ZonedDateTime.now().minusDays(21));
+        closedSprint.setEndDate(ZonedDateTime.now().minusDays(7));
+
+        draftSprint = new Sprint();
+        ReflectionTestUtils.setField(draftSprint, "id", 3L);
+        draftSprint.setStatus(SprintStatus.DRAFT);
+        draftSprint.setStartDate(ZonedDateTime.now().plusDays(7));
+        draftSprint.setEndDate(ZonedDateTime.now().plusDays(21));
+
+        // Create USER_STORY task
+        userStoryTask = createTask(1L, "User Story", TaskType.USER_STORY, TaskStatus.TODO);
+
+        // Create TASK task
+        taskTask = createTask(2L, "Task", TaskType.TASK, TaskStatus.TODO);
+
+        // Create BUG task
+        bugTask = createTask(3L, "Bug", TaskType.BUG, TaskStatus.TODO);
+
+        // Setup mocks
+        lenient().when(userService.get("admin-id")).thenReturn(adminUser);
+        lenient().when(userService.get("professor-id")).thenReturn(professorUser);
+        lenient().when(userService.get("student-id")).thenReturn(studentUser);
+        lenient().when(userService.get("other-student-id")).thenReturn(otherStudentUser);
+    }
+
+    private Task createTask(Long id, String name, TaskType type, TaskStatus status) {
+        Task task = new Task();
+        ReflectionTestUtils.setField(task, "id", id);
+        task.setName(name);
+        task.setType(type);
+        task.setStatus(status);
+        task.setProject(project);
+        task.setReporter(studentUser);
+        task.setAssignee(studentUser);
+        task.setFrozen(false);
+        ReflectionTestUtils.setField(task, "activeSprints", new ArrayList<>(List.of(activeSprint)));
+        return task;
+    }
+
+    // =============================================================================
+    // isProfessorForTask Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("isProfessorForTask")
+    class IsProfessorForTaskTests {
+
+        @Test
+        @DisplayName("Admin should be considered professor for any task")
+        void admin_shouldBeConsideredProfessor() {
+            assertTrue(accessChecker.isProfessorForTask(taskTask, "admin-id"));
+        }
+
+        @Test
+        @DisplayName("Course owner should be considered professor")
+        void courseOwner_shouldBeConsideredProfessor() {
+            assertTrue(accessChecker.isProfessorForTask(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Student should NOT be considered professor")
+        void student_shouldNotBeConsideredProfessor() {
+            assertFalse(accessChecker.isProfessorForTask(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
+    // isTaskInPastSprintOnly Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("isTaskInPastSprintOnly")
+    class IsTaskInPastSprintOnlyTests {
+
+        @Test
+        @DisplayName("USER_STORY should never be considered in past sprint only")
+        void userStory_shouldNeverBeInPastSprintOnly() {
+            ReflectionTestUtils.setField(userStoryTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.isTaskInPastSprintOnly(userStoryTask));
+        }
+
+        @Test
+        @DisplayName("TASK in CLOSED sprint should be in past sprint only")
+        void taskInClosedSprint_shouldBeInPastSprintOnly() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertTrue(accessChecker.isTaskInPastSprintOnly(taskTask));
+        }
+
+        @Test
+        @DisplayName("TASK in ACTIVE sprint should NOT be in past sprint only")
+        void taskInActiveSprint_shouldNotBeInPastSprintOnly() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(activeSprint));
+            assertFalse(accessChecker.isTaskInPastSprintOnly(taskTask));
+        }
+
+        @Test
+        @DisplayName("TASK with no sprints should NOT be in past sprint only")
+        void taskWithNoSprints_shouldNotBeInPastSprintOnly() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", new ArrayList<>());
+            assertFalse(accessChecker.isTaskInPastSprintOnly(taskTask));
+        }
+
+        @Test
+        @DisplayName("BUG in CLOSED sprint should be in past sprint only")
+        void bugInClosedSprint_shouldBeInPastSprintOnly() {
+            ReflectionTestUtils.setField(bugTask, "activeSprints", List.of(closedSprint));
+            assertTrue(accessChecker.isTaskInPastSprintOnly(bugTask));
+        }
+    }
+
+    // =============================================================================
+    // canEditStatus Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canEditStatus")
+    class CanEditStatusTests {
+
+        @Test
+        @DisplayName("USER_STORY status should NOT be editable by anyone")
+        void userStory_statusShouldNotBeEditable() {
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "student-id"));
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "professor-id"));
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "admin-id"));
+        }
+
+        @Test
+        @DisplayName("TASK status should be editable by assignee")
+        void task_statusShouldBeEditableByAssignee() {
+            assertTrue(accessChecker.canEditStatus(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint should NOT be editable by student")
+        void taskInPastSprint_statusShouldNotBeEditableByStudent() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.canEditStatus(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint SHOULD be editable by professor")
+        void taskInPastSprint_statusShouldBeEditableByProfessor() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK should NOT be editable by student")
+        void frozenTask_statusShouldNotBeEditableByStudent() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canEditStatus(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK SHOULD be editable by professor")
+        void frozenTask_statusShouldBeEditableByProfessor() {
+            taskTask.setFrozen(true);
+            assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
+        }
+    }
+
+    // =============================================================================
+    // canEditSprint Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canEditSprint")
+    class CanEditSprintTests {
+
+        @Test
+        @DisplayName("USER_STORY with subtasks having sprints should NOT edit sprint")
+        void userStoryWithSubtaskSprints_shouldNotEditSprint() {
+            Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.TODO);
+            ReflectionTestUtils.setField(subtask, "activeSprints", List.of(activeSprint));
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask));
+            
+            assertFalse(accessChecker.canEditSprint(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY without subtasks SHOULD edit sprint")
+        void userStoryWithoutSubtasks_shouldEditSprint() {
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", new ArrayList<>());
+            assertTrue(accessChecker.canEditSprint(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in DONE status should NOT edit sprint (student)")
+        void taskInDoneStatus_shouldNotEditSprintByStudent() {
+            taskTask.setStatus(TaskStatus.DONE);
+            assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in DONE status SHOULD edit sprint by professor")
+        void taskInDoneStatus_shouldEditSprintByProfessor() {
+            taskTask.setStatus(TaskStatus.DONE);
+            assertTrue(accessChecker.canEditSprint(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint (not DONE) SHOULD edit sprint to escape")
+        void taskInPastSprintNotDone_shouldEditSprintToEscape() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            taskTask.setStatus(TaskStatus.INPROGRESS);
+            assertTrue(accessChecker.canEditSprint(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint with DONE status should NOT edit sprint (student)")
+        void taskInPastSprintDone_shouldNotEditSprintByStudent() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            taskTask.setStatus(TaskStatus.DONE);
+            assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK should NOT edit sprint (student)")
+        void frozenTask_shouldNotEditSprintByStudent() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canEditType Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canEditType")
+    class CanEditTypeTests {
+
+        @Test
+        @DisplayName("USER_STORY type should NOT be editable")
+        void userStory_typeShouldNotBeEditable() {
+            assertFalse(accessChecker.canEditType(userStoryTask, "student-id"));
+            assertFalse(accessChecker.canEditType(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("BUG type should NOT be editable")
+        void bug_typeShouldNotBeEditable() {
+            assertFalse(accessChecker.canEditType(bugTask, "student-id"));
+            assertFalse(accessChecker.canEditType(bugTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK type SHOULD be editable by assignee")
+        void task_typeShouldBeEditableByAssignee() {
+            assertTrue(accessChecker.canEditType(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint type should NOT be editable by student")
+        void taskInPastSprint_typeShouldNotBeEditableByStudent() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.canEditType(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint type SHOULD be editable by professor")
+        void taskInPastSprint_typeShouldBeEditableByProfessor() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertTrue(accessChecker.canEditType(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK type should NOT be editable by student")
+        void frozenTask_typeShouldNotBeEditableByStudent() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canEditType(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canEditEstimation Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canEditEstimation")
+    class CanEditEstimationTests {
+
+        @Test
+        @DisplayName("USER_STORY estimation should NOT be editable (computed from subtasks)")
+        void userStory_estimationShouldNotBeEditable() {
+            assertFalse(accessChecker.canEditEstimation(userStoryTask, "student-id"));
+            assertFalse(accessChecker.canEditEstimation(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK estimation SHOULD be editable by assignee")
+        void task_estimationShouldBeEditableByAssignee() {
+            assertTrue(accessChecker.canEditEstimation(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("BUG estimation SHOULD be editable by assignee")
+        void bug_estimationShouldBeEditableByAssignee() {
+            assertTrue(accessChecker.canEditEstimation(bugTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint estimation should NOT be editable by student")
+        void taskInPastSprint_estimationShouldNotBeEditableByStudent() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.canEditEstimation(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK estimation should NOT be editable by student")
+        void frozenTask_estimationShouldNotBeEditableByStudent() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canEditEstimation(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canDeleteTask Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canDeleteTask")
+    class CanDeleteTaskTests {
+
+        @Test
+        @DisplayName("USER_STORY with subtasks should NOT be deletable")
+        void userStoryWithSubtasks_shouldNotBeDeletable() {
+            Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.TODO);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask));
+            
+            assertFalse(accessChecker.canDeleteTask(userStoryTask, "student-id"));
+            assertFalse(accessChecker.canDeleteTask(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY without subtasks SHOULD be deletable")
+        void userStoryWithoutSubtasks_shouldBeDeletable() {
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", new ArrayList<>());
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in TODO status SHOULD be deletable")
+        void taskInTodoStatus_shouldBeDeletable() {
+            taskTask.setStatus(TaskStatus.TODO);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in INPROGRESS status SHOULD be deletable")
+        void taskInInProgressStatus_shouldBeDeletable() {
+            taskTask.setStatus(TaskStatus.INPROGRESS);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in VERIFY status should NOT be deletable")
+        void taskInVerifyStatus_shouldNotBeDeletable() {
+            taskTask.setStatus(TaskStatus.VERIFY);
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in DONE status should NOT be deletable")
+        void taskInDoneStatus_shouldNotBeDeletable() {
+            taskTask.setStatus(TaskStatus.DONE);
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK should NOT be deletable by student")
+        void frozenTask_shouldNotBeDeletableByStudent() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen TASK in TODO SHOULD be deletable by professor")
+        void frozenTaskInTodo_shouldBeDeletableByProfessor() {
+            taskTask.setFrozen(true);
+            taskTask.setStatus(TaskStatus.TODO);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in PAST sprint should NOT be deletable by student")
+        void taskInPastSprint_shouldNotBeDeletableByStudent() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Reporter (not assignee) should NOT be able to delete task")
+        void reporter_notAssignee_shouldNotDelete() {
+            // Student is reporter but not assignee
+            taskTask.setReporter(studentUser);
+            taskTask.setAssignee(null);  // Unassigned
+            taskTask.setStatus(TaskStatus.TODO);
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("After unassign, former assignee should NOT be able to delete")
+        void afterUnassign_formerAssigneeShouldNotDelete() {
+            // Student was assignee, now unassigned
+            taskTask.setReporter(studentUser);  // Still reporter
+            taskTask.setAssignee(null);  // No longer assignee
+            taskTask.setStatus(TaskStatus.TODO);
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Current assignee SHOULD be able to delete (TODO status)")
+        void currentAssignee_shouldDelete() {
+            taskTask.setAssignee(studentUser);
+            taskTask.setStatus(TaskStatus.TODO);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canSelfAssign Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canSelfAssign")
+    class CanSelfAssignTests {
+
+        @Test
+        @DisplayName("Unassigned task SHOULD allow student self-assign")
+        void unassignedTask_shouldAllowStudentSelfAssign() {
+            taskTask.setAssignee(null);
+            assertTrue(accessChecker.canSelfAssign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Already assigned task should NOT allow self-assign")
+        void assignedTask_shouldNotAllowSelfAssign() {
+            taskTask.setAssignee(studentUser);
+            assertFalse(accessChecker.canSelfAssign(taskTask, "other-student-id"));
+        }
+
+        @Test
+        @DisplayName("Professor should NOT self-assign (not a student)")
+        void professor_shouldNotSelfAssign() {
+            taskTask.setAssignee(null);
+            assertFalse(accessChecker.canSelfAssign(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task should NOT allow self-assign")
+        void frozenTask_shouldNotAllowSelfAssign() {
+            taskTask.setAssignee(null);
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canSelfAssign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Task in PAST sprint should NOT allow self-assign")
+        void taskInPastSprint_shouldNotAllowSelfAssign() {
+            taskTask.setAssignee(null);
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.canSelfAssign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Non-project-member should NOT self-assign")
+        void nonProjectMember_shouldNotSelfAssign() {
+            taskTask.setAssignee(null);
+            // other-student is not a project member
+            assertFalse(accessChecker.canSelfAssign(taskTask, "other-student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canUnassign Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canUnassign")
+    class CanUnassignTests {
+
+        @Test
+        @DisplayName("Unassigned task should NOT allow unassign")
+        void unassignedTask_shouldNotAllowUnassign() {
+            taskTask.setAssignee(null);
+            assertFalse(accessChecker.canUnassign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Assignee SHOULD be able to unassign themselves")
+        void assignee_shouldBeAbleToUnassign() {
+            taskTask.setAssignee(studentUser);
+            assertTrue(accessChecker.canUnassign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Professor SHOULD be able to unassign anyone")
+        void professor_shouldBeAbleToUnassignAnyone() {
+            taskTask.setAssignee(studentUser);
+            assertTrue(accessChecker.canUnassign(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Other student should NOT be able to unassign")
+        void otherStudent_shouldNotBeAbleToUnassign() {
+            taskTask.setAssignee(studentUser);
+            assertFalse(accessChecker.canUnassign(taskTask, "other-student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task should NOT allow student to unassign")
+        void frozenTask_shouldNotAllowStudentToUnassign() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canUnassign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task SHOULD allow professor to unassign")
+        void frozenTask_shouldAllowProfessorToUnassign() {
+            taskTask.setFrozen(true);
+            assertTrue(accessChecker.canUnassign(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Task in PAST sprint should NOT allow student to unassign")
+        void taskInPastSprint_shouldNotAllowStudentToUnassign() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertFalse(accessChecker.canUnassign(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canAddSubtask Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canAddSubtask")
+    class CanAddSubtaskTests {
+
+        @Test
+        @DisplayName("TASK should NOT allow adding subtasks")
+        void task_shouldNotAllowAddingSubtasks() {
+            assertFalse(accessChecker.canAddSubtask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("BUG should NOT allow adding subtasks")
+        void bug_shouldNotAllowAddingSubtasks() {
+            assertFalse(accessChecker.canAddSubtask(bugTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY SHOULD allow project member to add subtasks")
+        void userStory_shouldAllowProjectMemberToAddSubtasks() {
+            assertTrue(accessChecker.canAddSubtask(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY SHOULD allow professor to add subtasks")
+        void userStory_shouldAllowProfessorToAddSubtasks() {
+            assertTrue(accessChecker.canAddSubtask(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen USER_STORY should NOT allow student to add subtasks")
+        void frozenUserStory_shouldNotAllowStudentToAddSubtasks() {
+            userStoryTask.setFrozen(true);
+            assertFalse(accessChecker.canAddSubtask(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen USER_STORY SHOULD allow professor to add subtasks")
+        void frozenUserStory_shouldAllowProfessorToAddSubtasks() {
+            userStoryTask.setFrozen(true);
+            assertTrue(accessChecker.canAddSubtask(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Non-project-member should NOT add subtasks")
+        void nonProjectMember_shouldNotAddSubtasks() {
+            assertFalse(accessChecker.canAddSubtask(userStoryTask, "other-student-id"));
+        }
+    }
+
+    // =============================================================================
+    // canFreeze Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canFreeze")
+    class CanFreezeTests {
+
+        @Test
+        @DisplayName("Student should NOT be able to freeze")
+        void student_shouldNotBeAbleToFreeze() {
+            assertFalse(accessChecker.canFreeze(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Professor SHOULD be able to freeze")
+        void professor_shouldBeAbleToFreeze() {
+            assertTrue(accessChecker.canFreeze(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Admin SHOULD be able to freeze")
+        void admin_shouldBeAbleToFreeze() {
+            assertTrue(accessChecker.canFreeze(taskTask, "admin-id"));
+        }
+    }
+
+    // =============================================================================
+    // canComment Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canComment")
+    class CanCommentTests {
+
+        @Test
+        @DisplayName("Project member SHOULD be able to comment")
+        void projectMember_shouldBeAbleToComment() {
+            assertTrue(accessChecker.canComment(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Professor SHOULD be able to comment")
+        void professor_shouldBeAbleToComment() {
+            assertTrue(accessChecker.canComment(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Non-project-member should NOT be able to comment")
+        void nonProjectMember_shouldNotBeAbleToComment() {
+            assertFalse(accessChecker.canComment(taskTask, "other-student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task should NOT allow student to comment")
+        void frozenTask_shouldNotAllowStudentToComment() {
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canComment(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task SHOULD allow professor to comment")
+        void frozenTask_shouldAllowProfessorToComment() {
+            taskTask.setFrozen(true);
+            assertTrue(accessChecker.canComment(taskTask, "professor-id"));
+        }
+    }
+
+    // =============================================================================
+    // Cross-cutting Security Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("Security - Bypass Prevention")
+    class SecurityBypassPreventionTests {
+
+        @Test
+        @DisplayName("Non-member student should NOT edit task")
+        void nonMemberStudent_shouldNotEditTask() {
+            assertFalse(accessChecker.canEditTask(taskTask, "other-student-id"));
+        }
+
+        @Test
+        @DisplayName("Task in PAST sprint - all edit operations blocked for student")
+        void taskInPastSprint_allEditOperationsBlockedForStudent() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            
+            assertFalse(accessChecker.canEditStatus(taskTask, "student-id"));
+            assertFalse(accessChecker.canEditType(taskTask, "student-id"));
+            assertFalse(accessChecker.canEditEstimation(taskTask, "student-id"));
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+            assertFalse(accessChecker.canUnassign(taskTask, "student-id"));
+            assertFalse(accessChecker.canSelfAssign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Task in PAST sprint - professor CAN still edit")
+        void taskInPastSprint_professorCanStillEdit() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            taskTask.setStatus(TaskStatus.TODO); // Ensure TODO for delete test
+            
+            assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
+            assertTrue(accessChecker.canEditType(taskTask, "professor-id"));
+            assertTrue(accessChecker.canEditEstimation(taskTask, "professor-id"));
+            assertTrue(accessChecker.canDeleteTask(taskTask, "professor-id"));
+            assertTrue(accessChecker.canUnassign(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task - all edit operations blocked for student")
+        void frozenTask_allEditOperationsBlockedForStudent() {
+            taskTask.setFrozen(true);
+            taskTask.setAssignee(null); // for self-assign test
+            
+            assertFalse(accessChecker.canEditStatus(taskTask, "student-id"));
+            assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
+            assertFalse(accessChecker.canEditType(taskTask, "student-id"));
+            assertFalse(accessChecker.canEditEstimation(taskTask, "student-id"));
+            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+            assertFalse(accessChecker.canSelfAssign(taskTask, "student-id"));
+            assertFalse(accessChecker.canComment(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task - professor CAN still edit")
+        void frozenTask_professorCanStillEdit() {
+            taskTask.setFrozen(true);
+            taskTask.setStatus(TaskStatus.TODO);
+            
+            assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
+            assertTrue(accessChecker.canEditSprint(taskTask, "professor-id"));
+            assertTrue(accessChecker.canEditType(taskTask, "professor-id"));
+            assertTrue(accessChecker.canEditEstimation(taskTask, "professor-id"));
+            assertTrue(accessChecker.canDeleteTask(taskTask, "professor-id"));
+            assertTrue(accessChecker.canFreeze(taskTask, "professor-id"));
+            assertTrue(accessChecker.canComment(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY constraints cannot be bypassed")
+        void userStoryConstraints_cannotBeBypassed() {
+            // Status never editable
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "admin-id"));
+            
+            // Type never editable
+            assertFalse(accessChecker.canEditType(userStoryTask, "admin-id"));
+            
+            // Estimation never editable
+            assertFalse(accessChecker.canEditEstimation(userStoryTask, "admin-id"));
+            
+            // Delete blocked if has subtasks
+            Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.TODO);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask));
+            assertFalse(accessChecker.canDeleteTask(userStoryTask, "admin-id"));
+        }
+
+        @Test
+        @DisplayName("BUG type constraints cannot be bypassed")
+        void bugTypeConstraints_cannotBeBypassed() {
+            // Type never editable for BUG
+            assertFalse(accessChecker.canEditType(bugTask, "admin-id"));
+            assertFalse(accessChecker.canEditType(bugTask, "professor-id"));
+            assertFalse(accessChecker.canEditType(bugTask, "student-id"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements a comprehensive granular permission system for tasks that provides fine-grained, role-based authorization control. The system evaluates 11 distinct permission flags based on user role, task state, sprint status, and business rules, enabling the UI to show/hide controls dynamically while enforcing backend validation.

## Changes

### Permission System (Core Feature)
- **Added 11 granular permission flags** to `TaskDetailDTO`: `canEdit`, `canEditStatus`, `canEditSprint`, `canEditType`, `canEditEstimation`, `canDelete`, `canSelfAssign`, `canUnassign`, `canAddSubtask`, `canFreeze`, `canComment`
- **Implemented permission computation methods** in `AccessChecker` service with comprehensive business logic:
  - Professors can override most restrictions
  - Students restricted based on task assignment, sprint state, and task type
  - USER_STORY restrictions (no manual status/estimation changes, computed from subtasks)
  - Past sprint restrictions (tasks in closed sprints have limited editability)
  - Frozen task restrictions (blocks student edits, not professors)
- **Populated permission flags** in `TaskController.getTask()` endpoint for real-time authorization
- **Added comprehensive unit tests** (`AccessCheckerTaskPermissionsTest`) covering all permission scenarios

### Task & Sprint Enhancements
- **Enhanced subtask creation** with smart sprint assignment logic:
  - Subtasks inherit parent sprint or use active sprint
  - Prevents assignment to past sprints (redirects to active sprint)
  - Proper status initialization (BACKLOG vs TODO based on parent state)
- **USER_STORY sprints computed dynamically** from subtasks via `getActiveSprints()`
- **Added `findActiveSprintForProject()`** method to identify currently running sprint

### Validation & Error Messages
- **Added 4 new error constants** for task validation: type change restrictions, deletion rules
- **i18n support** for new validation messages in English, Spanish (es), and Catalan (ca)
- **Removed unused DEFINED status** from `TaskStatus` enum and all translations

### Testing & Demo Data
- **Enhanced Postman collection** with UdG student login and authorization test scenarios
- **Deterministic demo project** (pds25a) with comprehensive task scenarios for consistent testing
- **273 new lines** of permission computation logic with full test coverage

### Refactoring
- **Simplified Sprint repository methods** with explicit JPQL queries for clarity
- **Updated I18nService** to reflect current task status values (TODO, INPROGRESS, VERIFY, DONE)

## Why These Changes
The previous permission model used a single `canEdit` flag, which was insufficient for complex UI requirements. This granular system enables:
1. **Fine-grained UI control** - Show/hide specific form fields based on user permissions
2. **Backend enforcement** - Permission checks cannot be bypassed via direct API calls
3. **Business rule compliance** - Enforces complex rules (e.g., USER_STORY estimation is computed, BUG type cannot change)
4. **Better UX** - Users see only actions they're allowed to perform

## Breaking Changes
None. This is a backward-compatible addition. The existing `canEdit` flag is retained and continues to work.

## Testing Notes
- All permission scenarios covered by unit tests in `AccessCheckerTaskPermissionsTest`
- Postman collection updated with authorization test cases
- Demo data includes tasks in various states (past/active/future sprints, different statuses) for manual testing
- Run API tests: `./run-api-tests.sh` (Linux) or `.\run-api-tests.ps1` (Windows)