### PR TITLE
Sync webhook status from GitHub API on repo fetch

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/WebhookProperties.java
+++ b/src/main/java/org/trackdev/api/configuration/WebhookProperties.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "app.webhook")
+@ConfigurationProperties(prefix = "trackdev.webhook")
 public class WebhookProperties {
 
     private String url;


### PR DESCRIPTION
## Summary

Adds real-time webhook status synchronization from the GitHub API whenever GitHub repositories are retrieved, and fixes the configuration property prefix for webhook settings.

## Changes

### `GitHubRepoService` — Webhook status sync on fetch
- Injects `WebhookProperties` to access the app's webhook base URL
- Adds a `syncWebhookStatus()` helper that calls the GitHub API to check existing webhooks for a repo and updates the `webhookActive` flag accordingly
- Webhook matching is based on whether the webhook config URL contains the app's configured webhook base URL
- `getProjectRepos()` and `getRepo()` now call `syncWebhookStatus()` before returning, ensuring the returned data reflects the current state on GitHub
- Errors during sync are logged and swallowed to avoid breaking repo listing

### `WebhookProperties` — Fix configuration prefix
- Corrects the `@ConfigurationProperties` prefix from `app.webhook` to `trackdev.webhook`, aligning with the project's property namespace convention

## Why
Previously, the `webhookActive` flag was only updated when explicitly managing webhooks. This change ensures the flag always reflects the actual webhook state on GitHub when repos are fetched, preventing stale data from being displayed. The config prefix fix was needed to ensure `WebhookProperties` correctly binds to the application configuration.

## Notes
- No database migrations required
- No API contract changes; existing clients are unaffected
- Webhook sync errors are non-fatal and logged at warn/error level