### PR TITLE
feat: add Personal Access Token (PAT) authentication support

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/JWTAuthorizationFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/JWTAuthorizationFilter.java
@@ -39,6 +39,13 @@ public class JWTAuthorizationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        // Skip JWT validation if already authenticated by PAT filter
+        if (SecurityContextHolder.getContext().getAuthentication() != null
+                && SecurityContextHolder.getContext().getAuthentication().isAuthenticated()) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         try {
             Claims claims = validateToken(request);
             if (claims != null) {

--- a/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
@@ -56,11 +56,18 @@ public class JWTTokenRefreshFilter extends OncePerRequestFilter {
         try {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             
-            if (authentication != null && authentication.isAuthenticated() 
+            if (authentication != null && authentication.isAuthenticated()
                     && authentication.getPrincipal() instanceof String) {
-                
+
+                // Skip token refresh for PAT-authenticated requests
+                Boolean isPATAuth = (Boolean) request.getAttribute(
+                    PATAuthorizationFilter.PAT_AUTH_ATTRIBUTE);
+                if (Boolean.TRUE.equals(isPATAuth)) {
+                    return;
+                }
+
                 String userId = (String) authentication.getPrincipal();
-                
+
                 // Skip token refresh for certain endpoints
                 String requestPath = request.getRequestURI();
                 if (shouldSkipRefresh(requestPath)) {

--- a/src/main/java/org/trackdev/api/configuration/PATAuthorizationFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/PATAuthorizationFilter.java
@@ -1,0 +1,98 @@
+package org.trackdev.api.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.trackdev.api.entity.PersonalAccessToken;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.model.ErrorEntity;
+import org.trackdev.api.service.PersonalAccessTokenService;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class PATAuthorizationFilter extends OncePerRequestFilter {
+
+    public static final String HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String PAT_PREFIX = PersonalAccessTokenService.TOKEN_PREFIX;
+    public static final String PAT_AUTH_ATTRIBUTE = "PAT_AUTHENTICATED";
+
+    private final PersonalAccessTokenService patService;
+
+    public PATAuthorizationFilter(PersonalAccessTokenService patService) {
+        this.patService = patService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                     FilterChain chain) throws ServletException, IOException {
+        String authHeader = request.getHeader(HEADER);
+
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            String token = authHeader.substring(BEARER_PREFIX.length());
+
+            if (token.startsWith(PAT_PREFIX)) {
+                try {
+                    PersonalAccessToken pat = patService.authenticate(token);
+                    if (pat != null) {
+                        User user = pat.getUser();
+                        var authorities = user.getRoles().stream()
+                            .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getUserType().name()))
+                            .collect(Collectors.toList());
+
+                        UsernamePasswordAuthenticationToken auth =
+                            new UsernamePasswordAuthenticationToken(
+                                user.getId(), null, authorities);
+
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                        request.setAttribute(PAT_AUTH_ATTRIBUTE, true);
+                    } else {
+                        SecurityContextHolder.clearContext();
+                        sendErrorResponse(response, "Invalid or expired personal access token");
+                        return;
+                    }
+                } catch (Exception e) {
+                    SecurityContextHolder.clearContext();
+                    sendErrorResponse(response, "PAT authentication error");
+                    return;
+                }
+
+                chain.doFilter(request, response);
+                return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, String message)
+            throws IOException {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(
+            DateFormattingConfiguration.SIMPLE_DATE_FORMAT);
+        ErrorEntity errorEntity = new ErrorEntity(
+            dateFormat.format(new Date()),
+            HttpStatus.UNAUTHORIZED.value(),
+            "Authentication error",
+            message);
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        PrintWriter out = response.getWriter();
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        out.print(new ObjectMapper().writeValueAsString(errorEntity));
+        out.flush();
+    }
+}

--- a/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
@@ -36,6 +36,9 @@ public class SecurityConfiguration {
     @Autowired
     private JWTTokenRefreshFilter jwtTokenRefreshFilter;
 
+    @Autowired
+    private PATAuthorizationFilter patAuthorizationFilter;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
@@ -58,6 +61,7 @@ public class SecurityConfiguration {
             .addFilterBefore(
                 new JWTAuthorizationFilter(authorizationConfiguration, cookieManager),
                 UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(patAuthorizationFilter, JWTAuthorizationFilter.class)
             .addFilterAfter(jwtTokenRefreshFilter, JWTAuthorizationFilter.class);
 
         return http.build();

--- a/src/main/java/org/trackdev/api/controller/GitHubRepoController.java
+++ b/src/main/java/org/trackdev/api/controller/GitHubRepoController.java
@@ -61,8 +61,8 @@ public class GitHubRepoController extends BaseController {
         return new GitHubRepoResponse(repo);
     }
 
-    @Operation(summary = "Update a GitHub repository", 
-               description = "Updates the name or access token of a GitHub repository")
+    @Operation(summary = "Update a GitHub repository",
+               description = "Updates the name, access token, or webhook secret of a GitHub repository")
     @PatchMapping("/{repoId}")
     public GitHubRepoResponse updateRepository(Principal principal,
                                                @PathVariable(name = "projectId") Long projectId,
@@ -70,7 +70,7 @@ public class GitHubRepoController extends BaseController {
                                                @Valid @RequestBody UpdateRepoRequest request) {
         String userId = getUserId(principal);
         GitHubRepo repo = gitHubRepoService.updateRepository(
-                projectId, repoId, request.name, request.accessToken, userId);
+                projectId, repoId, request.name, request.accessToken, request.webhookSecret, userId);
         return new GitHubRepoResponse(repo);
     }
 
@@ -138,6 +138,9 @@ public class GitHubRepoController extends BaseController {
 
         @Size(min = 1, max = GitHubRepo.MAX_TOKEN_LENGTH)
         public String accessToken;
+
+        @Size(min = 1, max = GitHubRepo.MAX_TOKEN_LENGTH)
+        public String webhookSecret;
     }
 
     static class GitHubRepoResponse {

--- a/src/main/java/org/trackdev/api/controller/PersonalAccessTokenController.java
+++ b/src/main/java/org/trackdev/api/controller/PersonalAccessTokenController.java
@@ -1,0 +1,91 @@
+package org.trackdev.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.trackdev.api.dto.PersonalAccessTokenCreatedDTO;
+import org.trackdev.api.dto.PersonalAccessTokenDTO;
+import org.trackdev.api.dto.PersonalAccessTokensResponseDTO;
+import org.trackdev.api.entity.PersonalAccessToken;
+import org.trackdev.api.model.CreatePersonalAccessTokenRequest;
+import org.trackdev.api.service.PersonalAccessTokenService;
+import org.trackdev.api.service.PersonalAccessTokenService.PersonalAccessTokenWithPlaintext;
+
+import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "1. Authentication")
+@RestController
+@RequestMapping(path = "/auth/tokens")
+public class PersonalAccessTokenController extends BaseController {
+
+    @Autowired
+    PersonalAccessTokenService patService;
+
+    @Operation(summary = "Create a personal access token",
+               description = "Creates a new PAT for the authenticated user. " +
+                             "The full token is returned ONLY in this response.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public PersonalAccessTokenCreatedDTO createToken(
+            Principal principal,
+            @Valid @RequestBody CreatePersonalAccessTokenRequest request) {
+        String userId = super.getUserId(principal);
+        PersonalAccessTokenWithPlaintext result = patService.createToken(
+            userId, request.name, request.expiresAt);
+        return toCreatedDTO(result);
+    }
+
+    @Operation(summary = "List personal access tokens",
+               description = "Lists all active (non-revoked) PATs for the authenticated user.")
+    @GetMapping
+    public PersonalAccessTokensResponseDTO listTokens(Principal principal) {
+        String userId = super.getUserId(principal);
+        List<PersonalAccessToken> tokens = patService.listTokens(userId);
+        List<PersonalAccessTokenDTO> dtos = tokens.stream()
+            .map(this::toDTO)
+            .collect(Collectors.toList());
+        return new PersonalAccessTokensResponseDTO(dtos);
+    }
+
+    @Operation(summary = "Revoke a personal access token",
+               description = "Revokes (disables) a specific PAT. This cannot be undone.")
+    @DeleteMapping(path = "/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void revokeToken(
+            Principal principal,
+            @PathVariable(name = "id") String id) {
+        String userId = super.getUserId(principal);
+        patService.revokeToken(id, userId);
+    }
+
+    private PersonalAccessTokenDTO toDTO(PersonalAccessToken pat) {
+        PersonalAccessTokenDTO dto = new PersonalAccessTokenDTO();
+        dto.setId(pat.getId());
+        dto.setName(pat.getName());
+        dto.setTokenPrefix(pat.getTokenPrefix());
+        dto.setExpiresAt(pat.getExpiresAt());
+        dto.setCreatedAt(pat.getCreatedAt());
+        dto.setLastUsedAt(pat.getLastUsedAt());
+        dto.setRevoked(pat.getRevoked());
+        return dto;
+    }
+
+    private PersonalAccessTokenCreatedDTO toCreatedDTO(PersonalAccessTokenWithPlaintext result) {
+        PersonalAccessTokenCreatedDTO dto = new PersonalAccessTokenCreatedDTO();
+        PersonalAccessToken pat = result.getToken();
+        dto.setId(pat.getId());
+        dto.setName(pat.getName());
+        dto.setToken(result.getPlaintextToken());
+        dto.setTokenPrefix(pat.getTokenPrefix());
+        dto.setExpiresAt(pat.getExpiresAt());
+        dto.setCreatedAt(pat.getCreatedAt());
+        return dto;
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/PersonalAccessTokenCreatedDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PersonalAccessTokenCreatedDTO.java
@@ -1,0 +1,14 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+import java.time.ZonedDateTime;
+
+@Data
+public class PersonalAccessTokenCreatedDTO {
+    private String id;
+    private String name;
+    private String token;
+    private String tokenPrefix;
+    private ZonedDateTime expiresAt;
+    private ZonedDateTime createdAt;
+}

--- a/src/main/java/org/trackdev/api/dto/PersonalAccessTokenDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PersonalAccessTokenDTO.java
@@ -1,0 +1,15 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+import java.time.ZonedDateTime;
+
+@Data
+public class PersonalAccessTokenDTO {
+    private String id;
+    private String name;
+    private String tokenPrefix;
+    private ZonedDateTime expiresAt;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime lastUsedAt;
+    private Boolean revoked;
+}

--- a/src/main/java/org/trackdev/api/dto/PersonalAccessTokensResponseDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PersonalAccessTokensResponseDTO.java
@@ -1,0 +1,13 @@
+package org.trackdev.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PersonalAccessTokensResponseDTO {
+    private List<PersonalAccessTokenDTO> tokens;
+}

--- a/src/main/java/org/trackdev/api/entity/PersonalAccessToken.java
+++ b/src/main/java/org/trackdev/api/entity/PersonalAccessToken.java
@@ -1,0 +1,89 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "personal_access_tokens")
+public class PersonalAccessToken extends BaseEntityUUID {
+
+    public static final int NAME_LENGTH = 100;
+    public static final int TOKEN_HASH_LENGTH = 64;
+    public static final int TOKEN_PREFIX_LENGTH = 10;
+
+    @NotNull
+    @Column(length = NAME_LENGTH)
+    private String name;
+
+    @NotNull
+    @Column(name = "token_hash", unique = true, length = TOKEN_HASH_LENGTH)
+    private String tokenHash;
+
+    @NotNull
+    @Column(name = "token_prefix", length = TOKEN_PREFIX_LENGTH)
+    private String tokenPrefix;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "expires_at", columnDefinition = "TIMESTAMP")
+    private ZonedDateTime expiresAt;
+
+    @NotNull
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private ZonedDateTime createdAt;
+
+    @Column(name = "last_used_at", columnDefinition = "TIMESTAMP")
+    private ZonedDateTime lastUsedAt;
+
+    @NotNull
+    private Boolean revoked = false;
+
+    public PersonalAccessToken() {}
+
+    public PersonalAccessToken(String name, String tokenHash, String tokenPrefix,
+                                User user, ZonedDateTime expiresAt) {
+        this.name = name;
+        this.tokenHash = tokenHash;
+        this.tokenPrefix = tokenPrefix;
+        this.user = user;
+        this.expiresAt = expiresAt;
+        this.createdAt = ZonedDateTime.now();
+        this.revoked = false;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getTokenHash() { return tokenHash; }
+    public void setTokenHash(String tokenHash) { this.tokenHash = tokenHash; }
+
+    public String getTokenPrefix() { return tokenPrefix; }
+    public void setTokenPrefix(String tokenPrefix) { this.tokenPrefix = tokenPrefix; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public ZonedDateTime getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(ZonedDateTime expiresAt) { this.expiresAt = expiresAt; }
+
+    public ZonedDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(ZonedDateTime createdAt) { this.createdAt = createdAt; }
+
+    public ZonedDateTime getLastUsedAt() { return lastUsedAt; }
+    public void setLastUsedAt(ZonedDateTime lastUsedAt) { this.lastUsedAt = lastUsedAt; }
+
+    public Boolean getRevoked() { return revoked; }
+    public void setRevoked(Boolean revoked) { this.revoked = revoked; }
+
+    public boolean isExpired() {
+        return expiresAt != null && ZonedDateTime.now().isAfter(expiresAt);
+    }
+
+    public boolean isValid() {
+        return !revoked && !isExpired();
+    }
+}

--- a/src/main/java/org/trackdev/api/model/CreatePersonalAccessTokenRequest.java
+++ b/src/main/java/org/trackdev/api/model/CreatePersonalAccessTokenRequest.java
@@ -1,0 +1,14 @@
+package org.trackdev.api.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.ZonedDateTime;
+
+public class CreatePersonalAccessTokenRequest {
+
+    @NotBlank
+    @Size(min = 1, max = 100)
+    public String name;
+
+    public ZonedDateTime expiresAt;
+}

--- a/src/main/java/org/trackdev/api/repository/PersonalAccessTokenRepository.java
+++ b/src/main/java/org/trackdev/api/repository/PersonalAccessTokenRepository.java
@@ -1,0 +1,18 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.PersonalAccessToken;
+import org.trackdev.api.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PersonalAccessTokenRepository extends BaseRepositoryUUID<PersonalAccessToken> {
+
+    Optional<PersonalAccessToken> findByTokenHashAndRevokedFalse(String tokenHash);
+
+    List<PersonalAccessToken> findByUserAndRevokedFalseOrderByCreatedAtDesc(User user);
+
+    List<PersonalAccessToken> findByUserOrderByCreatedAtDesc(User user);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/org/trackdev/api/service/GitHubRepoService.java
+++ b/src/main/java/org/trackdev/api/service/GitHubRepoService.java
@@ -104,7 +104,7 @@ public class GitHubRepoService extends BaseServiceLong<GitHubRepo, GitHubRepoRep
      * Update a GitHub repository.
      */
     @Transactional
-    public GitHubRepo updateRepository(Long projectId, Long repoId, String name, String accessToken, String userId) {
+    public GitHubRepo updateRepository(Long projectId, Long repoId, String name, String accessToken, String webhookSecret, String userId) {
         Project project = projectService.get(projectId);
         accessChecker.checkCanManageGitHubRepos(project, userId);
 
@@ -118,6 +118,10 @@ public class GitHubRepoService extends BaseServiceLong<GitHubRepo, GitHubRepoRep
         if (accessToken != null && !accessToken.isEmpty()) {
             gitHubRepo.setAccessToken(accessToken);
             validateRepositoryAccess(gitHubRepo);
+        }
+
+        if (webhookSecret != null && !webhookSecret.isEmpty()) {
+            gitHubRepo.setWebhookSecret(webhookSecret);
         }
 
         repo.save(gitHubRepo);

--- a/src/main/java/org/trackdev/api/service/PersonalAccessTokenService.java
+++ b/src/main/java/org/trackdev/api/service/PersonalAccessTokenService.java
@@ -1,0 +1,160 @@
+package org.trackdev.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.entity.PersonalAccessToken;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.repository.PersonalAccessTokenRepository;
+import org.trackdev.api.utils.ErrorConstants;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PersonalAccessTokenService
+        extends BaseServiceUUID<PersonalAccessToken, PersonalAccessTokenRepository> {
+
+    private static final Logger log = LoggerFactory.getLogger(PersonalAccessTokenService.class);
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+    public static final String TOKEN_PREFIX = "tdpat_";
+    public static final int TOKEN_RANDOM_BYTES = 48;
+    public static final int DISPLAY_PREFIX_LENGTH = 10;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private SecurityAuditLogger auditLogger;
+
+    private String generateToken() {
+        byte[] randomBytes = new byte[TOKEN_RANDOM_BYTES];
+        secureRandom.nextBytes(randomBytes);
+        return TOKEN_PREFIX + base64Encoder.encodeToString(randomBytes);
+    }
+
+    public static String hashToken(String plaintextToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(plaintextToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+
+    @Transactional
+    public PersonalAccessTokenWithPlaintext createToken(String userId, String name,
+                                                         ZonedDateTime expiresAt) {
+        User user = userService.get(userId);
+
+        if (expiresAt != null && expiresAt.isBefore(ZonedDateTime.now(ZoneId.of("UTC")))) {
+            throw new ServiceException(ErrorConstants.PAT_EXPIRATION_IN_PAST);
+        }
+
+        String plaintextToken = generateToken();
+        String tokenHash = hashToken(plaintextToken);
+        String displayPrefix = plaintextToken.substring(0,
+            Math.min(DISPLAY_PREFIX_LENGTH, plaintextToken.length()));
+
+        PersonalAccessToken pat = new PersonalAccessToken(
+            name, tokenHash, displayPrefix, user, expiresAt);
+        repo().save(pat);
+
+        log.info("PAT created for user: {}, name: {}", userId, name);
+        auditLogger.logAdminAction(userId, "PAT_CREATED", userId, "name=" + name);
+
+        return new PersonalAccessTokenWithPlaintext(pat, plaintextToken);
+    }
+
+    @Transactional
+    public PersonalAccessToken authenticate(String plaintextToken) {
+        String tokenHash = hashToken(plaintextToken);
+        Optional<PersonalAccessToken> optToken = repo().findByTokenHashAndRevokedFalse(tokenHash);
+
+        if (optToken.isEmpty()) {
+            return null;
+        }
+
+        PersonalAccessToken pat = optToken.get();
+
+        if (!pat.isValid()) {
+            return null;
+        }
+
+        User user = pat.getUser();
+        if (!user.getEnabled()) {
+            return null;
+        }
+
+        pat.setLastUsedAt(ZonedDateTime.now(ZoneId.of("UTC")));
+        repo().save(pat);
+
+        return pat;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PersonalAccessToken> listTokens(String userId) {
+        User user = userService.get(userId);
+        return repo().findByUserAndRevokedFalseOrderByCreatedAtDesc(user);
+    }
+
+    @Transactional
+    public void revokeToken(String tokenId, String userId) {
+        PersonalAccessToken pat = get(tokenId);
+
+        if (!pat.getUser().getId().equals(userId)) {
+            throw new org.trackdev.api.controller.exceptions.SecurityException(ErrorConstants.UNAUTHORIZED);
+        }
+
+        if (pat.getRevoked()) {
+            throw new ServiceException(ErrorConstants.PAT_ALREADY_REVOKED);
+        }
+
+        pat.setRevoked(true);
+        repo().save(pat);
+
+        log.info("PAT revoked for user: {}, tokenId: {}", userId, tokenId);
+        auditLogger.logAdminAction(userId, "PAT_REVOKED", userId, "tokenId=" + tokenId);
+    }
+
+    @Transactional
+    public void revokeAllTokensForUser(String userId) {
+        User user = userService.get(userId);
+        List<PersonalAccessToken> activeTokens =
+            repo().findByUserAndRevokedFalseOrderByCreatedAtDesc(user);
+        for (PersonalAccessToken pat : activeTokens) {
+            pat.setRevoked(true);
+            repo().save(pat);
+        }
+        if (!activeTokens.isEmpty()) {
+            log.info("All PATs revoked for user: {} (count: {})", userId, activeTokens.size());
+        }
+    }
+
+    public static class PersonalAccessTokenWithPlaintext {
+        private final PersonalAccessToken token;
+        private final String plaintextToken;
+
+        public PersonalAccessTokenWithPlaintext(PersonalAccessToken token, String plaintextToken) {
+            this.token = token;
+            this.plaintextToken = plaintextToken;
+        }
+
+        public PersonalAccessToken getToken() { return token; }
+        public String getPlaintextToken() { return plaintextToken; }
+    }
+}

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -193,5 +193,9 @@ public final class ErrorConstants {
     public static final String POINTS_REVIEW_CANNOT_ADD_ASSIGNEE = "error.points.review.cannot.add.assignee";
     public static final String POINTS_REVIEW_PARTICIPANT_ALREADY_ADDED = "error.points.review.participant.exists";
 
+    // PAT errors
+    public static final String PAT_EXPIRATION_IN_PAST = "error.pat.expiration.past";
+    public static final String PAT_ALREADY_REVOKED = "error.pat.already.revoked";
+
     public static final String EMPTY = "";
 }

--- a/src/main/resources/db/migration/V13__personal_access_tokens.sql
+++ b/src/main/resources/db/migration/V13__personal_access_tokens.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `personal_access_tokens` (
+    `id` varchar(36) NOT NULL,
+    `name` varchar(100) NOT NULL,
+    `token_hash` varchar(64) NOT NULL,
+    `token_prefix` varchar(10) NOT NULL,
+    `user_id` varchar(36) NOT NULL,
+    `expires_at` timestamp NULL,
+    `created_at` timestamp NOT NULL,
+    `last_used_at` timestamp NULL,
+    `revoked` bit(1) NOT NULL DEFAULT 0,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_pat_token_hash` (`token_hash`),
+    KEY `FK_pat_user` (`user_id`),
+    CONSTRAINT `FK_pat_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -214,3 +214,7 @@ error.points.review.message.not.found=Points review message not found
 error.points.review.edit.time.expired=Message can only be edited within 10 minutes of posting
 error.points.review.cannot.add.assignee=The task assignee cannot be added as a participant
 error.points.review.participant.exists=This user is already a participant in the conversation
+
+# PAT errors
+error.pat.expiration.past=Expiration date must be in the future
+error.pat.already.revoked=This token has already been revoked

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -215,3 +215,7 @@ error.points.review.message.not.found=No s'ha trobat el missatge de revisió de 
 error.points.review.edit.time.expired=El missatge només es pot editar en els 10 minuts posteriors a la publicació
 error.points.review.cannot.add.assignee=L'assignat de la tasca no es pot afegir com a participant
 error.points.review.participant.exists=Aquest usuari ja és participant de la conversa
+
+# Errors de PAT
+error.pat.expiration.past=La data de caducitat ha de ser en el futur
+error.pat.already.revoked=Aquest token ja ha estat revocat

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -214,3 +214,7 @@ error.points.review.message.not.found=No se ha encontrado el mensaje de revisió
 error.points.review.edit.time.expired=El mensaje solo se puede editar en los 10 minutos posteriores a su publicación
 error.points.review.cannot.add.assignee=El asignado de la tarea no se puede añadir como participante
 error.points.review.participant.exists=Este usuario ya es participante de la conversación
+
+# Errores de PAT
+error.pat.expiration.past=La fecha de caducidad debe ser en el futuro
+error.pat.already.revoked=Este token ya ha sido revocado


### PR DESCRIPTION
## Summary

This PR introduces Personal Access Token (PAT) authentication as an alternative to JWT-based authentication, allowing API clients (scripts, integrations, CI/CD pipelines) to authenticate using long-lived tokens. It also adds webhook secret support to GitHub repository configuration.

## Changes

### New PAT Authentication System
- **Entity & Migration**: Added `PersonalAccessToken` JPA entity and Flyway migration `V13__personal_access_tokens.sql` to create the `personal_access_tokens` table with fields for hashed token, prefix, expiry, revocation status, and audit timestamps.
- **Service**: `PersonalAccessTokenService` handles secure token generation (`tdpat_` prefixed, 48 random bytes, URL-safe Base64), SHA-256 hashing for storage, token authentication, and revocation logic.
- **Repository**: `PersonalAccessTokenRepository` provides lookup by token hash and user-scoped queries.
- **Controller**: `PersonalAccessTokenController` exposes `POST /auth/tokens`, `GET /auth/tokens`, and `DELETE /auth/tokens/{id}` endpoints.
- **DTOs**: `PersonalAccessTokenDTO`, `PersonalAccessTokenCreatedDTO` (includes plaintext token, returned only once on creation), and `PersonalAccessTokensResponseDTO`.

### Security Filter Chain Integration
- **`PATAuthorizationFilter`**: New `OncePerRequestFilter` that intercepts requests bearing a `tdpat_`-prefixed Bearer token, validates against the stored hash, and sets the Spring Security context.
- **`JWTAuthorizationFilter`**: Updated to skip JWT validation if the request is already authenticated (e.g., by PAT).
- **`JWTTokenRefreshFilter`**: Updated to skip token refresh for PAT-authenticated requests.
- **`SecurityConfiguration`**: `PATAuthorizationFilter` registered before `JWTAuthorizationFilter` in the filter chain.

### GitHub Repo — Webhook Secret Support
- `UpdateRepoRequest` now accepts an optional `webhookSecret` field.
- `GitHubRepoService.updateRepository` updated to persist the webhook secret when provided.

### i18n
- Added PAT error messages (`error.pat.expiration.past`, `error.pat.already.revoked`) in English, Spanish, and Catalan.

## Migration Notes

- **Database**: Flyway migration `V13__personal_access_tokens.sql` must run before deploying. In development (`create-drop` mode), this is handled automatically.
- Plaintext tokens are **never stored** — only a SHA-256 hash is persisted. The full token is returned only in the `POST /auth/tokens` response and cannot be retrieved afterwards.

## Testing Notes

- Create a PAT via `POST /api/auth/tokens` and use the returned token as a `Bearer` token in subsequent requests to verify PAT authentication works end-to-end.
- Verify that JWT token refresh headers are not issued for PAT-authenticated requests.
- Verify revoked tokens are rejected with `401 Unauthorized`.