### PR TITLE
feat: add LIST-type profile attribute support for pull requests

### DIFF
--- a/src/main/java/org/trackdev/api/dto/PullRequestAttributeListValueDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PullRequestAttributeListValueDTO.java
@@ -1,0 +1,18 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * DTO for a LIST-type attribute value applied to a pull request.
+ * Contains the attribute metadata and all list items.
+ */
+@Data
+public class PullRequestAttributeListValueDTO {
+    private Long attributeId;
+    private String attributeName;
+    private String attributeType;
+    private List<ListItemDTO> items;
+    private EnumValueEntryDTO[] enumValues;
+}

--- a/src/main/java/org/trackdev/api/entity/PullRequestAttributeListValue.java
+++ b/src/main/java/org/trackdev/api/entity/PullRequestAttributeListValue.java
@@ -1,0 +1,120 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import org.springframework.lang.NonNull;
+
+/**
+ * Stores an individual list item for a LIST-type profile attribute applied to a pull request.
+ * Each row represents one item in the ordered list.
+ */
+@Entity
+@Table(name = "pull_request_attribute_list_values", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"pull_request_id", "attribute_id", "order_index"})
+})
+public class PullRequestAttributeListValue extends BaseEntityLong {
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pull_request_id")
+    private PullRequest pullRequest;
+
+    @Column(name = "pull_request_id", insertable = false, updatable = false, length = BaseEntityUUID.UUID_LENGTH)
+    private String pullRequestId;
+
+    @NonNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attribute_id")
+    private ProfileAttribute attribute;
+
+    @Column(name = "attribute_id", insertable = false, updatable = false)
+    private Long attributeId;
+
+    @Column(name = "order_index", nullable = false)
+    private int orderIndex;
+
+    /**
+     * Enum value selected from the referenced ProfileEnum.
+     * NULL for STRING-only lists (when the attribute has no enumRef).
+     */
+    @Column(name = "enum_value", length = 100)
+    private String enumValue;
+
+    /**
+     * Short title for this list item.
+     */
+    @Column(name = "title", length = 255)
+    private String title;
+
+    /**
+     * Extended description for this list item. Supports Markdown formatting.
+     */
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    public PullRequestAttributeListValue() {}
+
+    public PullRequestAttributeListValue(PullRequest pullRequest, ProfileAttribute attribute, int orderIndex, String enumValue, String title, String description) {
+        this.pullRequest = pullRequest;
+        this.attribute = attribute;
+        this.orderIndex = orderIndex;
+        this.enumValue = enumValue;
+        this.title = title;
+        this.description = description;
+    }
+
+    public PullRequest getPullRequest() {
+        return pullRequest;
+    }
+
+    public void setPullRequest(PullRequest pullRequest) {
+        this.pullRequest = pullRequest;
+    }
+
+    public String getPullRequestId() {
+        return pullRequestId;
+    }
+
+    public ProfileAttribute getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(ProfileAttribute attribute) {
+        this.attribute = attribute;
+    }
+
+    public Long getAttributeId() {
+        return attributeId;
+    }
+
+    public int getOrderIndex() {
+        return orderIndex;
+    }
+
+    public void setOrderIndex(int orderIndex) {
+        this.orderIndex = orderIndex;
+    }
+
+    public String getEnumValue() {
+        return enumValue;
+    }
+
+    public void setEnumValue(String enumValue) {
+        this.enumValue = enumValue;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/org/trackdev/api/mapper/PullRequestAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/PullRequestAttributeValueMapper.java
@@ -5,11 +5,16 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.trackdev.api.dto.EnumValueEntryDTO;
+import org.trackdev.api.dto.ListItemDTO;
+import org.trackdev.api.dto.PullRequestAttributeListValueDTO;
 import org.trackdev.api.dto.PullRequestAttributeValueDTO;
 import org.trackdev.api.entity.EnumValueEntry;
+import org.trackdev.api.entity.ProfileAttribute;
+import org.trackdev.api.entity.PullRequestAttributeListValue;
 import org.trackdev.api.entity.PullRequestAttributeValue;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface PullRequestAttributeValueMapper {
@@ -38,6 +43,31 @@ public interface PullRequestAttributeValueMapper {
         EnumValueEntryDTO dto = new EnumValueEntryDTO();
         dto.setValue(entry.getValue());
         dto.setDescription(entry.getDescription());
+        return dto;
+    }
+
+    // ==================== LIST value mapping ====================
+
+    default ListItemDTO toListItemDTO(PullRequestAttributeListValue entity) {
+        ListItemDTO dto = new ListItemDTO();
+        dto.setOrderIndex(entity.getOrderIndex());
+        dto.setEnumValue(entity.getEnumValue());
+        dto.setTitle(entity.getTitle());
+        dto.setDescription(entity.getDescription());
+        return dto;
+    }
+
+    default PullRequestAttributeListValueDTO toListValueDTO(ProfileAttribute attribute, List<PullRequestAttributeListValue> items) {
+        PullRequestAttributeListValueDTO dto = new PullRequestAttributeListValueDTO();
+        dto.setAttributeId(attribute.getId());
+        dto.setAttributeName(attribute.getName());
+        dto.setAttributeType("LIST");
+        dto.setItems(items.stream().map(this::toListItemDTO).collect(Collectors.toList()));
+        if (attribute.getEnumRef() != null) {
+            dto.setEnumValues(attribute.getEnumRef().getValues().stream()
+                    .map(this::toEnumValueEntryDTO)
+                    .toArray(EnumValueEntryDTO[]::new));
+        }
         return dto;
     }
 }

--- a/src/main/java/org/trackdev/api/repository/PullRequestAttributeListValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/PullRequestAttributeListValueRepository.java
@@ -1,0 +1,20 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.PullRequestAttributeListValue;
+
+import java.util.List;
+
+public interface PullRequestAttributeListValueRepository extends BaseRepositoryLong<PullRequestAttributeListValue> {
+
+    List<PullRequestAttributeListValue> findByPullRequestIdAndAttributeIdOrderByOrderIndex(String pullRequestId, Long attributeId);
+
+    List<PullRequestAttributeListValue> findByPullRequestId(String pullRequestId);
+
+    void deleteByPullRequestIdAndAttributeId(String pullRequestId, Long attributeId);
+
+    void deleteByPullRequestId(String pullRequestId);
+
+    boolean existsByAttributeId(Long attributeId);
+
+    boolean existsByAttributeIdAndEnumValue(Long attributeId, String enumValue);
+}

--- a/src/main/java/org/trackdev/api/service/ProfileService.java
+++ b/src/main/java/org/trackdev/api/service/ProfileService.java
@@ -208,8 +208,8 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
 
         // Handle LIST type constraints
         if (attrRequest.type == AttributeType.LIST) {
-            if (attrRequest.target != AttributeTarget.STUDENT) {
-                throw new ServiceException(ErrorConstants.LIST_ATTRIBUTE_MUST_TARGET_STUDENT);
+            if (attrRequest.target != AttributeTarget.STUDENT && attrRequest.target != AttributeTarget.PULL_REQUEST) {
+                throw new ServiceException(ErrorConstants.LIST_ATTRIBUTE_MUST_TARGET_STUDENT_OR_PR);
             }
             attribute.setAppliedBy(AttributeAppliedBy.PROFESSOR);
             attribute.setVisibility(AttributeVisibility.PROFESSOR_ONLY);

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -158,6 +158,7 @@ public final class ErrorConstants {
     public static final String ATTRIBUTE_VALUE_BELOW_MIN = "error.attribute.value.below.min";
     public static final String ATTRIBUTE_VALUE_ABOVE_MAX = "error.attribute.value.above.max";
     public static final String LIST_ATTRIBUTE_MUST_TARGET_STUDENT = "error.profile.attribute.list.must.target.student";
+    public static final String LIST_ATTRIBUTE_MUST_TARGET_STUDENT_OR_PR = "error.profile.attribute.list.must.target.student.or.pr";
     public static final String LIST_ATTRIBUTE_INVALID_ENUM_VALUE = "error.profile.attribute.list.invalid.enum.value";
     public static final String LIST_ATTRIBUTE_ENUM_VALUE_NOT_ALLOWED = "error.profile.attribute.list.enum.value.not.allowed";
     public static final String ATTRIBUTE_NOT_LIST_TYPE = "error.attribute.not.list.type";

--- a/src/main/resources/db/migration/V12__pr_list_attributes.sql
+++ b/src/main/resources/db/migration/V12__pr_list_attributes.sql
@@ -1,0 +1,20 @@
+-- Schema migration V12: LIST attribute support for Pull Requests
+-- Adds pull_request_attribute_list_values table (mirrors student_attribute_list_values)
+
+CREATE TABLE `pull_request_attribute_list_values` (
+	`id` bigint NOT NULL AUTO_INCREMENT,
+	`pull_request_id` varchar(36),
+	`attribute_id` bigint,
+	`order_index` int NOT NULL,
+	`enum_value` varchar(100),
+	`title` varchar(255),
+	`description` text,
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `UK_pralv_pr_attr_order` (`pull_request_id`, `attribute_id`, `order_index`),
+	KEY `FK_pralv_attribute` (`attribute_id`)
+) ENGINE InnoDB,
+  CHARSET utf8mb4,
+  COLLATE utf8mb4_0900_ai_ci;
+
+ALTER TABLE `pull_request_attribute_list_values` ADD CONSTRAINT `FK_pralv_attribute` FOREIGN KEY (`attribute_id`) REFERENCES `profile_attributes` (`id`);
+ALTER TABLE `pull_request_attribute_list_values` ADD CONSTRAINT `FK_pralv_pr` FOREIGN KEY (`pull_request_id`) REFERENCES `pull_requests` (`id`);


### PR DESCRIPTION
## Summary

This PR extends the profile attribute system to support LIST-type attributes targeting pull requests, mirroring the existing LIST attribute functionality available for students.

## Changes

### New Entity & Database
- Added `PullRequestAttributeListValue` JPA entity to store individual list items for LIST-type attributes applied to pull requests
- Added Flyway migration `V12__pr_list_attributes.sql` to create the `pull_request_attribute_list_values` table with appropriate foreign key constraints to `pull_requests` and `profile_attributes`

### Repository
- Added `PullRequestAttributeListValueRepository` with derived query methods for fetching, deleting, and existence checks by pull request and attribute

### Service
- Extended `PullRequestAttributeValueService` with full CRUD operations for LIST-type attribute values on pull requests (get, set/replace, delete)
- Fixed `ProfileService` to allow LIST-type attributes to target `PULL_REQUEST` in addition to `STUDENT`; previously only `STUDENT` was permitted

### Controller
- Added three new endpoints to `PullRequestController` (professors/admins only):
  - `GET /{prId}/list-attributes/{attributeId}` — retrieve list items for a pull request
  - `PUT /{prId}/list-attributes/{attributeId}` — replace all list items for a pull request
  - `DELETE /{prId}/list-attributes/{attributeId}` — remove all list items for a pull request

### DTO & Mapper
- Added `PullRequestAttributeListValueDTO` to represent LIST attribute values in API responses
- Extended `PullRequestAttributeValueMapper` with `toListItemDTO` and `toListValueDTO` mapping methods

### Error Handling
- Added `LIST_ATTRIBUTE_MUST_TARGET_STUDENT_OR_PR` error constant for the updated validation rule

## Migration Notes

- Requires running Flyway migration `V12__pr_list_attributes.sql` on production databases before deploying
- LIST-type attributes previously restricted to `STUDENT` target can now also target `PULL_REQUEST` — existing data is unaffected

## Access Control

LIST attribute endpoints for pull requests are restricted to `PROFESSOR` and `ADMIN` roles, consistent with the `PROFESSOR_ONLY` visibility of LIST attributes.