### PR TITLE
fix: implement task cascade deletion and enforce service layer pattern

### DIFF
--- a/src/main/java/org/trackdev/api/repository/ActivityRepository.java
+++ b/src/main/java/org/trackdev/api/repository/ActivityRepository.java
@@ -9,6 +9,7 @@ import org.trackdev.api.entity.Activity;
 import org.trackdev.api.entity.Project;
 import org.trackdev.api.entity.Sprint;
 import org.trackdev.api.entity.User;
+import org.trackdev.api.entity.Task;
 
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -66,4 +67,9 @@ public interface ActivityRepository extends BaseRepositoryLong<Activity> {
      * Delete all activities for a specific project
      */
     void deleteByProject(Project project);
+
+    /**
+     * Delete all activities for a specific task
+     */
+    void deleteByTask(Task task);
 }

--- a/src/main/java/org/trackdev/api/repository/CommentRepository.java
+++ b/src/main/java/org/trackdev/api/repository/CommentRepository.java
@@ -2,10 +2,12 @@ package org.trackdev.api.repository;
 
 import org.springframework.stereotype.Component;
 import org.trackdev.api.entity.Comment;
+import org.trackdev.api.entity.Task;
 
 import java.util.List;
 
 @Component
 public interface CommentRepository extends BaseRepositoryLong<Comment>{
     List<Comment> findByTaskId(Long taskId);
+    void deleteByTask(Task task);
 }

--- a/src/main/java/org/trackdev/api/repository/ProjectAnalysisFileRepository.java
+++ b/src/main/java/org/trackdev/api/repository/ProjectAnalysisFileRepository.java
@@ -67,4 +67,9 @@ public interface ProjectAnalysisFileRepository extends BaseRepositoryUUID<Projec
      * Find files by analysis and PR
      */
     List<ProjectAnalysisFile> findByAnalysisIdAndPullRequestId(String analysisId, String prId);
+
+    /**
+     * Delete all files associated with a specific task
+     */
+    void deleteByTask(org.trackdev.api.entity.Task task);
 }

--- a/src/main/java/org/trackdev/api/repository/TaskChangeRepository.java
+++ b/src/main/java/org/trackdev/api/repository/TaskChangeRepository.java
@@ -1,8 +1,10 @@
 package org.trackdev.api.repository;
 
 import org.springframework.stereotype.Repository;
+import org.trackdev.api.entity.Task;
 import org.trackdev.api.entity.taskchanges.TaskChange;
 
 @Repository
 public interface TaskChangeRepository extends BaseRepositoryLong<TaskChange> {
+    void deleteByTask(Task task);
 }

--- a/src/main/java/org/trackdev/api/service/ActivityService.java
+++ b/src/main/java/org/trackdev/api/service/ActivityService.java
@@ -199,4 +199,12 @@ public class ActivityService extends BaseServiceLong<Activity, ActivityRepositor
     public void deleteActivitiesForProject(Project project) {
         repo().deleteByProject(project);
     }
+
+    /**
+     * Delete all activities for a specific task (used when task is deleted).
+     */
+    @Transactional
+    public void deleteByTask(Task task) {
+        repo().deleteByTask(task);
+    }
 }

