### PR TITLE
Split list attribute string_value into title and description fields

### DIFF
--- a/src/main/java/org/trackdev/api/controller/CourseController.java
+++ b/src/main/java/org/trackdev/api/controller/CourseController.java
@@ -345,7 +345,8 @@ public class CourseController extends BaseController {
             items = request.items.stream().map(item -> {
                 StudentAttributeValueService.ListItemRequest r = new StudentAttributeValueService.ListItemRequest();
                 r.enumValue = item.enumValue;
-                r.stringValue = item.stringValue;
+                r.title = item.title;
+                r.description = item.description;
                 return r;
             }).collect(Collectors.toList());
         }
@@ -376,7 +377,8 @@ public class CourseController extends BaseController {
 
         static class ListItemInput {
             public String enumValue;
-            public String stringValue;
+            public String title;
+            public String description;
         }
     }
 

--- a/src/main/java/org/trackdev/api/dto/ListItemDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ListItemDTO.java
@@ -9,5 +9,6 @@ import lombok.Data;
 public class ListItemDTO {
     private int orderIndex;
     private String enumValue;
-    private String stringValue;
+    private String title;
+    private String description;
 }

--- a/src/main/java/org/trackdev/api/entity/StudentAttributeListValue.java
+++ b/src/main/java/org/trackdev/api/entity/StudentAttributeListValue.java
@@ -40,19 +40,26 @@ public class StudentAttributeListValue extends BaseEntityLong {
     private String enumValue;
 
     /**
-     * The string value for this list item.
+     * Short title for this list item.
      */
-    @Column(name = "string_value", length = 500)
-    private String stringValue;
+    @Column(name = "title", length = 255)
+    private String title;
+
+    /**
+     * Extended description for this list item. Supports Markdown formatting.
+     */
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
 
     public StudentAttributeListValue() {}
 
-    public StudentAttributeListValue(User user, ProfileAttribute attribute, int orderIndex, String enumValue, String stringValue) {
+    public StudentAttributeListValue(User user, ProfileAttribute attribute, int orderIndex, String enumValue, String title, String description) {
         this.user = user;
         this.attribute = attribute;
         this.orderIndex = orderIndex;
         this.enumValue = enumValue;
-        this.stringValue = stringValue;
+        this.title = title;
+        this.description = description;
     }
 
     public User getUser() {
@@ -95,11 +102,19 @@ public class StudentAttributeListValue extends BaseEntityLong {
         this.enumValue = enumValue;
     }
 
-    public String getStringValue() {
-        return stringValue;
+    public String getTitle() {
+        return title;
     }
 
-    public void setStringValue(String stringValue) {
-        this.stringValue = stringValue;
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
@@ -52,7 +52,8 @@ public interface StudentAttributeValueMapper {
         ListItemDTO dto = new ListItemDTO();
         dto.setOrderIndex(entity.getOrderIndex());
         dto.setEnumValue(entity.getEnumValue());
-        dto.setStringValue(entity.getStringValue());
+        dto.setTitle(entity.getTitle());
+        dto.setDescription(entity.getDescription());
         return dto;
     }
 

--- a/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
+++ b/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
@@ -1127,6 +1127,16 @@ public class DemoDataSeeder {
         ));
         profile.addEnum(reviewStatusEnum);
 
+        ProfileEnum listGradeEnum = new ProfileEnum("Grade", profile);
+        listGradeEnum.setValues(Arrays.asList(
+            new EnumValueEntry("A", "Excellent performance"),
+            new EnumValueEntry("B", "Good performance"),
+            new EnumValueEntry("C", "Satisfactory performance"),
+            new EnumValueEntry("D", "Below average performance"),
+            new EnumValueEntry("E", "Needs significant improvement")
+        ));
+        profile.addEnum(listGradeEnum);
+
         // Save to persist the enums
         profile = profileRepository.save(profile);
         
@@ -1137,6 +1147,8 @@ public class DemoDataSeeder {
             .filter(e -> e.getName().equals("Priority")).findFirst().orElseThrow();
         ProfileEnum savedReviewStatusEnum = profile.getEnums().stream()
             .filter(e -> e.getName().equals("Review Status")).findFirst().orElseThrow();
+        ProfileEnum savedListGradeEnum = profile.getEnums().stream()
+            .filter(e -> e.getName().equals("Grade")).findFirst().orElseThrow();
 
         // Create attributes for STUDENT target (one per type)
         ProfileAttribute studentNotes = new ProfileAttribute("Notes", AttributeType.STRING, AttributeTarget.STUDENT, profile);
@@ -1155,6 +1167,12 @@ public class DemoDataSeeder {
         ProfileAttribute studentGrade = new ProfileAttribute("Participation Grade", AttributeType.FLOAT, AttributeTarget.STUDENT, profile);
         studentGrade.setVisibility(AttributeVisibility.PROJECT_STUDENTS);
         profile.addAttribute(studentGrade);
+
+        ProfileAttribute studentEvaluations = new ProfileAttribute("Sprint Evaluations", AttributeType.LIST, AttributeTarget.STUDENT, profile);
+        studentEvaluations.setEnumRef(savedListGradeEnum);
+        studentEvaluations.setVisibility(AttributeVisibility.PROFESSOR_ONLY);
+        studentEvaluations.setAppliedBy(AttributeAppliedBy.PROFESSOR);
+        profile.addAttribute(studentEvaluations);
 
         // Create attributes for TASK target (one per type)
         ProfileAttribute taskDescription = new ProfileAttribute("Technical Notes", AttributeType.STRING, AttributeTarget.TASK, profile);

--- a/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
@@ -289,8 +289,9 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
             }
         }
 
-        // Delete existing items
+        // Delete existing items and flush to avoid unique constraint violation on (user_id, attribute_id, order_index)
         listValueRepository.deleteByUserIdAndAttributeId(targetUserId, attributeId);
+        listValueRepository.flush();
 
         if (items == null || items.isEmpty()) {
             return Collections.emptyList();
@@ -304,7 +305,8 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
             StudentAttributeListValue listValue = new StudentAttributeListValue(
                     targetUser, attribute, i,
                     hasEnumRef ? item.enumValue : null,
-                    item.stringValue
+                    item.title,
+                    item.description
             );
             savedItems.add(listValueRepository.save(listValue));
         }
@@ -415,6 +417,7 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
      */
     public static class ListItemRequest {
         public String enumValue;
-        public String stringValue;
+        public String title;
+        public String description;
     }
 }

--- a/src/main/resources/db/migration/V11__list_attribute_title_description.sql
+++ b/src/main/resources/db/migration/V11__list_attribute_title_description.sql
@@ -1,0 +1,6 @@
+-- Split string_value into title + description for list attribute items
+-- Title is a short text, description supports Markdown content
+
+ALTER TABLE `student_attribute_list_values`
+  CHANGE COLUMN `string_value` `title` varchar(255),
+  ADD COLUMN `description` text AFTER `title`;


### PR DESCRIPTION
## Summary

Replaces the single `string_value` field on list attribute items with two distinct fields: `title` (short text, max 255 chars) and `description` (Markdown-capable text field). This change applies across all layers of the stack.

## Changes

- **Database migration** (`V11`): `ALTER TABLE student_attribute_list_values` renames `string_value` to `title` (varchar 255) and adds a new `description` (text) column
- **Entity**: `StudentAttributeListValue` replaces `stringValue` with `title` and `description` fields, updating the constructor and accessors accordingly
- **DTO**: `ListItemDTO` updated to expose `title` and `description` instead of `stringValue`
- **Mapper**: `StudentAttributeValueMapper` maps both new fields from entity to DTO
- **Service**: `StudentAttributeValueService` and its inner `ListItemRequest` updated to accept and persist `title` and `description`; a `flush()` call added after deletion to avoid unique constraint violations on `(user_id, attribute_id, order_index)` during re-save
- **Controller**: `CourseController.ListItemInput` updated to receive `title` and `description` from API requests
- **Demo data**: Added a `Grade` enum (A–E) and a `Sprint Evaluations` LIST attribute (professor-only visibility) to the demo data seeder

## Breaking Changes / Migration Notes

- **API change**: Clients sending list attribute items must replace the `stringValue` field with `title` and optionally `description` in request payloads
- **Database migration required**: `V11__list_attribute_title_description.sql` must be applied — existing `string_value` data will be migrated into `title`; `description` will default to `null`

## Testing Notes

- Verify creating/updating list attribute items via `PUT /courses/{id}/students/{studentId}/attributes/{attributeId}` with the new `title`/`description` fields
- Verify existing list attribute values are readable after migration (data preserved in `title`)
- Confirm the demo data seeder correctly seeds the `Sprint Evaluations` attribute with the `Grade` enum