### PR TITLE
feat: verify webhook secret via GitHub ping before persisting

### DIFF
--- a/src/main/java/org/trackdev/api/controller/HookController.java
+++ b/src/main/java/org/trackdev/api/controller/HookController.java
@@ -15,6 +15,7 @@ import org.trackdev.api.entity.PullRequest;
 import org.trackdev.api.mapper.PullRequestMapper;
 import org.trackdev.api.repository.GitHubRepoRepository;
 import org.trackdev.api.service.PullRequestService;
+import org.trackdev.api.service.WebhookSecretVerifier;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -56,6 +57,9 @@ public class HookController extends BaseController {
     @Autowired
     PullRequestMapper pullRequestMapper;
 
+    @Autowired
+    WebhookSecretVerifier webhookSecretVerifier;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -73,6 +77,11 @@ public class HookController extends BaseController {
         
         log.info("Received GitHub webhook: event={}, delivery={}", event, deliveryId);
         
+        // Handle ping events for webhook secret verification
+        if ("ping".equals(event)) {
+            return handlePingEvent(rawPayload, signature);
+        }
+
         // Only process pull_request events
         if (!"pull_request".equals(event)) {
             log.debug("Ignoring non-pull_request event: {}", event);
@@ -272,6 +281,39 @@ public class HookController extends BaseController {
         return taskKeys;
     }
 
+    /**
+     * Handle GitHub ping events for webhook secret verification.
+     * When a ping arrives, checks if there's a pending secret verification
+     * for the repository and validates the signature against the candidate secret.
+     */
+    private ResponseEntity<WebhookResponse> handlePingEvent(String rawPayload, String signature) {
+        try {
+            GithubPingEvent pingEvent = objectMapper.readValue(rawPayload, GithubPingEvent.class);
+            String repoFullName = pingEvent.repository != null ? pingEvent.repository.full_name : null;
+
+            if (repoFullName == null) {
+                log.debug("Ping event missing repository info");
+                return ResponseEntity.ok(new WebhookResponse("ok", "Ping received"));
+            }
+
+            String[] parts = repoFullName.split("/");
+            if (parts.length != 2) {
+                return ResponseEntity.ok(new WebhookResponse("ok", "Ping received"));
+            }
+
+            List<GitHubRepo> repos = gitHubRepoRepository.findByOwnerAndRepoName(parts[0], parts[1]);
+            for (GitHubRepo repo : repos) {
+                webhookSecretVerifier.handlePing(repo.getId(), rawPayload, signature);
+            }
+
+            log.info("Ping event processed for {}", repoFullName);
+            return ResponseEntity.ok(new WebhookResponse("ok", "Ping received"));
+        } catch (Exception e) {
+            log.warn("Failed to process ping event: {}", e.getMessage());
+            return ResponseEntity.ok(new WebhookResponse("ok", "Ping received"));
+        }
+    }
+
     // ========== REQUEST/RESPONSE DTOs ==========
 
     static class WebhookResponse {
@@ -320,5 +362,12 @@ public class HookController extends BaseController {
     static class GithubRepo {
         public Long id;
         public String full_name;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class GithubPingEvent {
+        public Long hook_id;
+        public String zen;
+        public GithubRepo repository;
     }
 }

--- a/src/main/java/org/trackdev/api/service/GitHubRepoService.java
+++ b/src/main/java/org/trackdev/api/service/GitHubRepoService.java
@@ -19,6 +19,9 @@ import org.trackdev.api.configuration.WebhookProperties;
 import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Service for managing GitHub repositories linked to projects.
@@ -35,6 +38,9 @@ public class GitHubRepoService extends BaseServiceLong<GitHubRepo, GitHubRepoRep
 
     @Autowired
     private WebhookProperties webhookProperties;
+
+    @Autowired
+    private WebhookSecretVerifier webhookSecretVerifier;
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
@@ -121,7 +127,7 @@ public class GitHubRepoService extends BaseServiceLong<GitHubRepo, GitHubRepoRep
         }
 
         if (webhookSecret != null && !webhookSecret.isEmpty()) {
-            gitHubRepo.setWebhookSecret(webhookSecret);
+            verifyAndSetWebhookSecret(gitHubRepo, webhookSecret);
         }
 
         repo.save(gitHubRepo);
@@ -202,6 +208,56 @@ public class GitHubRepoService extends BaseServiceLong<GitHubRepo, GitHubRepoRep
         }
 
         return repo.findByOwnerAndRepoName(parts[0], parts[1]);
+    }
+
+    /**
+     * Verify a webhook secret by triggering a GitHub ping and checking the signature.
+     * Only saves the secret if the ping signature matches.
+     */
+    private void verifyAndSetWebhookSecret(GitHubRepo gitHubRepo, String secret) {
+        syncWebhookStatus(gitHubRepo);
+
+        if (gitHubRepo.getWebhookId() == null) {
+            throw new ServiceException(ErrorConstants.WEBHOOK_NOT_FOUND);
+        }
+
+        String owner = gitHubRepo.getOwner();
+        String repoName = gitHubRepo.getRepoName();
+        Long webhookId = gitHubRepo.getWebhookId();
+        Long repoId = gitHubRepo.getId();
+
+        CompletableFuture<Boolean> future = webhookSecretVerifier.startVerification(repoId, secret);
+
+        try {
+            // Trigger a ping from GitHub
+            HttpHeaders headers = createAuthHeaders(gitHubRepo.getAccessToken());
+            HttpEntity<String> request = new HttpEntity<>(headers);
+            String pingUrl = GithubConstants.getWebhookPingUrl(owner, repoName, webhookId);
+
+            restTemplate.exchange(pingUrl, HttpMethod.POST, request, String.class);
+
+            // Wait for the ping to arrive and be verified
+            boolean verified = future.get(10, TimeUnit.SECONDS);
+
+            if (verified) {
+                gitHubRepo.setWebhookSecret(secret);
+                log.info("Webhook secret verified and set for {}", gitHubRepo.getFullName());
+            } else {
+                throw new ServiceException(ErrorConstants.WEBHOOK_SECRET_INVALID);
+            }
+        } catch (TimeoutException e) {
+            throw new ServiceException(ErrorConstants.WEBHOOK_SECRET_VERIFICATION_TIMEOUT);
+        } catch (ServiceException e) {
+            throw e;
+        } catch (HttpClientErrorException e) {
+            log.warn("Failed to trigger ping for {}: {}", gitHubRepo.getFullName(), e.getMessage());
+            throw new ServiceException(ErrorConstants.API_GITHUB_KO, e);
+        } catch (Exception e) {
+            log.warn("Webhook secret verification failed for {}: {}", gitHubRepo.getFullName(), e.getMessage());
+            throw new ServiceException(ErrorConstants.WEBHOOK_SECRET_INVALID);
+        } finally {
+            webhookSecretVerifier.cancelVerification(repoId);
+        }
     }
 
     // ========== PRIVATE HELPER METHODS ==========

--- a/src/main/java/org/trackdev/api/service/WebhookSecretVerifier.java
+++ b/src/main/java/org/trackdev/api/service/WebhookSecretVerifier.java
@@ -1,0 +1,109 @@
+package org.trackdev.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Coordinates webhook secret verification via GitHub ping events.
+ *
+ * Flow:
+ * 1. Service calls startVerification(repoId, candidateSecret)
+ * 2. Service triggers a GitHub ping via API
+ * 3. HookController receives the ping and calls handlePing(repoId, payload, signature)
+ * 4. This class verifies the signature against the candidate secret
+ * 5. The CompletableFuture completes with true (match) or false (mismatch)
+ * 6. Service reads the result and saves or rejects the secret
+ */
+@Component
+public class WebhookSecretVerifier {
+
+    private static final Logger log = LoggerFactory.getLogger(WebhookSecretVerifier.class);
+
+    private final ConcurrentHashMap<Long, PendingVerification> pending = new ConcurrentHashMap<>();
+
+    /**
+     * Start a verification for the given repo. Returns a future that completes
+     * when the ping arrives (true = signature matches, false = mismatch).
+     */
+    public CompletableFuture<Boolean> startVerification(Long repoId, String candidateSecret) {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        pending.put(repoId, new PendingVerification(candidateSecret, future));
+        log.debug("Started webhook secret verification for repo {}", repoId);
+        return future;
+    }
+
+    /**
+     * Called by HookController when a ping event arrives.
+     * Returns true if this repo had a pending verification (handled), false otherwise.
+     */
+    public boolean handlePing(Long repoId, String rawPayload, String signature) {
+        PendingVerification verification = pending.get(repoId);
+        if (verification == null) {
+            return false;
+        }
+
+        boolean valid = verifySignature(rawPayload, signature, verification.secret);
+        verification.future.complete(valid);
+        log.info("Webhook secret verification for repo {}: {}", repoId, valid ? "SUCCESS" : "FAILED");
+        return true;
+    }
+
+    /**
+     * Cancel and clean up a pending verification.
+     */
+    public void cancelVerification(Long repoId) {
+        PendingVerification removed = pending.remove(repoId);
+        if (removed != null && !removed.future.isDone()) {
+            removed.future.complete(false);
+        }
+    }
+
+    /**
+     * Verify a GitHub webhook signature using HMAC-SHA256.
+     */
+    static boolean verifySignature(String payload, String signature, String secret) {
+        if (signature == null || !signature.startsWith("sha256=")) {
+            return false;
+        }
+
+        try {
+            Mac hmac = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKey = new SecretKeySpec(
+                    secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            hmac.init(secretKey);
+            byte[] hash = hmac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder sb = new StringBuilder("sha256=");
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+
+            return MessageDigest.isEqual(
+                    sb.toString().getBytes(StandardCharsets.UTF_8),
+                    signature.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            log.error("Failed to verify webhook signature", e);
+            return false;
+        }
+    }
+
+    private static class PendingVerification {
+        final String secret;
+        final CompletableFuture<Boolean> future;
+
+        PendingVerification(String secret, CompletableFuture<Boolean> future) {
+            this.secret = secret;
+            this.future = future;
+        }
+    }
+}

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -193,6 +193,11 @@ public final class ErrorConstants {
     public static final String POINTS_REVIEW_CANNOT_ADD_ASSIGNEE = "error.points.review.cannot.add.assignee";
     public static final String POINTS_REVIEW_PARTICIPANT_ALREADY_ADDED = "error.points.review.participant.exists";
 
+    // Webhook verification errors
+    public static final String WEBHOOK_NOT_FOUND = "error.webhook.not.found";
+    public static final String WEBHOOK_SECRET_INVALID = "error.webhook.secret.invalid";
+    public static final String WEBHOOK_SECRET_VERIFICATION_TIMEOUT = "error.webhook.secret.verification.timeout";
+
     // PAT errors
     public static final String PAT_EXPIRATION_IN_PAST = "error.pat.expiration.past";
     public static final String PAT_ALREADY_REVOKED = "error.pat.already.revoked";

--- a/src/main/java/org/trackdev/api/utils/GithubConstants.java
+++ b/src/main/java/org/trackdev/api/utils/GithubConstants.java
@@ -28,6 +28,11 @@ public final class GithubConstants {
     public static final String getWebhookUrl(String owner, String repo, Long hookId) {
         return getWebhooksUrl(owner, repo) + "/" + hookId;
     }
+
+    // Webhook ping endpoint - format: /repos/{owner}/{repo}/hooks/{hookId}/pings
+    public static String getWebhookPingUrl(String owner, String repo, Long hookId) {
+        return getWebhookUrl(owner, repo, hookId) + "/pings";
+    }
     
     // Commits endpoint - format: /repos/{owner}/{repo}/commits
     public static final String getCommitsUrl(String owner, String repo) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -215,6 +215,11 @@ error.points.review.edit.time.expired=Message can only be edited within 10 minut
 error.points.review.cannot.add.assignee=The task assignee cannot be added as a participant
 error.points.review.participant.exists=This user is already a participant in the conversation
 
+# Webhook verification errors
+error.webhook.not.found=No active webhook found on GitHub for this repository
+error.webhook.secret.invalid=Webhook secret verification failed. The secret does not match the one configured on GitHub.
+error.webhook.secret.verification.timeout=Webhook secret verification timed out. The ping from GitHub did not arrive in time.
+
 # PAT errors
 error.pat.expiration.past=Expiration date must be in the future
 error.pat.already.revoked=This token has already been revoked

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -216,6 +216,11 @@ error.points.review.edit.time.expired=El missatge només es pot editar en els 10
 error.points.review.cannot.add.assignee=L'assignat de la tasca no es pot afegir com a participant
 error.points.review.participant.exists=Aquest usuari ja és participant de la conversa
 
+# Errors de verificació de webhook
+error.webhook.not.found=No s'ha trobat cap webhook actiu a GitHub per a aquest repositori
+error.webhook.secret.invalid=La verificació del secret del webhook ha fallat. El secret no coincideix amb el configurat a GitHub.
+error.webhook.secret.verification.timeout=La verificació del secret del webhook ha expirat. El ping de GitHub no ha arribat a temps.
+
 # Errors de PAT
 error.pat.expiration.past=La data de caducitat ha de ser en el futur
 error.pat.already.revoked=Aquest token ja ha estat revocat

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -215,6 +215,11 @@ error.points.review.edit.time.expired=El mensaje solo se puede editar en los 10 
 error.points.review.cannot.add.assignee=El asignado de la tarea no se puede añadir como participante
 error.points.review.participant.exists=Este usuario ya es participante de la conversación
 
+# Errores de verificación de webhook
+error.webhook.not.found=No se encontró ningún webhook activo en GitHub para este repositorio
+error.webhook.secret.invalid=La verificación del secreto del webhook ha fallado. El secreto no coincide con el configurado en GitHub.
+error.webhook.secret.verification.timeout=La verificación del secreto del webhook ha expirado. El ping de GitHub no llegó a tiempo.
+
 # Errores de PAT
 error.pat.expiration.past=La fecha de caducidad debe ser en el futuro
 error.pat.already.revoked=Este token ya ha sido revocado


### PR DESCRIPTION
## Summary

Introduces a secure webhook secret verification flow that validates a candidate secret against GitHub before saving it. When a user sets a webhook secret on a linked repository, the system now triggers a GitHub ping event and checks that the HMAC-SHA256 signature matches, ensuring the secret is correct before persisting it.

## Changes

### Core verification flow
- **`WebhookSecretVerifier`** (new component): Coordinates async ping-based secret verification using `CompletableFuture` and a `ConcurrentHashMap` of pending verifications. Validates HMAC-SHA256 signatures and completes the future with `true` (match) or `false` (mismatch).
- **`GitHubRepoService`**: Replaced direct `setWebhookSecret()` with `verifyAndSetWebhookSecret()`, which triggers a GitHub ping and waits up to 10 seconds for the result before saving or rejecting the secret.
- **`HookController`**: Handles incoming GitHub `ping` events by delegating to `WebhookSecretVerifier`, enabling the verification future to complete when the ping arrives.

### Supporting changes
- **`GithubConstants`**: Added `getWebhookPingUrl()` helper to build the GitHub API endpoint for triggering webhook pings (`/repos/{owner}/{repo}/hooks/{hookId}/pings`).
- **`ErrorConstants`**: Added `WEBHOOK_NOT_FOUND`, `WEBHOOK_SECRET_INVALID`, and `WEBHOOK_SECRET_VERIFICATION_TIMEOUT` error key constants.
- **i18n**: Added error messages for all three new error keys in English, Spanish, and Catalan.

## Error cases

| Scenario | Error |
|----------|-------|
| No active webhook found on GitHub | `error.webhook.not.found` |
| Ping signature does not match candidate secret | `error.webhook.secret.invalid` |
| GitHub ping does not arrive within 10 seconds | `error.webhook.secret.verification.timeout` |

## Testing notes

To test manually: set a webhook secret on a linked repository via the API. Use a correct secret (should save successfully) and an incorrect secret (should return a validation error). Ensure the GitHub webhook is active and the application is reachable from GitHub for the ping to arrive.