--- a/src/main/java/org/trackdev/api/service/CommentService.java
+++ b/src/main/java/org/trackdev/api/service/CommentService.java
@@ -109,6 +109,14 @@ public class CommentService extends BaseServiceLong<Comment, CommentRepository>{
     }
 
     /**
+     * Delete all comments for a specific task (used when task is deleted).
+     */
+    @Transactional
+    public void deleteByTask(Task task) {
+        repo().deleteByTask(task);
+    }
+
+    /**
      * Check if user can delete a comment.
      * - Students CANNOT delete any comment
      * - Course owner (professor) can delete any comment in their project

--- a/src/main/java/org/trackdev/api/service/DiscordService.java
+++ b/src/main/java/org/trackdev/api/service/DiscordService.java
@@ -18,7 +18,6 @@ import org.trackdev.api.controller.exceptions.ServiceException;
 import org.trackdev.api.entity.DiscordInfo;
 import org.trackdev.api.entity.User;
 import org.trackdev.api.repository.DiscordInfoRepository;
-import org.trackdev.api.repository.UserRepository;
 import org.trackdev.api.utils.ErrorConstants;
 
 import java.net.URLEncoder;
@@ -42,7 +41,7 @@ public class DiscordService extends BaseServiceUUID<DiscordInfo, DiscordInfoRepo
     private TrackDevProperties properties;
 
     @Autowired
-    private UserRepository userRepository;
+    private UserService userService;
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
@@ -281,7 +280,7 @@ public class DiscordService extends BaseServiceUUID<DiscordInfo, DiscordInfoRepo
         userDiscordInfo.setAccessToken(accessToken);
         userDiscordInfo.setRefreshToken(refreshToken);
 
-        userRepository.save(user);
+        userService.save(user);
         log.info("Linked Discord account {} to user {}", username, user.getUsername());
     }
 
@@ -307,7 +306,7 @@ public class DiscordService extends BaseServiceUUID<DiscordInfo, DiscordInfoRepo
         }
 
         discordInfo.clear();
-        userRepository.save(user);
+        userService.save(user);
         log.info("Unlinked Discord account from user {}", user.getUsername());
     }
 

--- a/src/main/java/org/trackdev/api/service/GitHubRepoService.java
+++ b/src/main/java/org/trackdev/api/service/GitHubRepoService.java
@@ -394,6 +394,13 @@ public class GitHubRepoService extends BaseServiceLong<GitHubRepo, GitHubRepoRep
         return fetchBranches(gitHubRepo);
     }
 
+    /**
+     * Find a GitHub repository by its URL.
+     */
+    public Optional<GitHubRepo> findByUrl(String url) {
+        return repo.findByUrl(url);
+    }
+
     // ========== PRIVATE HELPER METHODS ==========
 
     private HttpHeaders createAuthHeaders(String token) {

--- a/src/main/java/org/trackdev/api/service/ProfileService.java
+++ b/src/main/java/org/trackdev/api/service/ProfileService.java
@@ -48,6 +48,14 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
         return repo.findByOwnerId(userId);
     }
 
