### PR TITLE
feat: add project code survival analysis system

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/EmailPrivacyAdvice.java
+++ b/src/main/java/org/trackdev/api/configuration/EmailPrivacyAdvice.java
@@ -67,7 +67,6 @@ public class EmailPrivacyAdvice implements ResponseBodyAdvice<Object> {
 
         // Student user - filter emails from user DTOs except their own
         try {
-            logger.info("EMAIL_PRIVACY: Filtering for student userId={}, body type={}", currentUserId, body.getClass().getSimpleName());
             filterEmailsRecursively(body, currentUserId, new HashSet<>());
         } catch (Exception e) {
             logger.warn("Error filtering emails from response", e);

--- a/src/main/java/org/trackdev/api/controller/ProjectAnalysisController.java
+++ b/src/main/java/org/trackdev/api/controller/ProjectAnalysisController.java
@@ -1,0 +1,126 @@
+package org.trackdev.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.trackdev.api.dto.PRFileDetailDTO;
+import org.trackdev.api.dto.ProjectAnalysisDTO;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.service.ProjectAnalysisService;
+import org.trackdev.api.service.UserService;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/project-analyses")
+@Tag(name = "Project Analysis", description = "Full project analysis endpoints")
+@SecurityRequirement(name = "bearerAuth")
+public class ProjectAnalysisController extends BaseController {
+
+    @Autowired
+    private ProjectAnalysisService analysisService;
+
+    @Autowired
+    private UserService userService;
+
+    /**
+     * Start a new project analysis.
+     * Only professors/admins who can manage the course can start an analysis.
+     */
+    @PostMapping("/projects/{projectId}/start")
+    @Operation(summary = "Start a new project analysis", 
+               description = "Starts an asynchronous analysis of all DONE tasks' PRs in the project")
+    public ResponseEntity<ProjectAnalysisDTO> startAnalysis(
+            Principal principal,
+            @PathVariable(name = "projectId") Long projectId) {
+        String userId = getUserId(principal);
+        User currentUser = userService.get(userId);
+        ProjectAnalysisDTO result = analysisService.startAnalysis(projectId, currentUser);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(result);
+    }
+
+    /**
+     * Get the status of a specific analysis
+     */
+    @GetMapping("/{analysisId}")
+    @Operation(summary = "Get analysis status", description = "Get the current status and progress of an analysis")
+    public ResponseEntity<ProjectAnalysisDTO> getAnalysisStatus(
+            Principal principal,
+            @PathVariable(name = "analysisId") String analysisId) {
+        String userId = getUserId(principal);
+        User currentUser = userService.get(userId);
+        ProjectAnalysisDTO result = analysisService.getAnalysisStatus(analysisId, currentUser);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Get the latest analysis for a project
+     */
+    @GetMapping("/projects/{projectId}/latest")
+    @Operation(summary = "Get latest analysis", description = "Get the most recent analysis for a project")
+    public ResponseEntity<ProjectAnalysisDTO> getLatestAnalysis(
+            Principal principal,
+            @PathVariable(name = "projectId") Long projectId) {
+        String userId = getUserId(principal);
+        User currentUser = userService.get(userId);
+        ProjectAnalysisDTO result = analysisService.getLatestAnalysis(projectId, currentUser);
+        if (result == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Get all analyses for a project
+     */
+    @GetMapping("/projects/{projectId}")
+    @Operation(summary = "Get all analyses", description = "Get all analyses for a project")
+    public ResponseEntity<List<ProjectAnalysisDTO>> getProjectAnalyses(
+            Principal principal,
+            @PathVariable(name = "projectId") Long projectId) {
+        String userId = getUserId(principal);
+        User currentUser = userService.get(userId);
+        List<ProjectAnalysisDTO> results = analysisService.getProjectAnalyses(projectId, currentUser);
+        return ResponseEntity.ok(results);
+    }
+
+    /**
+     * Get analysis results with optional filters
+     */
+    @GetMapping("/{analysisId}/results")
+    @Operation(summary = "Get analysis results", 
+               description = "Get detailed results with optional sprint and author filters")
+    public ResponseEntity<ProjectAnalysisDTO.ResultsDTO> getAnalysisResults(
+            Principal principal,
+            @PathVariable(name = "analysisId") String analysisId,
+            @RequestParam(name = "sprintId", required = false) Long sprintId,
+            @RequestParam(name = "authorId", required = false) String authorId) {
+        String userId = getUserId(principal);
+        User currentUser = userService.get(userId);
+        ProjectAnalysisDTO.ResultsDTO results = analysisService.getAnalysisResults(
+                analysisId, sprintId, authorId, currentUser);
+        return ResponseEntity.ok(results);
+    }
+
+    /**
+     * Get precomputed file details for a specific PR in an analysis.
+     * Returns the same format as the PR analysis endpoint but from precomputed data.
+     */
+    @GetMapping("/{analysisId}/prs/{prId}/files")
+    @Operation(summary = "Get precomputed PR file details", 
+               description = "Get precomputed per-line analysis for a PR from a project analysis")
+    public ResponseEntity<List<PRFileDetailDTO>> getPrecomputedFileDetails(
+            Principal principal,
+            @PathVariable(name = "analysisId") String analysisId,
+            @PathVariable(name = "prId") String prId) {
+        String userId = getUserId(principal);
+        User currentUser = userService.get(userId);
+        List<PRFileDetailDTO> result = analysisService.getPrecomputedFileDetails(analysisId, prId, currentUser);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/org/trackdev/api/controller/PullRequestController.java
+++ b/src/main/java/org/trackdev/api/controller/PullRequestController.java
@@ -1,0 +1,87 @@
+package org.trackdev.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import org.trackdev.api.dto.PRDetailedAnalysisDTO;
+import org.trackdev.api.dto.PRFileDetailDTO;
+import org.trackdev.api.entity.PullRequest;
+import org.trackdev.api.mapper.UserMapper;
+import org.trackdev.api.service.AccessChecker;
+import org.trackdev.api.service.PullRequestService;
+
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * Controller for Pull Request analysis endpoints
+ */
+@RestController
+@RequestMapping(path = "/pull-requests")
+@Tag(name = "Pull Requests", description = "Pull Request analysis endpoints")
+public class PullRequestController extends BaseController {
+
+    @Autowired
+    private PullRequestService pullRequestService;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Autowired
+    private AccessChecker accessChecker;
+
+    @Operation(summary = "Get detailed PR analysis with file information",
+            description = "Returns the pull request details including file-level surviving lines information",
+            security = {@SecurityRequirement(name = "bearerAuth")})
+    @GetMapping("/{prId}/details")
+    public PRDetailedAnalysisDTO getPRDetails(@PathVariable(name = "prId") String prId, Principal principal) {
+        String userId = getUserId(principal);
+        
+        PullRequest pr = pullRequestService.get(prId);
+        accessChecker.checkCanViewPullRequest(pr, userId);
+        
+        // Get file details
+        List<PRFileDetailDTO> fileDetails = pullRequestService.getFileDetails(prId);
+        
+        // Build response DTO
+        PRDetailedAnalysisDTO response = new PRDetailedAnalysisDTO();
+        response.setId(pr.getId());
+        response.setUrl(pr.getUrl());
+        response.setPrNumber(pr.getPrNumber());
+        response.setTitle(pr.getTitle());
+        response.setState(pr.getState());
+        response.setMerged(pr.getMerged());
+        response.setRepoFullName(pr.getRepoFullName());
+        response.setAdditions(pr.getAdditions());
+        response.setDeletions(pr.getDeletions());
+        response.setChangedFiles(pr.getChangedFiles());
+        response.setFiles(fileDetails);
+        
+        // Calculate total surviving lines
+        int totalSurviving = fileDetails.stream()
+                .mapToInt(f -> f.getSurvivingLines() != null ? f.getSurvivingLines() : 0)
+                .sum();
+        response.setSurvivingLines(totalSurviving);
+        
+        if (pr.getAuthor() != null) {
+            response.setAuthor(userMapper.toSummaryDTO(pr.getAuthor()));
+        }
+        
+        return response;
+    }
+
+    @Operation(summary = "Get file details for a PR",
+            description = "Returns detailed file information with line ranges for a pull request",
+            security = {@SecurityRequirement(name = "bearerAuth")})
+    @GetMapping("/{prId}/files")
+    public List<PRFileDetailDTO> getPRFiles(@PathVariable(name = "prId") String prId, Principal principal) {
+        String userId = getUserId(principal);
+        
+        PullRequest pr = pullRequestService.get(prId);
+        accessChecker.checkCanViewPullRequest(pr, userId);
+        
+        return pullRequestService.getFileDetails(prId);
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/PRDetailedAnalysisDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PRDetailedAnalysisDTO.java
@@ -1,0 +1,25 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * DTO for detailed Pull Request analysis with file-level information
+ */
+@Data
+public class PRDetailedAnalysisDTO {
+    private String id;
+    private String url;
+    private Integer prNumber;
+    private String title;
+    private String state;
+    private Boolean merged;
+    private String repoFullName;
+    private UserSummaryDTO author;
+    private Integer additions;
+    private Integer deletions;
+    private Integer changedFiles;
+    private Integer survivingLines;
+    private List<PRFileDetailDTO> files;
+}

--- a/src/main/java/org/trackdev/api/dto/PRFileDetailDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PRFileDetailDTO.java
@@ -1,0 +1,78 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * DTO for detailed file information in a Pull Request.
+ * Lines are provided in display order, interleaving current and deleted lines.
+ */
+@Data
+public class PRFileDetailDTO {
+    private String filePath;
+    private String status; // added, modified, deleted, renamed
+    private Integer additions;
+    private Integer deletions;
+    private Integer survivingLines;
+    private Integer deletedLines;
+    private Integer currentLines; // Total lines in current file
+    private List<LineDetailDTO> lines; // All lines in display order (current + deleted interleaved)
+    
+    // Internal use only - stores the diff patch for parsing added lines
+    private transient String patch;
+    
+    /**
+     * Represents a single line with its content and status.
+     * Lines are ordered for display: current file lines with deleted lines interleaved.
+     */
+    @Data
+    public static class LineDetailDTO {
+        private Integer lineNumber;      // Current line number (null for deleted lines)
+        private Integer originalLineNumber; // Line number in the merge commit (for deleted lines)
+        private String content;
+        private LineStatus status;
+        private String commitSha;
+        private String commitUrl;         // URL to the commit
+        private String authorFullName;    // Full name of the author (from app user matched by GitHub username)
+        private String authorGithubUsername; // GitHub username of the commit author
+        private String prFileUrl;         // URL to the file in the PR being analyzed
+        private Integer originPrNumber;   // PR number that originally introduced this line (for CURRENT lines)
+        private String originPrUrl;       // URL to the PR that originally introduced this line
+        
+        public LineDetailDTO() {}
+        
+        public LineDetailDTO(Integer lineNumber, Integer originalLineNumber, String content, LineStatus status, String commitSha) {
+            this.lineNumber = lineNumber;
+            this.originalLineNumber = originalLineNumber;
+            this.content = content;
+            this.status = status;
+            this.commitSha = commitSha;
+        }
+        
+        public LineDetailDTO(Integer lineNumber, Integer originalLineNumber, String content, LineStatus status, 
+                             String commitSha, String commitUrl, String authorFullName, String authorGithubUsername, 
+                             String prFileUrl, Integer originPrNumber, String originPrUrl) {
+            this.lineNumber = lineNumber;
+            this.originalLineNumber = originalLineNumber;
+            this.content = content;
+            this.status = status;
+            this.commitSha = commitSha;
+            this.commitUrl = commitUrl;
+            this.authorFullName = authorFullName;
+            this.authorGithubUsername = authorGithubUsername;
+            this.prFileUrl = prFileUrl;
+            this.originPrNumber = originPrNumber;
+            this.originPrUrl = originPrUrl;
+        }
+    }
+    
+    /**
+     * Status of a line
+     */
+    public enum LineStatus {
+        SURVIVING,  // Current line that came from the PR (still exists)
+        CURRENT,    // Current line that is NOT from the PR (context/other commits)
+        DELETED     // Line from PR that was modified or deleted since merge
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/ProjectAnalysisDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ProjectAnalysisDTO.java
@@ -1,0 +1,98 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * DTO for project analysis status and results
+ */
+@Data
+public class ProjectAnalysisDTO {
+    
+    private String id;
+    private Long projectId;
+    private String projectName;
+    private String status; // IN_PROGRESS, DONE, FAILED
+    private ZonedDateTime startedAt;
+    private ZonedDateTime completedAt;
+    private String startedByName;
+    private String startedById;
+    
+    // Progress tracking
+    private Integer totalPrs;
+    private Integer processedPrs;
+    private Integer progressPercent;
+    
+    // Summary statistics
+    private Integer totalFiles;
+    private Integer totalSurvivingLines;
+    private Integer totalDeletedLines;
+    private Double survivalRate;
+    
+    private String errorMessage;
+    
+    /**
+     * Summary by author
+     */
+    @Data
+    public static class AuthorSummaryDTO {
+        private String authorId;
+        private String authorName;
+        private String authorUsername;
+        private Integer survivingLines;
+        private Integer deletedLines;
+        private Integer fileCount;
+        private Double survivalRate;
+    }
+    
+    /**
+     * Summary by sprint
+     */
+    @Data
+    public static class SprintSummaryDTO {
+        private Long sprintId;
+        private String sprintName;
+        private Integer survivingLines;
+        private Integer deletedLines;
+        private Integer fileCount;
+        private Double survivalRate;
+    }
+    
+    /**
+     * File detail in analysis results
+     */
+    @Data
+    public static class FileDTO {
+        private String id;
+        private String prId;
+        private Integer prNumber;
+        private String prTitle;
+        private Long taskId;
+        private String taskName;
+        private Long sprintId;
+        private String sprintName;
+        private String authorId;
+        private String authorName;
+        private String filePath;
+        private String status;
+        private Integer additions;
+        private Integer deletions;
+        private Integer survivingLines;
+        private Integer deletedLines;
+        private Integer currentLines;
+        private Double survivalRate;
+    }
+    
+    /**
+     * Full results with summaries and file list
+     */
+    @Data
+    public static class ResultsDTO {
+        private ProjectAnalysisDTO analysis;
+        private List<AuthorSummaryDTO> authorSummaries;
+        private List<SprintSummaryDTO> sprintSummaries;
+        private List<FileDTO> files;
+    }
+}

--- a/src/main/java/org/trackdev/api/entity/ProjectAnalysis.java
+++ b/src/main/java/org/trackdev/api/entity/ProjectAnalysis.java
@@ -1,0 +1,140 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Represents a full project analysis run.
+ * Stores the status and summary of analyzing all DONE tasks' PRs in a project.
+ */
+@Entity
+@Table(name = "project_analyses")
+public class ProjectAnalysis extends BaseEntityUUID {
+
+    public enum AnalysisStatus {
+        IN_PROGRESS,
+        DONE,
+        FAILED
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    @NotNull
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "started_by_id", nullable = false)
+    @NotNull
+    private User startedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    @NotNull
+    private AnalysisStatus status = AnalysisStatus.IN_PROGRESS;
+
+    @Column(columnDefinition = "TIMESTAMP")
+    private ZonedDateTime startedAt;
+
+    @Column(columnDefinition = "TIMESTAMP")
+    private ZonedDateTime completedAt;
+
+    /**
+     * Total number of PRs to analyze
+     */
+    private Integer totalPrs = 0;
+
+    /**
+     * Number of PRs processed so far
+     */
+    private Integer processedPrs = 0;
+
+    /**
+     * Total files analyzed across all PRs
+     */
+    private Integer totalFiles = 0;
+
+    /**
+     * Total surviving lines across all files
+     */
+    private Integer totalSurvivingLines = 0;
+
+    /**
+     * Total deleted/non-surviving lines across all files
+     */
+    private Integer totalDeletedLines = 0;
+
+    /**
+     * Error message if analysis failed
+     */
+    @Column(length = 1000)
+    private String errorMessage;
+
+    public ProjectAnalysis() {}
+
+    public ProjectAnalysis(Project project, User startedBy) {
+        this.project = project;
+        this.startedBy = startedBy;
+        this.status = AnalysisStatus.IN_PROGRESS;
+        this.startedAt = ZonedDateTime.now();
+    }
+
+    // Getters and setters
+    public Project getProject() { return project; }
+    public void setProject(Project project) { this.project = project; }
+
+    public User getStartedBy() { return startedBy; }
+    public void setStartedBy(User startedBy) { this.startedBy = startedBy; }
+
+    public AnalysisStatus getStatus() { return status; }
+    public void setStatus(AnalysisStatus status) { this.status = status; }
+
+    public ZonedDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(ZonedDateTime startedAt) { this.startedAt = startedAt; }
+
+    public ZonedDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(ZonedDateTime completedAt) { this.completedAt = completedAt; }
+
+    public Integer getTotalPrs() { return totalPrs; }
+    public void setTotalPrs(Integer totalPrs) { this.totalPrs = totalPrs; }
+
+    public Integer getProcessedPrs() { return processedPrs; }
+    public void setProcessedPrs(Integer processedPrs) { this.processedPrs = processedPrs; }
+
+    public Integer getTotalFiles() { return totalFiles; }
+    public void setTotalFiles(Integer totalFiles) { this.totalFiles = totalFiles; }
+
+    public Integer getTotalSurvivingLines() { return totalSurvivingLines; }
+    public void setTotalSurvivingLines(Integer totalSurvivingLines) { this.totalSurvivingLines = totalSurvivingLines; }
+
+    public Integer getTotalDeletedLines() { return totalDeletedLines; }
+    public void setTotalDeletedLines(Integer totalDeletedLines) { this.totalDeletedLines = totalDeletedLines; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    /**
+     * Mark analysis as complete
+     */
+    public void complete() {
+        this.status = AnalysisStatus.DONE;
+        this.completedAt = ZonedDateTime.now();
+    }
+
+    /**
+     * Mark analysis as failed
+     */
+    public void fail(String errorMessage) {
+        this.status = AnalysisStatus.FAILED;
+        this.completedAt = ZonedDateTime.now();
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Increment processed PR count
+     */
+    public void incrementProcessedPrs() {
+        this.processedPrs = (this.processedPrs == null ? 0 : this.processedPrs) + 1;
+    }
+}

--- a/src/main/java/org/trackdev/api/entity/ProjectAnalysisFile.java
+++ b/src/main/java/org/trackdev/api/entity/ProjectAnalysisFile.java
@@ -1,0 +1,128 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Represents a file analyzed as part of a project analysis.
+ * Stores file-level summary of surviving/deleted lines.
+ */
+@Entity
+@Table(name = "project_analysis_files", indexes = {
+    @Index(name = "idx_paf_analysis", columnList = "analysis_id"),
+    @Index(name = "idx_paf_sprint", columnList = "sprint_id"),
+    @Index(name = "idx_paf_author", columnList = "author_id")
+})
+public class ProjectAnalysisFile extends BaseEntityUUID {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "analysis_id", nullable = false)
+    @NotNull
+    private ProjectAnalysis analysis;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pr_id", nullable = false)
+    @NotNull
+    private PullRequest pullRequest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sprint_id")
+    private Sprint sprint;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private User author;
+
+    @Column(length = 500, nullable = false)
+    @NotNull
+    private String filePath;
+
+    /**
+     * File status: added, modified, deleted, renamed
+     */
+    @Column(length = 20)
+    private String status;
+
+    /**
+     * Lines added in the PR (from GitHub API)
+     */
+    private Integer additions = 0;
+
+    /**
+     * Lines deleted in the PR (from GitHub API)
+     */
+    private Integer deletions = 0;
+
+    /**
+     * Lines from this PR that still exist in current code
+     */
+    private Integer survivingLines = 0;
+
+    /**
+     * Lines from this PR that have been modified/deleted since merge
+     */
+    private Integer deletedLines = 0;
+
+    /**
+     * Total lines in current file (for context)
+     */
+    private Integer currentLines = 0;
+
+    public ProjectAnalysisFile() {}
+
+    public ProjectAnalysisFile(ProjectAnalysis analysis, PullRequest pullRequest, String filePath) {
+        this.analysis = analysis;
+        this.pullRequest = pullRequest;
+        this.filePath = filePath;
+    }
+
+    // Getters and setters
+    public ProjectAnalysis getAnalysis() { return analysis; }
+    public void setAnalysis(ProjectAnalysis analysis) { this.analysis = analysis; }
+
+    public PullRequest getPullRequest() { return pullRequest; }
+    public void setPullRequest(PullRequest pullRequest) { this.pullRequest = pullRequest; }
+
+    public Task getTask() { return task; }
+    public void setTask(Task task) { this.task = task; }
+
+    public Sprint getSprint() { return sprint; }
+    public void setSprint(Sprint sprint) { this.sprint = sprint; }
+
+    public User getAuthor() { return author; }
+    public void setAuthor(User author) { this.author = author; }
+
+    public String getFilePath() { return filePath; }
+    public void setFilePath(String filePath) { this.filePath = filePath; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public Integer getAdditions() { return additions; }
+    public void setAdditions(Integer additions) { this.additions = additions; }
+
+    public Integer getDeletions() { return deletions; }
+    public void setDeletions(Integer deletions) { this.deletions = deletions; }
+
+    public Integer getSurvivingLines() { return survivingLines; }
+    public void setSurvivingLines(Integer survivingLines) { this.survivingLines = survivingLines; }
+
+    public Integer getDeletedLines() { return deletedLines; }
+    public void setDeletedLines(Integer deletedLines) { this.deletedLines = deletedLines; }
+
+    public Integer getCurrentLines() { return currentLines; }
+    public void setCurrentLines(Integer currentLines) { this.currentLines = currentLines; }
+
+    /**
+     * Get survival rate as percentage
+     */
+    public double getSurvivalRate() {
+        int total = (survivingLines != null ? survivingLines : 0) + (deletedLines != null ? deletedLines : 0);
+        if (total == 0) return 100.0;
+        return (survivingLines != null ? survivingLines : 0) * 100.0 / total;
+    }
+}

--- a/src/main/java/org/trackdev/api/entity/ProjectAnalysisFileLine.java
+++ b/src/main/java/org/trackdev/api/entity/ProjectAnalysisFileLine.java
@@ -1,0 +1,141 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Represents a single line analyzed as part of a project analysis file.
+ * Stores line-level details including status (surviving, current, deleted).
+ */
+@Entity
+@Table(name = "project_analysis_file_lines", indexes = {
+    @Index(name = "idx_pafl_file", columnList = "file_id"),
+    @Index(name = "idx_pafl_line_number", columnList = "line_number")
+})
+public class ProjectAnalysisFileLine extends BaseEntityUUID {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "file_id", nullable = false)
+    @NotNull
+    private ProjectAnalysisFile file;
+
+    /**
+     * Current line number (null for deleted lines)
+     */
+    @Column(name = "line_number")
+    private Integer lineNumber;
+
+    /**
+     * Line number in the merge commit (for deleted lines)
+     */
+    @Column(name = "original_line_number")
+    private Integer originalLineNumber;
+
+    /**
+     * Line content
+     */
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    /**
+     * Line status: SURVIVING, CURRENT, DELETED
+     */
+    @Column(length = 20, nullable = false)
+    @NotNull
+    private String status;
+
+    /**
+     * Commit SHA that introduced this line
+     */
+    @Column(length = 50)
+    private String commitSha;
+
+    /**
+     * URL to the commit
+     */
+    @Column(length = 500)
+    private String commitUrl;
+
+    /**
+     * Full name of the author
+     */
+    @Column(length = 200)
+    private String authorFullName;
+
+    /**
+     * GitHub username of the commit author
+     */
+    @Column(length = 100)
+    private String authorGithubUsername;
+
+    /**
+     * URL to the file in the PR being analyzed
+     */
+    @Column(length = 500)
+    private String prFileUrl;
+
+    /**
+     * PR number that originally introduced this line (for CURRENT lines)
+     */
+    @Column(name = "origin_pr_number")
+    private Integer originPrNumber;
+
+    /**
+     * URL to the PR that originally introduced this line
+     */
+    @Column(name = "origin_pr_url", length = 500)
+    private String originPrUrl;
+
+    /**
+     * Display order for interleaved lines
+     */
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder = 0;
+
+    public ProjectAnalysisFileLine() {}
+
+    public ProjectAnalysisFileLine(ProjectAnalysisFile file, Integer displayOrder) {
+        this.file = file;
+        this.displayOrder = displayOrder;
+    }
+
+    // Getters and setters
+    public ProjectAnalysisFile getFile() { return file; }
+    public void setFile(ProjectAnalysisFile file) { this.file = file; }
+
+    public Integer getLineNumber() { return lineNumber; }
+    public void setLineNumber(Integer lineNumber) { this.lineNumber = lineNumber; }
+
+    public Integer getOriginalLineNumber() { return originalLineNumber; }
+    public void setOriginalLineNumber(Integer originalLineNumber) { this.originalLineNumber = originalLineNumber; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getCommitSha() { return commitSha; }
+    public void setCommitSha(String commitSha) { this.commitSha = commitSha; }
+
+    public String getCommitUrl() { return commitUrl; }
+    public void setCommitUrl(String commitUrl) { this.commitUrl = commitUrl; }
+
+    public String getAuthorFullName() { return authorFullName; }
+    public void setAuthorFullName(String authorFullName) { this.authorFullName = authorFullName; }
+
+    public String getAuthorGithubUsername() { return authorGithubUsername; }
+    public void setAuthorGithubUsername(String authorGithubUsername) { this.authorGithubUsername = authorGithubUsername; }
+
+    public String getPrFileUrl() { return prFileUrl; }
+    public void setPrFileUrl(String prFileUrl) { this.prFileUrl = prFileUrl; }
+
+    public Integer getOriginPrNumber() { return originPrNumber; }
+    public void setOriginPrNumber(Integer originPrNumber) { this.originPrNumber = originPrNumber; }
+
+    public String getOriginPrUrl() { return originPrUrl; }
+    public void setOriginPrUrl(String originPrUrl) { this.originPrUrl = originPrUrl; }
+
+    public Integer getDisplayOrder() { return displayOrder; }
+    public void setDisplayOrder(Integer displayOrder) { this.displayOrder = displayOrder; }
+}

--- a/src/main/java/org/trackdev/api/mapper/ProjectAnalysisMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/ProjectAnalysisMapper.java
@@ -1,0 +1,66 @@
+package org.trackdev.api.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.trackdev.api.dto.ProjectAnalysisDTO;
+import org.trackdev.api.entity.ProjectAnalysis;
+import org.trackdev.api.entity.ProjectAnalysisFile;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ProjectAnalysisMapper {
+
+    @Mapping(target = "projectId", source = "project.id")
+    @Mapping(target = "projectName", source = "project.name")
+    @Mapping(target = "status", source = "status")
+    @Mapping(target = "startedByName", source = "startedBy.fullName")
+    @Mapping(target = "startedById", source = "startedBy.id")
+    @Mapping(target = "progressPercent", source = ".", qualifiedByName = "calculateProgress")
+    @Mapping(target = "survivalRate", source = ".", qualifiedByName = "calculateSurvivalRate")
+    ProjectAnalysisDTO toDTO(ProjectAnalysis entity);
+
+    List<ProjectAnalysisDTO> toDTOList(List<ProjectAnalysis> entities);
+
+    @Mapping(target = "prId", source = "pullRequest.id")
+    @Mapping(target = "prNumber", source = "pullRequest.prNumber")
+    @Mapping(target = "prTitle", source = "pullRequest.title")
+    @Mapping(target = "taskId", source = "task.id")
+    @Mapping(target = "taskName", source = "task.name")
+    @Mapping(target = "sprintId", source = "sprint.id")
+    @Mapping(target = "sprintName", source = "sprint.name")
+    @Mapping(target = "authorId", source = "author.id")
+    @Mapping(target = "authorName", source = "author.fullName")
+    @Mapping(target = "survivalRate", source = ".", qualifiedByName = "calculateFileSurvivalRate")
+    ProjectAnalysisDTO.FileDTO toFileDTO(ProjectAnalysisFile file);
+
+    List<ProjectAnalysisDTO.FileDTO> toFileDTOList(List<ProjectAnalysisFile> files);
+
+    @Named("calculateProgress")
+    default Integer calculateProgress(ProjectAnalysis analysis) {
+        if (analysis.getTotalPrs() == null || analysis.getTotalPrs() == 0) {
+            return 0;
+        }
+        int processed = analysis.getProcessedPrs() != null ? analysis.getProcessedPrs() : 0;
+        return (int) ((processed * 100.0) / analysis.getTotalPrs());
+    }
+
+    @Named("calculateSurvivalRate")
+    default Double calculateSurvivalRate(ProjectAnalysis analysis) {
+        int surviving = analysis.getTotalSurvivingLines() != null ? analysis.getTotalSurvivingLines() : 0;
+        int deleted = analysis.getTotalDeletedLines() != null ? analysis.getTotalDeletedLines() : 0;
+        int total = surviving + deleted;
+        if (total == 0) return 100.0;
+        return (surviving * 100.0) / total;
+    }
+
+    @Named("calculateFileSurvivalRate")
+    default Double calculateFileSurvivalRate(ProjectAnalysisFile file) {
+        int surviving = file.getSurvivingLines() != null ? file.getSurvivingLines() : 0;
+        int deleted = file.getDeletedLines() != null ? file.getDeletedLines() : 0;
+        int total = surviving + deleted;
+        if (total == 0) return 100.0;
+        return (surviving * 100.0) / total;
+    }
+}

--- a/src/main/java/org/trackdev/api/repository/ProjectAnalysisFileLineRepository.java
+++ b/src/main/java/org/trackdev/api/repository/ProjectAnalysisFileLineRepository.java
@@ -1,0 +1,33 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.ProjectAnalysisFileLine;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ProjectAnalysisFileLineRepository extends BaseRepositoryUUID<ProjectAnalysisFileLine> {
+
+    /**
+     * Find all lines for a specific file, ordered by display order
+     */
+    List<ProjectAnalysisFileLine> findByFileIdOrderByDisplayOrderAsc(String fileId);
+
+    /**
+     * Find all lines for files in a specific analysis and PR
+     */
+    @Query("SELECT l FROM ProjectAnalysisFileLine l " +
+           "JOIN l.file f " +
+           "WHERE f.analysis.id = :analysisId AND f.pullRequest.id = :prId " +
+           "ORDER BY f.filePath, l.displayOrder")
+    List<ProjectAnalysisFileLine> findByAnalysisIdAndPrId(
+            @Param("analysisId") String analysisId, 
+            @Param("prId") String prId);
+
+    /**
+     * Delete all lines for files in a specific analysis
+     */
+    @Query("DELETE FROM ProjectAnalysisFileLine l WHERE l.file.id IN " +
+           "(SELECT f.id FROM ProjectAnalysisFile f WHERE f.analysis.id = :analysisId)")
+    void deleteByAnalysisId(@Param("analysisId") String analysisId);
+}

--- a/src/main/java/org/trackdev/api/repository/ProjectAnalysisFileRepository.java
+++ b/src/main/java/org/trackdev/api/repository/ProjectAnalysisFileRepository.java
@@ -1,0 +1,70 @@
+package org.trackdev.api.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.trackdev.api.entity.ProjectAnalysisFile;
+
+import java.util.List;
+
+public interface ProjectAnalysisFileRepository extends BaseRepositoryUUID<ProjectAnalysisFile> {
+
+    /**
+     * Find all files for an analysis
+     */
+    List<ProjectAnalysisFile> findByAnalysisId(String analysisId);
+
+    /**
+     * Find files for an analysis filtered by sprint
+     */
+    List<ProjectAnalysisFile> findByAnalysisIdAndSprintId(String analysisId, Long sprintId);
+
+    /**
+     * Find files for an analysis filtered by author
+     */
+    List<ProjectAnalysisFile> findByAnalysisIdAndAuthorId(String analysisId, String authorId);
+
+    /**
+     * Find files for an analysis filtered by sprint and author
+     */
+    List<ProjectAnalysisFile> findByAnalysisIdAndSprintIdAndAuthorId(String analysisId, Long sprintId, String authorId);
+
+    /**
+     * Get summary statistics grouped by author for an analysis
+     */
+    @Query("SELECT f.author.id, f.author.fullName, f.author.username, " +
+           "SUM(f.survivingLines), SUM(f.deletedLines), COUNT(f) " +
+           "FROM ProjectAnalysisFile f " +
+           "WHERE f.analysis.id = :analysisId " +
+           "GROUP BY f.author.id, f.author.fullName, f.author.username")
+    List<Object[]> getSummaryByAuthor(@Param("analysisId") String analysisId);
+
+    /**
+     * Get summary statistics grouped by author for an analysis, filtered by sprint
+     */
+    @Query("SELECT f.author.id, f.author.fullName, f.author.username, " +
+           "SUM(f.survivingLines), SUM(f.deletedLines), COUNT(f) " +
+           "FROM ProjectAnalysisFile f " +
+           "WHERE f.analysis.id = :analysisId AND f.sprint.id = :sprintId " +
+           "GROUP BY f.author.id, f.author.fullName, f.author.username")
+    List<Object[]> getSummaryByAuthorAndSprint(@Param("analysisId") String analysisId, @Param("sprintId") Long sprintId);
+
+    /**
+     * Get summary statistics grouped by sprint for an analysis
+     */
+    @Query("SELECT f.sprint.id, f.sprint.name, " +
+           "SUM(f.survivingLines), SUM(f.deletedLines), COUNT(f) " +
+           "FROM ProjectAnalysisFile f " +
+           "WHERE f.analysis.id = :analysisId " +
+           "GROUP BY f.sprint.id, f.sprint.name")
+    List<Object[]> getSummaryBySprint(@Param("analysisId") String analysisId);
+
+    /**
+     * Delete all files for an analysis (for cleanup/re-run)
+     */
+    void deleteByAnalysisId(String analysisId);
+
+    /**
+     * Find files by analysis and PR
+     */
+    List<ProjectAnalysisFile> findByAnalysisIdAndPullRequestId(String analysisId, String prId);
+}

--- a/src/main/java/org/trackdev/api/repository/ProjectAnalysisRepository.java
+++ b/src/main/java/org/trackdev/api/repository/ProjectAnalysisRepository.java
@@ -1,0 +1,32 @@
+package org.trackdev.api.repository;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.trackdev.api.entity.ProjectAnalysis;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectAnalysisRepository extends BaseRepositoryUUID<ProjectAnalysis> {
+
+    /**
+     * Find all analyses for a project, ordered by most recent first
+     */
+    List<ProjectAnalysis> findByProjectIdOrderByStartedAtDesc(Long projectId);
+
+    /**
+     * Find the most recent analysis for a project
+     */
+    Optional<ProjectAnalysis> findFirstByProjectIdOrderByStartedAtDesc(Long projectId);
+
+    /**
+     * Check if there's an in-progress analysis for a project
+     */
+    @Query("SELECT COUNT(a) > 0 FROM ProjectAnalysis a WHERE a.project.id = :projectId AND a.status = 'IN_PROGRESS'")
+    boolean existsInProgressByProjectId(@Param("projectId") Long projectId);
+
+    /**
+     * Find in-progress analysis for a project
+     */
+    Optional<ProjectAnalysis> findByProjectIdAndStatus(Long projectId, ProjectAnalysis.AnalysisStatus status);
+}

--- a/src/main/java/org/trackdev/api/repository/UserRepository.java
+++ b/src/main/java/org/trackdev/api/repository/UserRepository.java
@@ -47,7 +47,13 @@ public interface UserRepository extends BaseRepositoryUUID<User> {
 
     /**
      * Find user by their GitHub username (login)
+     * Note: This may not work correctly with encrypted fields
      */
     Optional<User> findByGithubInfoLogin(@Param("login") String login);
+
+    /**
+     * Find all users that have GitHub info linked
+     */
+    List<User> findByGithubInfoIsNotNull();
 
 }

--- a/src/main/java/org/trackdev/api/service/ProjectAnalysisService.java
+++ b/src/main/java/org/trackdev/api/service/ProjectAnalysisService.java
@@ -1,0 +1,516 @@
+package org.trackdev.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.dto.PRFileDetailDTO;
+import org.trackdev.api.dto.ProjectAnalysisDTO;
+import org.trackdev.api.entity.*;
+import org.trackdev.api.mapper.ProjectAnalysisMapper;
+import org.trackdev.api.repository.ProjectAnalysisFileLineRepository;
+import org.trackdev.api.repository.ProjectAnalysisFileRepository;
+import org.trackdev.api.repository.ProjectAnalysisRepository;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class ProjectAnalysisService {
+
+    private static final Logger log = LoggerFactory.getLogger(ProjectAnalysisService.class);
+
+    @Autowired
+    private ProjectAnalysisRepository analysisRepository;
+
+    @Autowired
+    private ProjectAnalysisFileRepository fileRepository;
+
+    @Autowired
+    private ProjectAnalysisFileLineRepository lineRepository;
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Autowired
+    private TaskService taskService;
+
+    @Autowired
+    private PullRequestService pullRequestService;
+
+    @Autowired
+    private AccessChecker accessChecker;
+
+    @Autowired
+    private ProjectAnalysisMapper mapper;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    /**
+     * Start a new project analysis. Only professors/admins who can manage the course can do this.
+     */
+    @Transactional
+    public ProjectAnalysisDTO startAnalysis(Long projectId, User currentUser) {
+        // Check permissions - only course managers (professors/admins) can run analysis
+        Project project = projectService.get(projectId);
+        accessChecker.checkCanManageCourse(project.getCourse(), currentUser.getId());
+
+        // Check if there's already an in-progress analysis
+        if (analysisRepository.existsInProgressByProjectId(projectId)) {
+            throw new ServiceException("An analysis is already in progress for this project");
+        }
+
+        // Create new analysis
+        ProjectAnalysis analysis = new ProjectAnalysis(project, currentUser);
+        analysis = analysisRepository.save(analysis);
+
+        // Schedule async processing AFTER transaction commits
+        // This is important because @Async within the same class doesn't work due to Spring proxy limitations
+        final String analysisId = analysis.getId();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                // Get the bean from ApplicationContext to ensure @Async works through the proxy
+                ProjectAnalysisService self = applicationContext.getBean(ProjectAnalysisService.class);
+                self.runAnalysisAsync(analysisId);
+            }
+        });
+
+        return mapper.toDTO(analysis);
+    }
+
+    /**
+     * Get analysis status
+     */
+    public ProjectAnalysisDTO getAnalysisStatus(String analysisId, User currentUser) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+        
+        // Check permissions
+        accessChecker.checkCanViewProject(analysis.getProject(), currentUser.getId());
+        
+        return mapper.toDTO(analysis);
+    }
+
+    /**
+     * Get the latest analysis for a project
+     */
+    public ProjectAnalysisDTO getLatestAnalysis(Long projectId, User currentUser) {
+        Project project = projectService.get(projectId);
+        accessChecker.checkCanViewProject(project, currentUser.getId());
+
+        return analysisRepository.findFirstByProjectIdOrderByStartedAtDesc(projectId)
+                .map(mapper::toDTO)
+                .orElse(null);
+    }
+
+    /**
+     * Get all analyses for a project
+     */
+    public List<ProjectAnalysisDTO> getProjectAnalyses(Long projectId, User currentUser) {
+        Project project = projectService.get(projectId);
+        accessChecker.checkCanViewProject(project, currentUser.getId());
+
+        return mapper.toDTOList(analysisRepository.findByProjectIdOrderByStartedAtDesc(projectId));
+    }
+
+    /**
+     * Get precomputed file details for a specific PR in an analysis.
+     * Returns the same structure as PullRequestService.getFileDetails() but from stored data.
+     */
+    @Transactional(readOnly = true)
+    public List<PRFileDetailDTO> getPrecomputedFileDetails(String analysisId, String prId, User currentUser) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+        
+        accessChecker.checkCanViewProject(analysis.getProject(), currentUser.getId());
+
+        // Get all files for this PR in the analysis
+        List<ProjectAnalysisFile> files = fileRepository.findByAnalysisIdAndPullRequestId(analysisId, prId);
+        
+        if (files.isEmpty()) {
+            throw new ServiceException("No file data found for this PR in the analysis");
+        }
+
+        // Build DTOs with line details
+        // Cache for GitHub username to fullName lookups to avoid repeated database queries
+        Map<String, String> githubUsernameToFullName = new HashMap<>();
+        
+        List<PRFileDetailDTO> result = new ArrayList<>();
+        for (ProjectAnalysisFile file : files) {
+            PRFileDetailDTO dto = new PRFileDetailDTO();
+            dto.setFilePath(file.getFilePath());
+            dto.setStatus(file.getStatus());
+            dto.setAdditions(file.getAdditions());
+            dto.setDeletions(file.getDeletions());
+            dto.setSurvivingLines(file.getSurvivingLines());
+            dto.setDeletedLines(file.getDeletedLines());
+            dto.setCurrentLines(file.getCurrentLines());
+
+            // Get lines for this file
+            List<ProjectAnalysisFileLine> lines = lineRepository.findByFileIdOrderByDisplayOrderAsc(file.getId());
+            List<PRFileDetailDTO.LineDetailDTO> lineDTOs = new ArrayList<>();
+            for (ProjectAnalysisFileLine line : lines) {
+                PRFileDetailDTO.LineDetailDTO lineDTO = new PRFileDetailDTO.LineDetailDTO();
+                lineDTO.setLineNumber(line.getLineNumber());
+                lineDTO.setOriginalLineNumber(line.getOriginalLineNumber());
+                lineDTO.setContent(line.getContent());
+                if (line.getStatus() != null) {
+                    lineDTO.setStatus(PRFileDetailDTO.LineStatus.valueOf(line.getStatus()));
+                }
+                lineDTO.setCommitSha(line.getCommitSha());
+                lineDTO.setCommitUrl(line.getCommitUrl());
+                
+                // Dynamically lookup fullName from GitHub username to get current user data
+                String githubUsername = line.getAuthorGithubUsername();
+                if (githubUsername != null) {
+                    String fullName = githubUsernameToFullName.computeIfAbsent(githubUsername, login -> {
+                        User user = userService.findByGithubUsernameOrUsername(login);
+                        return user != null ? user.getFullName() : null;
+                    });
+                    lineDTO.setAuthorFullName(fullName);
+                } else {
+                    lineDTO.setAuthorFullName(line.getAuthorFullName());
+                }
+                lineDTO.setAuthorGithubUsername(githubUsername);
+                
+                lineDTO.setPrFileUrl(line.getPrFileUrl());
+                lineDTO.setOriginPrNumber(line.getOriginPrNumber());
+                lineDTO.setOriginPrUrl(line.getOriginPrUrl());
+                lineDTOs.add(lineDTO);
+            }
+            dto.setLines(lineDTOs);
+            result.add(dto);
+        }
+
+        return result;
+    }
+
+    /**
+     * Get analysis results with optional filters
+     */
+    @Transactional(readOnly = true)
+    public ProjectAnalysisDTO.ResultsDTO getAnalysisResults(String analysisId, Long sprintId, 
+            String authorId, User currentUser) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+        
+        accessChecker.checkCanViewProject(analysis.getProject(), currentUser.getId());
+
+        if (analysis.getStatus() != ProjectAnalysis.AnalysisStatus.DONE) {
+            throw new ServiceException("Analysis is not complete yet");
+        }
+
+        ProjectAnalysisDTO.ResultsDTO results = new ProjectAnalysisDTO.ResultsDTO();
+        results.setAnalysis(mapper.toDTO(analysis));
+
+        // Get files with filters
+        List<ProjectAnalysisFile> files;
+        if (sprintId != null && authorId != null) {
+            files = fileRepository.findByAnalysisIdAndSprintIdAndAuthorId(analysisId, sprintId, authorId);
+        } else if (sprintId != null) {
+            files = fileRepository.findByAnalysisIdAndSprintId(analysisId, sprintId);
+        } else if (authorId != null) {
+            files = fileRepository.findByAnalysisIdAndAuthorId(analysisId, authorId);
+        } else {
+            files = fileRepository.findByAnalysisId(analysisId);
+        }
+        results.setFiles(mapper.toFileDTOList(files));
+
+        // Get summaries
+        results.setAuthorSummaries(getAuthorSummaries(analysisId, sprintId));
+        results.setSprintSummaries(getSprintSummaries(analysisId));
+
+        return results;
+    }
+
+    /**
+     * Get author summaries for an analysis
+     */
+    private List<ProjectAnalysisDTO.AuthorSummaryDTO> getAuthorSummaries(String analysisId, Long sprintId) {
+        List<Object[]> rawData = sprintId != null 
+                ? fileRepository.getSummaryByAuthorAndSprint(analysisId, sprintId)
+                : fileRepository.getSummaryByAuthor(analysisId);
+
+        return rawData.stream().map(row -> {
+            ProjectAnalysisDTO.AuthorSummaryDTO dto = new ProjectAnalysisDTO.AuthorSummaryDTO();
+            dto.setAuthorId((String) row[0]);
+            dto.setAuthorName((String) row[1]);
+            dto.setAuthorUsername((String) row[2]);
+            dto.setSurvivingLines(((Number) row[3]).intValue());
+            dto.setDeletedLines(((Number) row[4]).intValue());
+            dto.setFileCount(((Number) row[5]).intValue());
+            int total = dto.getSurvivingLines() + dto.getDeletedLines();
+            dto.setSurvivalRate(total > 0 ? (dto.getSurvivingLines() * 100.0 / total) : 100.0);
+            return dto;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Get sprint summaries for an analysis
+     */
+    private List<ProjectAnalysisDTO.SprintSummaryDTO> getSprintSummaries(String analysisId) {
+        List<Object[]> rawData = fileRepository.getSummaryBySprint(analysisId);
+
+        return rawData.stream().map(row -> {
+            ProjectAnalysisDTO.SprintSummaryDTO dto = new ProjectAnalysisDTO.SprintSummaryDTO();
+            dto.setSprintId(row[0] != null ? ((Number) row[0]).longValue() : null);
+            dto.setSprintName((String) row[1]);
+            dto.setSurvivingLines(((Number) row[2]).intValue());
+            dto.setDeletedLines(((Number) row[3]).intValue());
+            dto.setFileCount(((Number) row[4]).intValue());
+            int total = dto.getSurvivingLines() + dto.getDeletedLines();
+            dto.setSurvivalRate(total > 0 ? (dto.getSurvivingLines() * 100.0 / total) : 100.0);
+            return dto;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Run analysis asynchronously
+     */
+    @Async
+    public void runAnalysisAsync(String analysisId) {
+        try {
+            // Get the bean from ApplicationContext to ensure @Transactional works through the proxy
+            ProjectAnalysisService self = applicationContext.getBean(ProjectAnalysisService.class);
+            self.doRunAnalysis(analysisId);
+        } catch (Exception e) {
+            log.error("Error running analysis {}: {}", analysisId, e.getMessage(), e);
+            try {
+                markAnalysisFailed(analysisId, e.getMessage());
+            } catch (Exception ex) {
+                log.error("Error marking analysis as failed: {}", ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Main analysis orchestration - NOT transactional so each step commits separately
+     */
+    public void doRunAnalysis(String analysisId) {
+        ProjectAnalysisService self = applicationContext.getBean(ProjectAnalysisService.class);
+        
+        try {
+            // Phase 1: Collect PRs and set total count (separate transaction)
+            List<PrTaskPair> prsToProcess = self.initializeAnalysis(analysisId);
+            
+            if (prsToProcess.isEmpty()) {
+                log.info("No merged PRs found to analyze");
+                self.completeAnalysis(analysisId, 0, 0, 0);
+                return;
+            }
+
+            int totalFiles = 0;
+            int totalSurviving = 0;
+            int totalDeleted = 0;
+
+            // Phase 2: Process each PR (each in its own transaction)
+            for (PrTaskPair pair : prsToProcess) {
+                try {
+                    ProcessingResult result = self.processPullRequest(analysisId, pair.prId, pair.taskId);
+                    totalFiles += result.fileCount;
+                    totalSurviving += result.survivingLines;
+                    totalDeleted += result.deletedLines;
+                } catch (Exception e) {
+                    log.warn("Error analyzing PR {}: {}", pair.prId, e.getMessage());
+                }
+                // Increment processed count (separate transaction)
+                self.incrementProcessedPrs(analysisId);
+            }
+
+            // Phase 3: Complete the analysis (separate transaction)
+            self.completeAnalysis(analysisId, totalFiles, totalSurviving, totalDeleted);
+
+        } catch (Exception e) {
+            log.error("Analysis failed: {}", e.getMessage(), e);
+            self.markAnalysisFailed(analysisId, e.getMessage());
+        }
+    }
+
+    /**
+     * Helper class to pass PR/Task IDs between transactions
+     */
+    private static class PrTaskPair {
+        final String prId;
+        final Long taskId;
+        PrTaskPair(String prId, Long taskId) {
+            this.prId = prId;
+            this.taskId = taskId;
+        }
+    }
+
+    /**
+     * Helper class for processing results
+     */
+    private static class ProcessingResult {
+        final int fileCount;
+        final int survivingLines;
+        final int deletedLines;
+        ProcessingResult(int fileCount, int survivingLines, int deletedLines) {
+            this.fileCount = fileCount;
+            this.survivingLines = survivingLines;
+            this.deletedLines = deletedLines;
+        }
+    }
+
+    /**
+     * Initialize analysis: collect PRs and set total count
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public List<PrTaskPair> initializeAnalysis(String analysisId) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+
+        Project project = analysis.getProject();
+        log.info("Starting analysis for project: {}", project.getName());
+
+        // Get all DONE tasks in the project
+        List<Task> doneTasks = taskService.findByProjectIdAndStatus(project.getId(), TaskStatus.DONE);
+        log.info("Found {} DONE tasks", doneTasks.size());
+
+        // Collect unique PRs from tasks
+        List<PrTaskPair> prsToProcess = new ArrayList<>();
+        Set<String> seenPrIds = new HashSet<>();
+        
+        for (Task task : doneTasks) {
+            for (PullRequest pr : task.getPullRequests()) {
+                if (pr.getMerged() != null && pr.getMerged() && !seenPrIds.contains(pr.getId())) {
+                    seenPrIds.add(pr.getId());
+                    prsToProcess.add(new PrTaskPair(pr.getId(), task.getId()));
+                }
+            }
+        }
+
+        // Set total PRs count - this commits immediately due to REQUIRES_NEW
+        analysis.setTotalPrs(prsToProcess.size());
+        analysisRepository.save(analysis);
+
+        log.info("Found {} unique merged PRs to analyze", prsToProcess.size());
+        return prsToProcess;
+    }
+
+    /**
+     * Process a single PR and save its file results
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ProcessingResult processPullRequest(String analysisId, String prId, Long taskId) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+
+        PullRequest pr = pullRequestService.get(prId);
+        Task task = taskService.get(taskId);
+        
+        log.info("Analyzing PR #{}: {}", pr.getPrNumber(), pr.getTitle());
+
+        // Get file details using existing PR analysis logic
+        List<PRFileDetailDTO> fileDetails = pullRequestService.getFileDetails(pr.getId());
+
+        Sprint sprint = getTaskSprint(task);
+        User author = pr.getAuthor();
+
+        int fileCount = 0;
+        int survivingLines = 0;
+        int deletedLines = 0;
+
+        // Store file results
+        for (PRFileDetailDTO fileDetail : fileDetails) {
+            ProjectAnalysisFile analysisFile = new ProjectAnalysisFile(analysis, pr, fileDetail.getFilePath());
+            analysisFile.setTask(task);
+            analysisFile.setSprint(sprint);
+            analysisFile.setAuthor(author);
+            analysisFile.setStatus(fileDetail.getStatus());
+            analysisFile.setAdditions(fileDetail.getAdditions());
+            analysisFile.setDeletions(fileDetail.getDeletions());
+            analysisFile.setSurvivingLines(fileDetail.getSurvivingLines());
+            analysisFile.setDeletedLines(fileDetail.getDeletedLines());
+            analysisFile.setCurrentLines(fileDetail.getCurrentLines());
+
+            fileRepository.save(analysisFile);
+
+            // Save line details for precomputed analysis
+            if (fileDetail.getLines() != null) {
+                int displayOrder = 0;
+                for (PRFileDetailDTO.LineDetailDTO line : fileDetail.getLines()) {
+                    ProjectAnalysisFileLine fileLine = new ProjectAnalysisFileLine(analysisFile, displayOrder++);
+                    fileLine.setLineNumber(line.getLineNumber());
+                    fileLine.setOriginalLineNumber(line.getOriginalLineNumber());
+                    fileLine.setContent(line.getContent());
+                    fileLine.setStatus(line.getStatus() != null ? line.getStatus().name() : null);
+                    fileLine.setCommitSha(line.getCommitSha());
+                    fileLine.setCommitUrl(line.getCommitUrl());
+                    fileLine.setAuthorFullName(line.getAuthorFullName());
+                    fileLine.setAuthorGithubUsername(line.getAuthorGithubUsername());
+                    fileLine.setPrFileUrl(line.getPrFileUrl());
+                    fileLine.setOriginPrNumber(line.getOriginPrNumber());
+                    fileLine.setOriginPrUrl(line.getOriginPrUrl());
+                    lineRepository.save(fileLine);
+                }
+            }
+
+            fileCount++;
+            survivingLines += fileDetail.getSurvivingLines() != null ? fileDetail.getSurvivingLines() : 0;
+            deletedLines += fileDetail.getDeletedLines() != null ? fileDetail.getDeletedLines() : 0;
+        }
+
+        return new ProcessingResult(fileCount, survivingLines, deletedLines);
+    }
+
+    /**
+     * Increment processed PRs count
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementProcessedPrs(String analysisId) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+        analysis.incrementProcessedPrs();
+        analysisRepository.save(analysis);
+    }
+
+    /**
+     * Complete the analysis with final totals
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void completeAnalysis(String analysisId, int totalFiles, int totalSurviving, int totalDeleted) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new ServiceException("Analysis not found"));
+        
+        analysis.setTotalFiles(totalFiles);
+        analysis.setTotalSurvivingLines(totalSurviving);
+        analysis.setTotalDeletedLines(totalDeleted);
+        analysis.complete();
+        analysisRepository.save(analysis);
+
+        log.info("Analysis complete: {} files, {} surviving lines, {} deleted lines",
+                totalFiles, totalSurviving, totalDeleted);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAnalysisFailed(String analysisId, String errorMessage) {
+        ProjectAnalysis analysis = analysisRepository.findById(analysisId).orElse(null);
+        if (analysis != null) {
+            analysis.fail(errorMessage);
+            analysisRepository.save(analysis);
+        }
+    }
+
+    /**
+     * Get the sprint for a task (first sprint if multiple)
+     */
+    private Sprint getTaskSprint(Task task) {
+        if (task == null) return null;
+        Collection<Sprint> sprints = task.getActiveSprints();
+        if (sprints == null || sprints.isEmpty()) return null;
+        return sprints.iterator().next();
+    }
+}

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -1032,6 +1032,13 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
     }
 
     /**
+     * Find all tasks in a project with a specific status.
+     */
+    public List<Task> findByProjectIdAndStatus(Long projectId, TaskStatus status) {
+        return this.repo.findByProjectIdAndStatus(projectId, status);
+    }
+
+    /**
      * Link a pull request to a task.
      * This method is transactional to ensure the task's lazy collections are accessible.
      */


### PR DESCRIPTION
## Summary
Implements a comprehensive code survival analysis system that tracks which lines of code from merged pull requests survive over time in a project. This feature allows professors and admins to analyze code quality and contribution longevity at the project, file, and line level.

## Key Features Added

### Core Analysis Infrastructure
- **ProjectAnalysis entity**: Tracks asynchronous analysis runs with progress monitoring (IN_PROGRESS, DONE, FAILED states)
- **ProjectAnalysisFile entity**: Stores file-level metrics including surviving/deleted line counts per file
- **ProjectAnalysisFileLine entity**: Captures line-level details with status (SURVIVING, CURRENT, DELETED), author attribution, and origin PR tracking

### REST API Endpoints
- `POST /project-analyses/projects/{projectId}/start` - Initiate analysis for all DONE tasks' PRs in a project
- `GET /project-analyses/{analysisId}` - Retrieve analysis status and results
- `GET /project-analyses/{analysisId}/files` - Get file-level breakdown with filtering by sprint/author
- `GET /pull-requests/{prId}/details` - Get detailed PR analysis with file-level survival metrics

### Service Layer
- **ProjectAnalysisService**: Orchestrates asynchronous analysis of merged PRs, computing survival rates by comparing original PR changes with current repository state
- **PullRequestService enhancements**: Added `getFileDetails()` method (608 lines) to perform deep Git blame analysis using GitHub API, tracking line-by-line survival with author attribution and origin PR linking

### Supporting Changes
- Added authorization checks for viewing pull requests based on project access
- Fixed GitHub login search to work with encrypted fields by filtering in-memory
- Enhanced demo data seeder to link multiple PRs to different DONE tasks for testing
- Added repository methods for querying users with GitHub accounts and tasks by project/status

## Technical Details
- Uses MapStruct for entity-to-DTO transformation
- Asynchronous processing for long-running analysis operations
- Leverages GitHub API for git blame and PR file diff data
- Calculates survival rates as: `survivingLines / (survivingLines + deletedLines) * 100`

## Authorization
- Only professors/admins who can manage a course can start project analyses
- Users can only view PR details if they have access to the linked project

## Breaking Changes
None. This is a new feature with no modifications to existing endpoints.

## Testing Notes
- Demo data now includes 4 hardcoded PRs (#8, #22, #26, #35) linked to DONE tasks for testing
- Requires GitHub access tokens configured for repositories being analyzed
- Analysis only works for merged PRs with valid repository and PR number data