### PR TITLE
Restrict personal access token endpoints to staff roles

### DIFF
--- a/src/main/java/org/trackdev/api/controller/PersonalAccessTokenController.java
+++ b/src/main/java/org/trackdev/api/controller/PersonalAccessTokenController.java
@@ -15,6 +15,7 @@ import org.trackdev.api.service.PersonalAccessTokenService;
 import org.trackdev.api.service.PersonalAccessTokenService.PersonalAccessTokenWithPlaintext;
 
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import java.security.Principal;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,7 @@ import java.util.stream.Collectors;
 @Tag(name = "1. Authentication")
 @RestController
 @RequestMapping(path = "/auth/tokens")
+@PreAuthorize("hasAnyRole('ADMIN', 'WORKSPACE_ADMIN', 'PROFESSOR')")
 public class PersonalAccessTokenController extends BaseController {
 
     @Autowired


### PR DESCRIPTION
## Summary

Adds a `@PreAuthorize` annotation to `PersonalAccessTokenController` to restrict all personal access token endpoints to users with the `ADMIN`, `WORKSPACE_ADMIN`, or `PROFESSOR` roles.

## Why

Students should not be able to create or manage personal access tokens, as these are intended for administrative and instructor use only. Previously, any authenticated user could access these endpoints.

## Changes

- Added `@PreAuthorize("hasAnyRole('ADMIN', 'WORKSPACE_ADMIN', 'PROFESSOR')")` at the class level on `PersonalAccessTokenController`, applying the restriction uniformly to all endpoints in the controller.

## Breaking Changes

Any `STUDENT` users who previously had access to `/auth/tokens` endpoints will now receive a `403 Forbidden` response.

## Testing

- Verify that `ADMIN`, `WORKSPACE_ADMIN`, and `PROFESSOR` users can still create and manage personal access tokens.
- Verify that `STUDENT` users receive `403 Forbidden` when accessing any `/auth/tokens` endpoint.