+    /**
+     * Get a profile attribute by its ID.
+     */
+    public ProfileAttribute getAttributeById(Long attributeId) {
+        return attributeRepository.findById(attributeId)
+                .orElseThrow(() -> new EntityNotFound("Attribute not found"));
+    }
+
     @Transactional
     public Profile createProfile(ProfileRequest request, String userId) {
         User owner = userService.get(userId);

--- a/src/main/java/org/trackdev/api/service/ProjectAnalysisService.java
+++ b/src/main/java/org/trackdev/api/service/ProjectAnalysisService.java
@@ -505,6 +505,14 @@ public class ProjectAnalysisService {
     }
 
     /**
+     * Delete all analysis files for a specific task (used when task is deleted).
+     */
+    @Transactional
+    public void deleteFilesByTask(Task task) {
+        fileRepository.deleteByTask(task);
+    }
+
+    /**
      * Get the sprint for a task (first sprint if multiple)
      */
     private Sprint getTaskSprint(Task task) {

--- a/src/main/java/org/trackdev/api/service/ProjectService.java
+++ b/src/main/java/org/trackdev/api/service/ProjectService.java
@@ -1,6 +1,7 @@
 package org.trackdev.api.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.trackdev.api.controller.exceptions.ServiceException;
@@ -32,7 +33,8 @@ public class ProjectService extends BaseServiceLong<Project, GroupRepository> {
     AccessChecker accessChecker;
 
     @Autowired
-    org.trackdev.api.repository.TaskRepository taskRepository;
+    @Lazy
+    TaskService taskService;
 
     @Transactional
     public Project createProject(String name, Collection<String> memberIds, Long courseId,
@@ -166,7 +168,7 @@ public class ProjectService extends BaseServiceLong<Project, GroupRepository> {
         accessChecker.checkCanManageCourse(project.getCourse(), userId);
         
         // Check if project has any tasks
-        if (taskRepository.existsByProjectId(projectId)) {
+        if (taskService.existsByProjectId(projectId)) {
             throw new ServiceException(ErrorConstants.PROJECT_HAS_TASKS);
         }
         
@@ -433,7 +435,7 @@ public class ProjectService extends BaseServiceLong<Project, GroupRepository> {
         Project project = get(projectId);
         accessChecker.checkCanViewProject(project, userId);
         
-        return taskRepository.findByProjectIdAndStatus(projectId, TaskStatus.DONE).stream()
+        return taskService.findByProjectIdAndStatus(projectId, TaskStatus.DONE).stream()
                 .filter(task -> task.getPullRequests() != null && !task.getPullRequests().isEmpty())
                 .filter(task -> {
                     // If no sprint filter, include all tasks

--- a/src/main/java/org/trackdev/api/service/PullRequestChangeService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestChangeService.java
@@ -1,0 +1,20 @@
+package org.trackdev.api.service;
+
+import org.springframework.stereotype.Service;
+import org.trackdev.api.entity.PullRequest;
+import org.trackdev.api.entity.prchanges.PullRequestChange;
+import org.trackdev.api.repository.PullRequestChangeRepository;
+
+import java.util.List;
+
+@Service
+public class PullRequestChangeService extends BaseServiceLong<PullRequestChange, PullRequestChangeRepository> {
+
+    public List<PullRequestChange> findByPullRequestOrderByChangedAtDesc(PullRequest pullRequest) {
+        return repo().findByPullRequestOrderByChangedAtDesc(pullRequest);
+    }
+
+    public List<PullRequestChange> findByPullRequestInOrderByChangedAtDesc(List<PullRequest> pullRequests) {
+        return repo().findByPullRequestInOrderByChangedAtDesc(pullRequests);
+    }
+}

--- a/src/main/java/org/trackdev/api/service/SprintPatternService.java
+++ b/src/main/java/org/trackdev/api/service/SprintPatternService.java
@@ -10,7 +10,6 @@ import org.trackdev.api.entity.SprintPattern;
 import org.trackdev.api.entity.SprintPatternItem;
 import org.trackdev.api.model.SprintPatternRequest;
 import org.trackdev.api.repository.SprintPatternRepository;
-import org.trackdev.api.repository.SprintRepository;
 import org.trackdev.api.utils.ErrorConstants;
 
 import java.util.HashSet;
@@ -30,7 +29,7 @@ public class SprintPatternService extends BaseServiceLong<SprintPattern, SprintP
     AccessChecker accessChecker;
 
     @Autowired
-    SprintRepository sprintRepository;
+    SprintService sprintService;
 
     /**
      * Get all sprint patterns for a course
@@ -143,12 +142,12 @@ public class SprintPatternService extends BaseServiceLong<SprintPattern, SprintP
      * Propagate changes from a SprintPatternItem to all associated Sprints.
      */
     private void propagateChangesToSprints(SprintPatternItem item) {
-        List<Sprint> associatedSprints = sprintRepository.findByPatternItemId(item.getId());
+        List<Sprint> associatedSprints = sprintService.findByPatternItemId(item.getId());
         for (Sprint sprint : associatedSprints) {
             sprint.setName(item.getName());
             sprint.setStartDate(item.getStartDate());
             sprint.setEndDate(item.getEndDate());
-            sprintRepository.save(sprint);
+            sprintService.save(sprint);
         }
     }
 

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -165,6 +165,13 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
     }
 
     /**
+     * Find all sprints created from a specific sprint pattern item.
+     */
+    public List<Sprint> findByPatternItemId(Long patternItemId) {
+        return repo.findByPatternItemId(patternItemId);
+    }
+
+    /**
      * Find the currently active sprint for a project.
      * Active sprint = startDate <= now < endDate
      */

--- a/src/main/java/org/trackdev/api/service/TaskAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/TaskAttributeValueService.java
@@ -1,0 +1,31 @@
+package org.trackdev.api.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.entity.TaskAttributeValue;
+import org.trackdev.api.repository.TaskAttributeValueRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TaskAttributeValueService extends BaseServiceLong<TaskAttributeValue, TaskAttributeValueRepository> {
+
+    public List<TaskAttributeValue> findByTaskId(Long taskId) {
+        return repo().findByTaskId(taskId);
+    }
+
+    public Optional<TaskAttributeValue> findByTaskIdAndAttributeId(Long taskId, Long attributeId) {
+        return repo().findByTaskIdAndAttributeId(taskId, attributeId);
+    }
+
+    @Transactional
+    public void deleteByTaskId(Long taskId) {
+        repo().deleteByTaskId(taskId);
+    }
+
+    @Transactional
+    public void deleteByTaskIdAndAttributeId(Long taskId, Long attributeId) {
+        repo().deleteByTaskIdAndAttributeId(taskId, attributeId);
+    }
+}

--- a/src/main/java/org/trackdev/api/service/TaskChangeService.java
+++ b/src/main/java/org/trackdev/api/service/TaskChangeService.java
@@ -1,6 +1,8 @@
 package org.trackdev.api.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.entity.Task;
 import org.trackdev.api.entity.taskchanges.TaskChange;
 import org.trackdev.api.repository.TaskChangeRepository;
 
@@ -9,5 +11,13 @@ public class TaskChangeService extends BaseServiceLong<TaskChange, TaskChangeRep
 
     public void store(TaskChange taskChange) {
         repo().save(taskChange);
+    }
+
+    /**
+     * Delete all task change records for a specific task (used when task is deleted).
+     */
+    @Transactional
+    public void deleteByTask(Task task) {
+        repo().deleteByTask(task);
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses two critical architectural improvements:

1. **Task cascade deletion**: Implements proper cleanup of all related entities when a task is deleted, preventing foreign key constraint violations
2. **Service layer consistency**: Refactors multiple services to call other services instead of repositories directly, maintaining the established 4-tier architecture pattern

## Changes Made

### Task Deletion Fix
- Added `deleteByTask` methods to repositories: `TaskChangeRepository`, `ActivityRepository`, `CommentRepository`, `ProjectAnalysisFileRepository`
- Implemented corresponding service methods in: `TaskChangeService`, `ActivityService`, `CommentService`, `ProjectAnalysisService`
- Updated `TaskService.deleteTask()` to properly cascade delete all related entities before removing the task

### Service Layer Refactoring
Replaced direct repository access with service layer calls in:
- `DiscordService`: `UserRepository` → `UserService`
- `ProjectService`: `TaskRepository` → `TaskService` (with `@Lazy` injection to avoid circular dependency)
- `PullRequestService`: `TaskRepository`, `GitHubRepoRepository`, `PullRequestChangeRepository` → respective services
- `SprintPatternService`: `SprintRepository` → `SprintService`
- `ReportService`: `CourseRepository`, `GroupRepository`, `ProfileAttributeRepository`, `TaskAttributeValueRepository` → respective services

### New Service Classes
- Created `PullRequestChangeService` to encapsulate pull request change operations
- Created `TaskAttributeValueService` to encapsulate task attribute value operations

### Helper Methods
- `SprintService.findByPatternItemId()` - query sprints by pattern item
- `GitHubRepoService.findByUrl()` - find GitHub repository by URL
- `ProfileService.getAttributeById()` - retrieve profile attributes by ID

## Why These Changes Were Made
1. **Data Integrity**: Tasks with related entities (comments, activities, changes, etc.) could not be deleted due to foreign key constraints
2. **Architecture Compliance**: Services were bypassing the service layer by calling repositories directly, violating the established architectural pattern documented in CLAUDE.md
3. **Maintainability**: Centralizing business logic in the service layer makes the codebase more maintainable and easier to test

## Breaking Changes
None - these are internal refactorings that maintain the same API contracts

## Testing Notes
- Verify task deletion works correctly with all related entities (comments, activities, task changes, analysis files)
- Ensure existing functionality in affected services remains unchanged
- Test circular dependency resolution with `@Lazy` annotation in ProjectService

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>