### PR TITLE
feat(discord): add interactions endpoint with Ed25519 verification

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
@@ -50,6 +50,7 @@ public class SecurityConfiguration {
                 .requestMatchers(HttpMethod.GET, "/auth/reset-password/validate").permitAll()
                 .requestMatchers(HttpMethod.GET, "/invites/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/discord/callback").permitAll()
+                .requestMatchers(HttpMethod.POST, "/discord/interactions").permitAll()
                 .requestMatchers(HttpMethod.POST, "/invites/*/accept").permitAll()
                 .requestMatchers("/hooks/**").permitAll()  // GitHub webhooks (unauthenticated, validated via signature)
                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()

--- a/src/main/java/org/trackdev/api/configuration/TrackDevProperties.java
+++ b/src/main/java/org/trackdev/api/configuration/TrackDevProperties.java
@@ -156,6 +156,7 @@ public class TrackDevProperties {
         private String guildId;
         private String verifiedRoleId;
         private String redirectUri;
+        private String publicKey;
 
         public String getClientId() {
             return clientId;
@@ -203,6 +204,14 @@ public class TrackDevProperties {
 
         public void setRedirectUri(String redirectUri) {
             this.redirectUri = redirectUri;
+        }
+
+        public String getPublicKey() {
+            return publicKey;
+        }
+
+        public void setPublicKey(String publicKey) {
+            this.publicKey = publicKey;
         }
 
         @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,7 @@ trackdev:
     guild-id: ${DISCORD_GUILD_ID:}
     verified-role-id: ${DISCORD_VERIFIED_ROLE_ID:}
     redirect-uri: ${DISCORD_REDIRECT_URI:http://localhost:8080/api/discord/callback}
+    public-key: ${DISCORD_PUBLIC_KEY:}
 
 ---
 # Profile: mysqldb


### PR DESCRIPTION
## Summary
Implements Discord Interactions Endpoint URL support to handle Discord bot callbacks (slash commands, buttons, modals, etc.) with cryptographic signature verification.

## Changes Made
- **New endpoint**: `POST /discord/interactions` in `DiscordController`
  - Verifies Ed25519 signatures using Discord's public key on every request
  - Responds to PING interactions (type 1) with PONG for Discord verification
  - Handles other interaction types with appropriate responses
- **Configuration**: Added `discord.public-key` property to `TrackDevProperties`
  - Mapped to `DISCORD_PUBLIC_KEY` environment variable in `application.yml`
- **Security**: Configured endpoint as publicly accessible in `SecurityConfiguration`
  - Security is enforced via Ed25519 signature verification, not JWT

## Technical Details
The endpoint implements Discord's security requirements by verifying the `X-Signature-Ed25519` header against the request body using the bot's public key. This ensures all requests originate from Discord's servers.

## Configuration Required
Add the following environment variable:
```
DISCORD_PUBLIC_KEY=<your_discord_bot_public_key>
```

## Testing
- Verify endpoint responds to Discord PING with type 1 (PONG) response
- Confirm signature verification rejects requests with invalid signatures
- Test interaction handling for registered Discord commands