### PR TITLE
feat: add attribute visibility controls and LIST attribute type

### DIFF
--- a/src/main/java/org/trackdev/api/controller/PullRequestController.java
+++ b/src/main/java/org/trackdev/api/controller/PullRequestController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.trackdev.api.dto.PRDetailedAnalysisDTO;
 import org.trackdev.api.dto.PRFileDetailDTO;
@@ -124,9 +125,10 @@ public class PullRequestController extends BaseController {
         return profileMapper.attributesToDTO(attributes);
     }
 
-    @Operation(summary = "Set attribute value for a pull request", description = "Set or update an attribute value for a pull request. Authorization depends on the attribute's appliedBy field.",
+    @Operation(summary = "Set attribute value for a pull request", description = "Set or update an attribute value for a pull request (professors only).",
             security = {@SecurityRequirement(name = "bearerAuth")})
     @PutMapping("/{prId}/attributes/{attributeId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PROFESSOR')")
     public PullRequestAttributeValueDTO setPullRequestAttributeValue(
             @PathVariable(name = "prId") String prId,
             @PathVariable(name = "attributeId") Long attributeId,
@@ -137,9 +139,10 @@ public class PullRequestController extends BaseController {
         return pullRequestAttributeValueMapper.toDTO(value);
     }
 
-    @Operation(summary = "Delete attribute value from a pull request", description = "Remove an attribute value from a pull request. Authorization depends on the attribute's appliedBy field.",
+    @Operation(summary = "Delete attribute value from a pull request", description = "Remove an attribute value from a pull request (professors only).",
             security = {@SecurityRequirement(name = "bearerAuth")})
     @DeleteMapping("/{prId}/attributes/{attributeId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PROFESSOR')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deletePullRequestAttributeValue(
             @PathVariable(name = "prId") String prId,

--- a/src/main/java/org/trackdev/api/dto/ListItemDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ListItemDTO.java
@@ -1,0 +1,13 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+/**
+ * DTO for an individual list item in a LIST-type attribute.
+ */
+@Data
+public class ListItemDTO {
+    private int orderIndex;
+    private String enumValue;
+    private String stringValue;
+}

--- a/src/main/java/org/trackdev/api/dto/ProfileAttributeDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ProfileAttributeDTO.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.trackdev.api.entity.AttributeAppliedBy;
 import org.trackdev.api.entity.AttributeTarget;
 import org.trackdev.api.entity.AttributeType;
+import org.trackdev.api.entity.AttributeVisibility;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ public class ProfileAttributeDTO {
     private AttributeType type;
     private AttributeTarget target;
     private AttributeAppliedBy appliedBy;
+    private AttributeVisibility visibility;
     private Long enumRefId;
     private String enumRefName;
     private List<EnumValueEntryDTO> enumValues;

--- a/src/main/java/org/trackdev/api/dto/StudentAttributeListValueDTO.java
+++ b/src/main/java/org/trackdev/api/dto/StudentAttributeListValueDTO.java
@@ -1,0 +1,18 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * DTO for a LIST-type attribute value applied to a student.
+ * Contains the attribute metadata and all list items.
+ */
+@Data
+public class StudentAttributeListValueDTO {
+    private Long attributeId;
+    private String attributeName;
+    private String attributeType;
+    private List<ListItemDTO> items;
+    private EnumValueEntryDTO[] enumValues;
+}

--- a/src/main/java/org/trackdev/api/entity/AttributeType.java
+++ b/src/main/java/org/trackdev/api/entity/AttributeType.java
@@ -7,5 +7,6 @@ public enum AttributeType {
     STRING,
     ENUM,
     INTEGER,
-    FLOAT
+    FLOAT,
+    LIST
 }

--- a/src/main/java/org/trackdev/api/entity/AttributeVisibility.java
+++ b/src/main/java/org/trackdev/api/entity/AttributeVisibility.java
@@ -1,0 +1,13 @@
+package org.trackdev.api.entity;
+
+/**
+ * Defines who can view/read values of a profile attribute.
+ */
+public enum AttributeVisibility {
+    /** Only professors and admins can see */
+    PROFESSOR_ONLY,
+    /** All students in the same project can see */
+    PROJECT_STUDENTS,
+    /** Only the student with edit access can see (e.g. task assignee) */
+    ASSIGNED_STUDENT
+}

--- a/src/main/java/org/trackdev/api/entity/ProfileAttribute.java
+++ b/src/main/java/org/trackdev/api/entity/ProfileAttribute.java
@@ -35,6 +35,11 @@ public class ProfileAttribute extends BaseEntityLong {
     private AttributeAppliedBy appliedBy = AttributeAppliedBy.PROFESSOR;
 
     @NonNull
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private AttributeVisibility visibility = AttributeVisibility.PROFESSOR_ONLY;
+
+    @NonNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_id")
     private Profile profile;
@@ -111,6 +116,14 @@ public class ProfileAttribute extends BaseEntityLong {
 
     public void setAppliedBy(AttributeAppliedBy appliedBy) {
         this.appliedBy = appliedBy;
+    }
+
+    public AttributeVisibility getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(AttributeVisibility visibility) {
+        this.visibility = visibility;
     }
 
     public Profile getProfile() {

--- a/src/main/java/org/trackdev/api/entity/StudentAttributeListValue.java
+++ b/src/main/java/org/trackdev/api/entity/StudentAttributeListValue.java
@@ -1,0 +1,105 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import org.springframework.lang.NonNull;
+
+/**
+ * Stores an individual list item for a LIST-type profile attribute applied to a student.
+ * Each row represents one item in the ordered list.
+ */
+@Entity
+@Table(name = "student_attribute_list_values", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "attribute_id", "order_index"})
+})
+public class StudentAttributeListValue extends BaseEntityLong {
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "user_id", insertable = false, updatable = false, length = BaseEntityUUID.UUID_LENGTH)
+    private String userId;
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attribute_id")
+    private ProfileAttribute attribute;
+
+    @Column(name = "attribute_id", insertable = false, updatable = false)
+    private Long attributeId;
+
+    @Column(name = "order_index", nullable = false)
+    private int orderIndex;
+
+    /**
+     * Enum value selected from the referenced ProfileEnum.
+     * NULL for STRING-only lists (when the attribute has no enumRef).
+     */
+    @Column(name = "enum_value", length = 100)
+    private String enumValue;
+
+    /**
+     * The string value for this list item.
+     */
+    @Column(name = "string_value", length = 500)
+    private String stringValue;
+
+    public StudentAttributeListValue() {}
+
+    public StudentAttributeListValue(User user, ProfileAttribute attribute, int orderIndex, String enumValue, String stringValue) {
+        this.user = user;
+        this.attribute = attribute;
+        this.orderIndex = orderIndex;
+        this.enumValue = enumValue;
+        this.stringValue = stringValue;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public ProfileAttribute getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(ProfileAttribute attribute) {
+        this.attribute = attribute;
+    }
+
+    public Long getAttributeId() {
+        return attributeId;
+    }
+
+    public int getOrderIndex() {
+        return orderIndex;
+    }
+
+    public void setOrderIndex(int orderIndex) {
+        this.orderIndex = orderIndex;
+    }
+
+    public String getEnumValue() {
+        return enumValue;
+    }
+
+    public void setEnumValue(String enumValue) {
+        this.enumValue = enumValue;
+    }
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+}

--- a/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
@@ -5,11 +5,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.trackdev.api.dto.EnumValueEntryDTO;
+import org.trackdev.api.dto.ListItemDTO;
+import org.trackdev.api.dto.StudentAttributeListValueDTO;
 import org.trackdev.api.dto.StudentAttributeValueDTO;
 import org.trackdev.api.entity.EnumValueEntry;
+import org.trackdev.api.entity.ProfileAttribute;
+import org.trackdev.api.entity.StudentAttributeListValue;
 import org.trackdev.api.entity.StudentAttributeValue;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface StudentAttributeValueMapper {
@@ -38,6 +43,30 @@ public interface StudentAttributeValueMapper {
         EnumValueEntryDTO dto = new EnumValueEntryDTO();
         dto.setValue(entry.getValue());
         dto.setDescription(entry.getDescription());
+        return dto;
+    }
+
+    // ==================== LIST value mapping ====================
+
+    default ListItemDTO toListItemDTO(StudentAttributeListValue entity) {
+        ListItemDTO dto = new ListItemDTO();
+        dto.setOrderIndex(entity.getOrderIndex());
+        dto.setEnumValue(entity.getEnumValue());
+        dto.setStringValue(entity.getStringValue());
+        return dto;
+    }
+
+    default StudentAttributeListValueDTO toListValueDTO(ProfileAttribute attribute, List<StudentAttributeListValue> items) {
+        StudentAttributeListValueDTO dto = new StudentAttributeListValueDTO();
+        dto.setAttributeId(attribute.getId());
+        dto.setAttributeName(attribute.getName());
+        dto.setAttributeType("LIST");
+        dto.setItems(items.stream().map(this::toListItemDTO).collect(Collectors.toList()));
+        if (attribute.getEnumRef() != null) {
+            dto.setEnumValues(attribute.getEnumRef().getValues().stream()
+                    .map(this::toEnumValueEntryDTO)
+                    .toArray(EnumValueEntryDTO[]::new));
+        }
         return dto;
     }
 }

--- a/src/main/java/org/trackdev/api/model/ProfileRequest.java
+++ b/src/main/java/org/trackdev/api/model/ProfileRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import org.trackdev.api.entity.AttributeAppliedBy;
 import org.trackdev.api.entity.AttributeTarget;
 import org.trackdev.api.entity.AttributeType;
+import org.trackdev.api.entity.AttributeVisibility;
 
 import java.util.List;
 
@@ -70,6 +71,12 @@ public class ProfileRequest {
          * Defaults to PROFESSOR if not specified.
          */
         public AttributeAppliedBy appliedBy;
+
+        /**
+         * Who can view/read values of this attribute.
+         * Defaults to PROFESSOR_ONLY if not specified.
+         */
+        public AttributeVisibility visibility;
 
         /**
          * Reference to enum by name (required when type is ENUM)

--- a/src/main/java/org/trackdev/api/repository/StudentAttributeListValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/StudentAttributeListValueRepository.java
@@ -1,0 +1,18 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.StudentAttributeListValue;
+
+import java.util.List;
+
+public interface StudentAttributeListValueRepository extends BaseRepositoryLong<StudentAttributeListValue> {
+
+    List<StudentAttributeListValue> findByUserIdAndAttributeIdOrderByOrderIndex(String userId, Long attributeId);
+
+    List<StudentAttributeListValue> findByUserId(String userId);
+
+    void deleteByUserIdAndAttributeId(String userId, Long attributeId);
+
+    void deleteByUserId(String userId);
+
+    boolean existsByAttributeId(Long attributeId);
+}

--- a/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
+++ b/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
@@ -1140,41 +1140,55 @@ public class DemoDataSeeder {
 
         // Create attributes for STUDENT target (one per type)
         ProfileAttribute studentNotes = new ProfileAttribute("Notes", AttributeType.STRING, AttributeTarget.STUDENT, profile);
+        studentNotes.setVisibility(AttributeVisibility.PROFESSOR_ONLY);
         profile.addAttribute(studentNotes);
 
         ProfileAttribute studentSkill = new ProfileAttribute("Technical Skill", AttributeType.ENUM, AttributeTarget.STUDENT, profile);
         studentSkill.setEnumRef(savedSkillLevelEnum);
+        studentSkill.setVisibility(AttributeVisibility.ASSIGNED_STUDENT);
         profile.addAttribute(studentSkill);
 
         ProfileAttribute studentAttendance = new ProfileAttribute("Attendance Count", AttributeType.INTEGER, AttributeTarget.STUDENT, profile);
+        studentAttendance.setVisibility(AttributeVisibility.PROFESSOR_ONLY);
         profile.addAttribute(studentAttendance);
 
         ProfileAttribute studentGrade = new ProfileAttribute("Participation Grade", AttributeType.FLOAT, AttributeTarget.STUDENT, profile);
+        studentGrade.setVisibility(AttributeVisibility.PROJECT_STUDENTS);
         profile.addAttribute(studentGrade);
 
         // Create attributes for TASK target (one per type)
         ProfileAttribute taskDescription = new ProfileAttribute("Technical Notes", AttributeType.STRING, AttributeTarget.TASK, profile);
+        taskDescription.setVisibility(AttributeVisibility.PROJECT_STUDENTS);
+        taskDescription.setAppliedBy(AttributeAppliedBy.STUDENT);
         profile.addAttribute(taskDescription);
 
         ProfileAttribute taskPriority = new ProfileAttribute("Business Priority", AttributeType.ENUM, AttributeTarget.TASK, profile);
         taskPriority.setEnumRef(savedPriorityEnum);
+        taskPriority.setVisibility(AttributeVisibility.PROJECT_STUDENTS);
+        taskPriority.setAppliedBy(AttributeAppliedBy.STUDENT);
         profile.addAttribute(taskPriority);
 
         ProfileAttribute taskComplexity = new ProfileAttribute("Complexity Score", AttributeType.INTEGER, AttributeTarget.TASK, profile);
+        taskComplexity.setVisibility(AttributeVisibility.PROFESSOR_ONLY);
         profile.addAttribute(taskComplexity);
 
         ProfileAttribute taskCodeCoverage = new ProfileAttribute("Code Coverage", AttributeType.FLOAT, AttributeTarget.TASK, profile);
+        taskCodeCoverage.setVisibility(AttributeVisibility.ASSIGNED_STUDENT);
+        taskCodeCoverage.setAppliedBy(AttributeAppliedBy.STUDENT);
         profile.addAttribute(taskCodeCoverage);
 
         // Create attributes for PULL_REQUEST target (one per type)
         ProfileAttribute prReviewNotes = new ProfileAttribute("Review Notes", AttributeType.STRING, AttributeTarget.PULL_REQUEST, profile);
+        prReviewNotes.setVisibility(AttributeVisibility.PROFESSOR_ONLY);
         profile.addAttribute(prReviewNotes);
 
         ProfileAttribute prStatus = new ProfileAttribute("Review Outcome", AttributeType.ENUM, AttributeTarget.PULL_REQUEST, profile);
         prStatus.setEnumRef(savedReviewStatusEnum);
+        prStatus.setVisibility(AttributeVisibility.PROJECT_STUDENTS);
         profile.addAttribute(prStatus);
 
         ProfileAttribute prChangesRequested = new ProfileAttribute("Changes Requested", AttributeType.INTEGER, AttributeTarget.PULL_REQUEST, profile);
+        prChangesRequested.setVisibility(AttributeVisibility.ASSIGNED_STUDENT);
         profile.addAttribute(prChangesRequested);
 
         ProfileAttribute prQualityScore = new ProfileAttribute("Quality Score", AttributeType.FLOAT, AttributeTarget.PULL_REQUEST, profile);

--- a/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
@@ -6,13 +6,21 @@ import org.springframework.transaction.annotation.Transactional;
 import org.trackdev.api.configuration.UserType;
 import org.trackdev.api.controller.exceptions.ServiceException;
 import org.trackdev.api.entity.*;
+import org.trackdev.api.repository.StudentAttributeListValueRepository;
 import org.trackdev.api.repository.StudentAttributeValueRepository;
 import org.trackdev.api.utils.ErrorConstants;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+/**
+ * Service for managing student attribute values.
+ * Read access: enrolled students (filtered by visibility), professors, admins.
+ * Write access: professors and admins only.
+ */
 
 @Service
 public class StudentAttributeValueService extends BaseServiceLong<StudentAttributeValue, StudentAttributeValueRepository> {
@@ -26,6 +34,31 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
     @Autowired
     private ProfileService profileService;
 
+    @Autowired
+    private AccessChecker accessChecker;
+
+    @Autowired
+    private StudentAttributeListValueRepository listValueRepository;
+
+    /**
+     * Get a course with access check that also allows enrolled students.
+     * Standard checkCanViewCourse blocks students; this method adds student enrollment check.
+     */
+    private Course getCourseForStudentAttributeAccess(Long courseId, String requestingUserId) {
+        Course course = courseService.get(courseId);
+        User user = userService.get(requestingUserId);
+
+        // Enrolled students can access student attributes (filtered by visibility later)
+        if (user.isUserType(UserType.STUDENT) && course.isStudentEnrolled(requestingUserId)) {
+            return course;
+        }
+
+        // For all other roles, fall back to standard course view check
+        // (handles ADMIN, WORKSPACE_ADMIN, course owner, subject owner)
+        accessChecker.checkCanViewCourse(course, requestingUserId);
+        return course;
+    }
+
     public List<StudentAttributeValue> findByUserId(String userId) {
         return repo().findByUserId(userId);
     }
@@ -37,6 +70,7 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
     @Transactional
     public void deleteByUserId(String userId) {
         repo().deleteByUserId(userId);
+        listValueRepository.deleteByUserId(userId);
     }
 
     @Transactional
@@ -45,37 +79,73 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
     }
 
     /**
-     * Get all attribute values for a student in a course.
+     * Get all scalar (non-LIST) attribute values for a student in a course.
+     * Filters by attribute visibility based on requesting user's role.
      */
     public List<StudentAttributeValue> getStudentAttributeValues(Long courseId, String targetUserId, String requestingUserId) {
-        Course course = courseService.getCourse(courseId, requestingUserId);
+        Course course = getCourseForStudentAttributeAccess(courseId, requestingUserId);
 
         if (!course.isStudentEnrolled(targetUserId)) {
             throw new ServiceException("Student is not enrolled in this course");
         }
+
+        User requestingUser = userService.get(requestingUserId);
 
         return repo().findByUserId(targetUserId).stream()
                 .filter(v -> {
                     Profile profile = course.getProfile();
                     return profile != null && v.getAttribute().getProfileId().equals(profile.getId());
                 })
+                .filter(v -> v.getAttribute().getType() != AttributeType.LIST)
+                .filter(v -> {
+                    if (requestingUser.isUserType(UserType.PROFESSOR) || requestingUser.isUserType(UserType.ADMIN)) {
+                        return true;
+                    }
+                    return isAttributeVisibleToStudent(v.getAttribute(), requestingUserId.equals(targetUserId));
+                })
                 .collect(Collectors.toList());
     }
 
     /**
      * Get available student-targeted attributes for a course.
+     * Filters by visibility based on requesting user's role.
      */
     public List<ProfileAttribute> getAvailableStudentAttributes(Long courseId, String requestingUserId) {
-        Course course = courseService.getCourse(courseId, requestingUserId);
+        return getAvailableStudentAttributes(courseId, null, requestingUserId);
+    }
+
+    /**
+     * Get available student-targeted attributes for a course, for a specific target student.
+     * Filters by visibility based on requesting user's role.
+     */
+    public List<ProfileAttribute> getAvailableStudentAttributes(Long courseId, String targetUserId, String requestingUserId) {
+        Course course = getCourseForStudentAttributeAccess(courseId, requestingUserId);
 
         Profile profile = course.getProfile();
         if (profile == null) {
             return Collections.emptyList();
         }
 
+        User requestingUser = userService.get(requestingUserId);
+
         return profile.getAttributes().stream()
                 .filter(attr -> attr.getTarget() == AttributeTarget.STUDENT)
+                .filter(attr -> {
+                    if (requestingUser.isUserType(UserType.PROFESSOR) || requestingUser.isUserType(UserType.ADMIN)) {
+                        return true;
+                    }
+                    boolean isTargetSelf = targetUserId != null && requestingUserId.equals(targetUserId);
+                    return isAttributeVisibleToStudent(attr, isTargetSelf);
+                })
                 .collect(Collectors.toList());
+    }
+
+    private boolean isAttributeVisibleToStudent(ProfileAttribute attr, boolean isTargetStudent) {
+        return switch (attr.getVisibility()) {
+            case PROFESSOR_ONLY -> false;
+            case PROJECT_STUDENTS -> true;
+            case ASSIGNED_STUDENT -> isTargetStudent;
+        };
     }
 
     /**
@@ -103,6 +173,10 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
 
         if (attribute.getTarget() != AttributeTarget.STUDENT) {
             throw new ServiceException("Attribute is not applicable to students");
+        }
+
+        if (attribute.getType() == AttributeType.LIST) {
+            throw new ServiceException(ErrorConstants.ATTRIBUTE_NOT_LIST_TYPE);
         }
 
         checkAuthorization(attribute, requestingUser, targetUserId);
@@ -140,20 +214,146 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         repo().deleteByUserIdAndAttributeId(targetUserId, attributeId);
     }
 
-    private void checkAuthorization(ProfileAttribute attribute, User requestingUser, String targetUserId) {
-        if (attribute.getAppliedBy() == AttributeAppliedBy.PROFESSOR) {
-            if (!requestingUser.isUserType(UserType.PROFESSOR) && !requestingUser.isUserType(UserType.ADMIN)) {
-                throw new ServiceException(ErrorConstants.UNAUTHORIZED);
-            }
-        } else {
-            // STUDENT: the target student themselves or professor/admin
-            if (requestingUser.isUserType(UserType.STUDENT)) {
-                if (!requestingUser.getId().equals(targetUserId)) {
-                    throw new ServiceException(ErrorConstants.UNAUTHORIZED);
+    // ==================== LIST Attribute Values ====================
+
+    /**
+     * Get a LIST-type attribute with access validation.
+     */
+    public ProfileAttribute getListAttribute(Long courseId, Long attributeId, String requestingUserId) {
+        Course course = courseService.getCourse(courseId, requestingUserId);
+        ProfileAttribute attribute = profileService.getAttributeById(attributeId);
+        validateListAttributeAccess(attribute, course);
+        return attribute;
+    }
+
+    /**
+     * Get list items for a LIST-type attribute for a student in a course.
+     */
+    public List<StudentAttributeListValue> getStudentListAttributeValues(Long courseId, String targetUserId, Long attributeId, String requestingUserId) {
+        Course course = courseService.getCourse(courseId, requestingUserId);
+        User requestingUser = userService.get(requestingUserId);
+
+        // LIST attributes are PROFESSOR_ONLY visible
+        if (!requestingUser.isUserType(UserType.PROFESSOR) && !requestingUser.isUserType(UserType.ADMIN)) {
+            throw new ServiceException(ErrorConstants.UNAUTHORIZED);
+        }
+
+        if (!course.isStudentEnrolled(targetUserId)) {
+            throw new ServiceException("Student is not enrolled in this course");
+        }
+
+        ProfileAttribute attribute = profileService.getAttributeById(attributeId);
+        validateListAttributeAccess(attribute, course);
+
+        return listValueRepository.findByUserIdAndAttributeIdOrderByOrderIndex(targetUserId, attributeId);
+    }
+
+    /**
+     * Replace all list items for a LIST-type attribute for a student.
+     */
+    @Transactional
+    public List<StudentAttributeListValue> setStudentListAttributeValues(Long courseId, String targetUserId, Long attributeId,
+                                                                          List<ListItemRequest> items, String requestingUserId) {
+        Course course = courseService.getCourse(courseId, requestingUserId);
+        User requestingUser = userService.get(requestingUserId);
+
+        if (!requestingUser.isUserType(UserType.PROFESSOR) && !requestingUser.isUserType(UserType.ADMIN)) {
+            throw new ServiceException(ErrorConstants.UNAUTHORIZED);
+        }
+
+        if (!course.isStudentEnrolled(targetUserId)) {
+            throw new ServiceException("Student is not enrolled in this course");
+        }
+
+        ProfileAttribute attribute = profileService.getAttributeById(attributeId);
+        validateListAttributeAccess(attribute, course);
+
+        // Validate list items
+        boolean hasEnumRef = attribute.getEnumRef() != null;
+        List<String> allowedEnumValues = hasEnumRef ? attribute.getEnumRef().getValueStrings() : null;
+
+        if (items != null) {
+            for (ListItemRequest item : items) {
+                if (hasEnumRef) {
+                    if (item.enumValue == null || item.enumValue.isBlank()) {
+                        throw new ServiceException(ErrorConstants.LIST_ATTRIBUTE_INVALID_ENUM_VALUE);
+                    }
+                    if (!allowedEnumValues.contains(item.enumValue)) {
+                        throw new ServiceException(ErrorConstants.LIST_ATTRIBUTE_ENUM_VALUE_NOT_ALLOWED);
+                    }
+                } else {
+                    if (item.enumValue != null && !item.enumValue.isBlank()) {
+                        throw new ServiceException(ErrorConstants.LIST_ATTRIBUTE_ENUM_VALUE_NOT_ALLOWED);
+                    }
                 }
-            } else if (!requestingUser.isUserType(UserType.PROFESSOR) && !requestingUser.isUserType(UserType.ADMIN)) {
-                throw new ServiceException(ErrorConstants.UNAUTHORIZED);
             }
+        }
+
+        // Delete existing items
+        listValueRepository.deleteByUserIdAndAttributeId(targetUserId, attributeId);
+
+        if (items == null || items.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Insert new items
+        User targetUser = userService.get(targetUserId);
+        List<StudentAttributeListValue> savedItems = new ArrayList<>();
+        for (int i = 0; i < items.size(); i++) {
+            ListItemRequest item = items.get(i);
+            StudentAttributeListValue listValue = new StudentAttributeListValue(
+                    targetUser, attribute, i,
+                    hasEnumRef ? item.enumValue : null,
+                    item.stringValue
+            );
+            savedItems.add(listValueRepository.save(listValue));
+        }
+
+        return savedItems;
+    }
+
+    /**
+     * Delete all list items for a LIST-type attribute for a student.
+     */
+    @Transactional
+    public void deleteStudentListAttributeValues(Long courseId, String targetUserId, Long attributeId, String requestingUserId) {
+        Course course = courseService.getCourse(courseId, requestingUserId);
+        User requestingUser = userService.get(requestingUserId);
+
+        if (!requestingUser.isUserType(UserType.PROFESSOR) && !requestingUser.isUserType(UserType.ADMIN)) {
+            throw new ServiceException(ErrorConstants.UNAUTHORIZED);
+        }
+
+        if (!course.isStudentEnrolled(targetUserId)) {
+            throw new ServiceException("Student is not enrolled in this course");
+        }
+
+        ProfileAttribute attribute = profileService.getAttributeById(attributeId);
+        validateListAttributeAccess(attribute, course);
+
+        listValueRepository.deleteByUserIdAndAttributeId(targetUserId, attributeId);
+    }
+
+    private void validateListAttributeAccess(ProfileAttribute attribute, Course course) {
+        Profile profile = course.getProfile();
+        if (profile == null) {
+            throw new ServiceException("No profile is applied to this course");
+        }
+        if (!attribute.getProfileId().equals(profile.getId())) {
+            throw new ServiceException("Attribute does not belong to the course profile");
+        }
+        if (attribute.getType() != AttributeType.LIST) {
+            throw new ServiceException(ErrorConstants.ATTRIBUTE_NOT_LIST_TYPE);
+        }
+        if (attribute.getTarget() != AttributeTarget.STUDENT) {
+            throw new ServiceException("Attribute is not applicable to students");
+        }
+    }
+
+    private void checkAuthorization(ProfileAttribute attribute, User requestingUser, String targetUserId) {
+        // Student attributes can only be edited by PROFESSOR or ADMIN
+        if (!requestingUser.isUserType(UserType.PROFESSOR) && !requestingUser.isUserType(UserType.ADMIN)) {
+            throw new ServiceException(ErrorConstants.UNAUTHORIZED);
         }
     }
 
@@ -208,5 +408,13 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
             default:
                 break;
         }
+    }
+
+    /**
+     * Request object for individual list items.
+     */
+    public static class ListItemRequest {
+        public String enumValue;
+        public String stringValue;
     }
 }

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -157,6 +157,10 @@ public final class ErrorConstants {
     public static final String PROFILE_ATTRIBUTE_IMMUTABLE_ENUM_REF = "error.profile.attribute.immutable.enum.ref";
     public static final String ATTRIBUTE_VALUE_BELOW_MIN = "error.attribute.value.below.min";
     public static final String ATTRIBUTE_VALUE_ABOVE_MAX = "error.attribute.value.above.max";
+    public static final String LIST_ATTRIBUTE_MUST_TARGET_STUDENT = "error.profile.attribute.list.must.target.student";
+    public static final String LIST_ATTRIBUTE_INVALID_ENUM_VALUE = "error.profile.attribute.list.invalid.enum.value";
+    public static final String LIST_ATTRIBUTE_ENUM_VALUE_NOT_ALLOWED = "error.profile.attribute.list.enum.value.not.allowed";
+    public static final String ATTRIBUTE_NOT_LIST_TYPE = "error.attribute.not.list.type";
 
     // Backlog movement rules
     public static final String TASK_BEGUN_CANNOT_MOVE_TO_BACKLOG = "error.task.begun.cannot.move.to.backlog";

--- a/src/main/resources/db/migration/V10__profile_enhancements.sql
+++ b/src/main/resources/db/migration/V10__profile_enhancements.sql
@@ -1,6 +1,7 @@
 -- Schema migration V10: Profile enhancements
--- Adds: applied_by, min/max for attributes, enum value descriptions,
--- student_attribute_values table, pull_request_attribute_values table
+-- Adds: applied_by, visibility, min/max for attributes, enum value descriptions,
+-- student_attribute_values table, pull_request_attribute_values table,
+-- LIST attribute type, student_attribute_list_values table
 
 -- ============================================
 -- CREATE TABLES (without foreign keys)
@@ -30,6 +31,20 @@ CREATE TABLE `pull_request_attribute_values` (
   CHARSET utf8mb4,
   COLLATE utf8mb4_0900_ai_ci;
 
+CREATE TABLE `student_attribute_list_values` (
+	`id` bigint NOT NULL AUTO_INCREMENT,
+	`user_id` varchar(36),
+	`attribute_id` bigint,
+	`order_index` int NOT NULL,
+	`enum_value` varchar(100),
+	`string_value` varchar(500),
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `UK_salv_user_attr_order` (`user_id`, `attribute_id`, `order_index`),
+	KEY `FK_salv_attribute` (`attribute_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
 -- ============================================
 -- ADD COLUMNS
 -- ============================================
@@ -37,9 +52,15 @@ CREATE TABLE `pull_request_attribute_values` (
 -- Add applied_by to profile_attributes (default PROFESSOR for backward compat)
 ALTER TABLE `profile_attributes` ADD COLUMN `applied_by` enum('PROFESSOR', 'STUDENT') NOT NULL DEFAULT 'PROFESSOR' AFTER `target`;
 
+-- Add visibility to profile_attributes
+ALTER TABLE `profile_attributes` ADD COLUMN `visibility` varchar(20) NOT NULL DEFAULT 'PROFESSOR_ONLY' AFTER `applied_by`;
+
 -- Add min_value and max_value to profile_attributes
 ALTER TABLE `profile_attributes` ADD COLUMN `min_value` varchar(255) AFTER `default_value`;
 ALTER TABLE `profile_attributes` ADD COLUMN `max_value` varchar(255) AFTER `min_value`;
+
+-- Add LIST to the type enum
+ALTER TABLE `profile_attributes` MODIFY COLUMN `type` enum('ENUM', 'FLOAT', 'INTEGER', 'STRING', 'LIST') NOT NULL;
 
 -- Add description to profile_enum_values
 ALTER TABLE `profile_enum_values` ADD COLUMN `description` varchar(500) AFTER `value`;
@@ -53,3 +74,6 @@ ALTER TABLE `student_attribute_values` ADD CONSTRAINT `FK_sav_user` FOREIGN KEY 
 
 ALTER TABLE `pull_request_attribute_values` ADD CONSTRAINT `FK_prav_attribute` FOREIGN KEY (`attribute_id`) REFERENCES `profile_attributes` (`id`);
 ALTER TABLE `pull_request_attribute_values` ADD CONSTRAINT `FK_prav_pr` FOREIGN KEY (`pull_request_id`) REFERENCES `pull_requests` (`id`);
+
+ALTER TABLE `student_attribute_list_values` ADD CONSTRAINT `FK_salv_attribute` FOREIGN KEY (`attribute_id`) REFERENCES `profile_attributes` (`id`);
+ALTER TABLE `student_attribute_list_values` ADD CONSTRAINT `FK_salv_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);


### PR DESCRIPTION
## Summary

This PR introduces role-based visibility controls for profile attributes and adds a new LIST attribute type for multi-value student attributes. The changes ensure that students only see attributes they're authorized to view based on their role and relationship to the entity.

## Key Changes

### Attribute Visibility System
- **New `AttributeVisibility` enum** with three levels:
  - `PROFESSOR_ONLY` - Only professors and admins can view
  - `PROJECT_STUDENTS` - All students in the same project can view
  - `ASSIGNED_STUDENT` - Only the student with edit access (e.g., task assignee) can view
- **Applied across all attribute targets**: Tasks, Students, and Pull Requests
- **Filtering logic** implemented in `TaskService`, `StudentAttributeValueService`, and `PullRequestAttributeValueService`
- All existing attributes default to `PROFESSOR_ONLY` for backward compatibility

### LIST Attribute Type
- **New attribute type** for storing ordered lists of values on student profiles
- **Validation**: LIST attributes can only target STUDENT entities
- **Data model**: New `StudentAttributeListValue` entity with support for:
  - Ordered items (via `orderIndex`)
  - Optional enum reference for constrained values
  - Free-text string values
- **REST endpoints** for CRUD operations on list values
- **Repository layer**: `StudentAttributeListValueRepository` with ordering support

### Access Control Enhancements
- **Enforced professor-only write access** for all attribute value modifications (student, task, and PR attributes)
- Added `@PreAuthorize` annotations on modification endpoints
- Students can still *read* attributes based on visibility rules, but only professors can write

### API Changes
- New endpoints in `CourseController`:
  - `GET /courses/{id}/students/{userId}/list-attributes/{attributeId}` - Read list values
  - `PUT /courses/{id}/students/{userId}/list-attributes/{attributeId}` - Set list values
  - `DELETE /courses/{id}/students/{userId}/list-attributes/{attributeId}` - Clear list values
- Updated DTOs: `ProfileAttributeDTO`, `StudentAttributeListValueDTO`, `ListItemDTO`
- Extended `ProfileRequest` to accept `visibility` field

## Database Migration

**Migration V10** adds:
- `visibility` column to `profile_attributes` (defaults to `PROFESSOR_ONLY`)
- `student_attribute_list_values` table for LIST attribute storage
- LIST enum value to `profile_attributes.type`
- Constraints ensuring unique (user_id, attribute_id, order_index) combinations

## Breaking Changes

⚠️ **Access control changes**: 
- Student and PR attribute modification endpoints now require PROFESSOR or ADMIN role
- Existing API clients that allowed students to set their own attribute values will receive 403 Forbidden
- This aligns with the original design intent where `appliedBy` was meant to indicate who *should* apply values, not who *can*

## Testing Notes

- Demo data seeder updated with visibility configuration examples
- Test attribute creation with all three visibility levels
- Verify students can only see attributes matching their role/relationship
- Verify professors can see all attributes regardless of visibility
- Test LIST attribute CRUD operations with and without enum references