### PR TITLE
Fix task status transition for future sprints

### DIFF
--- a/src/main/java/org/trackdev/api/entity/Sprint.java
+++ b/src/main/java/org/trackdev/api/entity/Sprint.java
@@ -176,8 +176,10 @@ public class Sprint extends BaseEntityLong {
 
     public void addTask(Task task, User modifier) {
         this.activeTasks.add(task);
-        // When adding task to an active sprint, change from BACKLOG to TODO
-        if(this.getEffectiveStatus() == SprintStatus.ACTIVE && task.getStatus() == TaskStatus.BACKLOG) {
+        // When adding task to a sprint (active or future), change from BACKLOG to TODO
+        SprintStatus effectiveStatus = this.getEffectiveStatus();
+        if((effectiveStatus == SprintStatus.ACTIVE || effectiveStatus == SprintStatus.DRAFT)
+                && task.getStatus() == TaskStatus.BACKLOG) {
             task.setStatus(TaskStatus.TODO);
         }
     }


### PR DESCRIPTION
## Summary
Fixed `Sprint.addTask()` to transition tasks from BACKLOG to TODO status when adding them to DRAFT (future) sprints, not just ACTIVE sprints.

## Changes
- Modified the status check in `Sprint.addTask()` to include both `ACTIVE` and `DRAFT` sprint statuses
- Tasks moved from backlog to a future sprint now correctly change to TODO status

## Motivation
According to domain rules, tasks assigned to future sprints should be in TODO state (not BACKLOG). Previously, the status transition only occurred for active sprints, leaving tasks in BACKLOG status when added to future sprints, which violated the expected behavior.

## Testing
Verify that:
- Tasks moved to DRAFT sprints transition from BACKLOG to TODO
- Tasks moved to ACTIVE sprints continue to transition from BACKLOG to TODO
- Tasks in other statuses remain unchanged when added to sprints