### PR TITLE
feat: add paginated project listing endpoint with role-based filtering

### DIFF
--- a/src/main/java/org/trackdev/api/dto/PagedProjectsResponseDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PagedProjectsResponseDTO.java
@@ -1,0 +1,20 @@
+package org.trackdev.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagedProjectsResponseDTO {
+    private List<ProjectWithMembersDTO> projects;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}

--- a/src/main/java/org/trackdev/api/repository/GroupRepository.java
+++ b/src/main/java/org/trackdev/api/repository/GroupRepository.java
@@ -1,5 +1,9 @@
 package org.trackdev.api.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 import org.trackdev.api.entity.Project;
 
@@ -7,8 +11,23 @@ import java.util.List;
 
 @Component
 public interface GroupRepository extends BaseRepositoryLong<Project> {
-    
+
     boolean existsBySlug(String slug);
-    
+
     List<Project> findByCourseIdOrderByNameAsc(Long courseId);
+
+    Page<Project> findAllByOrderByNameAsc(Pageable pageable);
+
+    Page<Project> findByCourseIdOrderByNameAsc(Long courseId, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Project p LEFT JOIN p.members m LEFT JOIN p.course c LEFT JOIN c.subject s " +
+           "WHERE m.id = :userId OR c.owner.id = :userId OR s.owner.id = :userId " +
+           "ORDER BY p.name ASC")
+    Page<Project> findProjectsForUser(@Param("userId") String userId, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Project p LEFT JOIN p.members m LEFT JOIN p.course c LEFT JOIN c.subject s " +
+           "WHERE (m.id = :userId OR c.owner.id = :userId OR s.owner.id = :userId) " +
+           "AND c.id = :courseId " +
+           "ORDER BY p.name ASC")
+    Page<Project> findProjectsForUserByCourse(@Param("userId") String userId, @Param("courseId") Long courseId, Pageable pageable);
 }

--- a/src/main/java/org/trackdev/api/service/ProjectService.java
+++ b/src/main/java/org/trackdev/api/service/ProjectService.java
@@ -2,6 +2,8 @@ package org.trackdev.api.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.trackdev.api.controller.exceptions.ServiceException;
@@ -197,6 +199,26 @@ public class ProjectService extends BaseServiceLong<Project, GroupRepository> {
         }
         
         return allProjects;
+    }
+
+    /**
+     * Get projects paginated and sorted by name.
+     * Admin/workspace admin sees all projects; other users see only their projects.
+     * Optionally filters by courseId.
+     */
+    @Transactional(readOnly = true)
+    public Page<Project> getProjectsPaginated(String userId, Long courseId, Pageable pageable) {
+        if (accessChecker.checkCanViewAllProjects(userId)) {
+            if (courseId != null) {
+                return repo.findByCourseIdOrderByNameAsc(courseId, pageable);
+            }
+            return repo.findAllByOrderByNameAsc(pageable);
+        } else {
+            if (courseId != null) {
+                return repo.findProjectsForUserByCourse(userId, courseId, pageable);
+            }
+            return repo.findProjectsForUser(userId, pageable);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a new `GET /projects/paged` endpoint that returns projects in a paginated, alphabetically sorted response. Access is role-based: admins and workspace admins see all projects, while other users (professors, students) see only projects they are members of or associated with through their courses/subjects.

## Changes

### Repository (`GroupRepository`)
- Added paginated overloads: `findAllByOrderByNameAsc(Pageable)` and `findByCourseIdOrderByNameAsc(Long, Pageable)`
- Added `findProjectsForUser` and `findProjectsForUserByCourse` custom JPQL queries that return projects where the user is a member, course owner, or subject owner

### Service (`ProjectService`)
- Added `getProjectsPaginated(userId, courseId, pageable)` method with `@Transactional(readOnly = true)`
- Delegates to the appropriate repository query based on user role and optional `courseId` filter

### Controller (`ProjectController`)
- Added `GET /projects/paged` endpoint accepting `page` (default `0`), `size` (default `15`, max `100`), and optional `courseId` query parameters
- Maps the `Page<Project>` result to `PagedProjectsResponseDTO`

### DTO (`PagedProjectsResponseDTO`)
- New response DTO wrapping a list of `ProjectWithMembersDTO` along with pagination metadata: `page`, `size`, `totalElements`, `totalPages`, `hasNext`, `hasPrevious`

## Breaking Changes

None. The new endpoint is additive and does not modify existing endpoints.

## Testing Notes

- Verify that admin users receive all projects; non-admin users receive only their associated projects
- Verify `courseId` filter correctly scopes results for both admin and non-admin roles
- Verify `size` parameter is capped at 100 regardless of input