### PR TITLE
feat(task): implement status transition validation and USER_STORY sync

### DIFF
--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -56,6 +56,7 @@ public final class ErrorConstants {
     public static final String TASK_IS_FROZEN = "error.task.frozen";
     public static final String ONLY_PROFESSOR_CAN_FREEZE_TASK = "error.task.freeze.professor.only";
     public static final String TASK_STATUS_CHANGE_IN_FUTURE_SPRINT = "error.task.status.future.sprint";
+    public static final String INVALID_STATUS_TRANSITION = "error.task.invalid.status.transition";
     public static final String BUG_CANNOT_CHANGE_TYPE = "error.task.bug.cannot.change.type";
     public static final String USER_STORY_CANNOT_CHANGE_TYPE = "error.task.user.story.cannot.change.type";
     public static final String USER_STORY_HAS_SUBTASKS_CANNOT_DELETE = "error.task.user.story.has.subtasks.delete";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -92,6 +92,7 @@ error.task.subtask.type.invalid=A subtask can only be of type TASK or BUG
 error.task.frozen=This task is frozen and cannot be modified
 error.task.freeze.professor.only=Only professors can freeze or unfreeze tasks
 error.task.status.future.sprint=Task status cannot be changed from TODO while in a sprint that has not started yet
+error.task.invalid.status.transition=Invalid status transition
 error.task.bug.cannot.change.type=A BUG task cannot change its type
 error.task.user.story.cannot.change.type=A USER_STORY cannot change its type
 error.task.user.story.has.subtasks.delete=A USER_STORY cannot be deleted while it has subtasks

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -92,6 +92,7 @@ error.task.subtask.type.invalid=Una subtasca només pot ser de tipus TASK o BUG
 error.task.frozen=Aquesta tasca està congelada i no es pot modificar
 error.task.freeze.professor.only=Només els professors poden congelar o descongelar tasques
 error.task.status.future.sprint=L'estat de la tasca no es pot canviar des de TODO mentre estigui en un sprint que encara no ha començat
+error.task.invalid.status.transition=Transició d'estat no vàlida
 error.task.bug.cannot.change.type=Una tasca de tipus BUG no pot canviar el seu tipus
 error.task.user.story.cannot.change.type=Una USER_STORY no pot canviar el seu tipus
 error.task.user.story.has.subtasks.delete=Una USER_STORY no es pot eliminar mentre tingui subtasques

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -92,6 +92,7 @@ error.task.subtask.type.invalid=Una subtarea solo puede ser de tipo TASK o BUG
 error.task.frozen=Esta tarea está congelada y no se puede modificar
 error.task.freeze.professor.only=Solo los profesores pueden congelar o descongelar tareas
 error.task.status.future.sprint=El estado de la tarea no se puede cambiar desde TODO mientras esté en un sprint que aún no ha comenzado
+error.task.invalid.status.transition=Transición de estado no válida
 error.task.bug.cannot.change.type=Una tarea de tipo BUG no puede cambiar su tipo
 error.task.user.story.cannot.change.type=Una USER_STORY no puede cambiar su tipo
 error.task.user.story.has.subtasks.delete=Una USER_STORY no se puede eliminar mientras tenga subtareas


### PR DESCRIPTION
## Summary
This PR implements strict status transition validation for tasks based on their type and adds automatic USER_STORY status synchronization with subtasks.

## Changes Made

### Status Transition Validation
- **TASK/BUG workflow**: `BACKLOG → TODO → INPROGRESS → VERIFY → DONE`
  - Tasks can move backward from INPROGRESS to TODO
  - Other backward transitions are blocked
- **USER_STORY workflow**: `BACKLOG → TODO → DONE`
  - DONE status is automatically set when all subtasks complete
  - Automatically reverts to TODO when subtasks change

### USER_STORY Synchronization
- When a subtask is added to a DONE USER_STORY, the parent reverts to TODO
- When a subtask moves away from DONE, the parent USER_STORY reverts from DONE to TODO
- When all subtasks reach DONE, the parent USER_STORY automatically transitions to DONE

### Implementation Details
- Added `checkCanMoveToStatus()` validation in `Task` entity with type-specific rules
- Added `forceSetStatus()` method for internal operations that bypass validation (data seeders, system operations)
- New error constant: `INVALID_STATUS_TRANSITION`
- Full i18n support (English, Spanish, Catalan)

## Breaking Changes
None. This adds validation that enforces existing business rules documented in the domain model.

## Testing Notes
- Test status transitions for TASK and BUG types follow the defined workflow
- Test USER_STORY cannot be manually set to DONE
- Test adding subtasks to DONE USER_STORY reverts parent to TODO
- Test all subtasks DONE automatically transitions USER_STORY to DONE