### PR TITLE
refactor(sanitizer): Remove forward slash escaping from HtmlSanitizer

### DIFF
--- a/src/main/java/org/trackdev/api/utils/HtmlSanitizer.java
+++ b/src/main/java/org/trackdev/api/utils/HtmlSanitizer.java
@@ -42,9 +42,6 @@ public final class HtmlSanitizer {
                 case '&':
                     sanitized.append("&amp;");
                     break;
-                case '/':
-                    sanitized.append("&#x2F;");
-                    break;
                 default:
                     sanitized.append(c);
             }


### PR DESCRIPTION
## Summary

Removes the escaping of forward slash (`/`) characters in `HtmlSanitizer`. Previously, `/` was encoded as `&#x2F;`, which is not required for XSS prevention in most contexts and can cause issues with URLs and paths being unnecessarily encoded in sanitized output.

## Why

Escaping `/` as `&#x2F;` is an OWASP recommendation for inline JavaScript contexts, but it is unnecessary for general HTML content and can corrupt URLs, file paths, and other slash-delimited data stored or displayed in the application.

## Breaking Changes

None. This is a non-breaking change — existing data is unaffected. New content containing `/` will no longer be encoded, which is the correct behavior.

## Testing Notes

Verify that strings containing forward slashes (e.g., URLs, paths) are stored and displayed without unnecessary encoding after this change.