### PR TITLE
Relax task deletion constraints to include BACKLOG status and TODO-on...

### DIFF
--- a/src/main/java/org/trackdev/api/service/AccessChecker.java
+++ b/src/main/java/org/trackdev/api/service/AccessChecker.java
@@ -996,8 +996,8 @@ public class AccessChecker {
     /**
      * Compute canDelete permission.
      * Professor, assignee, or reporter can delete.
-     * USER_STORY can only be deleted if it has no subtasks.
-     * TASK/BUG can only be deleted if status is TODO or INPROGRESS.
+     * USER_STORY can only be deleted if all its subtasks are in TODO status.
+     * TASK/BUG can only be deleted if status is BACKLOG, TODO or INPROGRESS.
      */
     public boolean canDeleteTask(org.trackdev.api.entity.Task task, String userId) {
         boolean isProfessor = isProfessorForTask(task, userId);
@@ -1013,13 +1013,16 @@ public class AccessChecker {
         if (!isProfessor && !isTaskAssignee(task, userId) && !isTaskReporter(task, userId)) {
             return false;
         }
-        // USER_STORY: can only delete if no subtasks
+        // USER_STORY: can only delete if all subtasks are in TODO status
         if (task.getTaskType() == TaskType.USER_STORY) {
             Collection<org.trackdev.api.entity.Task> children = task.getChildTasks();
-            return children == null || children.isEmpty();
+            if (children == null || children.isEmpty()) {
+                return true;
+            }
+            return children.stream().allMatch(child -> child.getStatus() == TaskStatus.TODO);
         }
-        // TASK/BUG: can only delete if status is TODO or INPROGRESS
-        return task.getStatus() == TaskStatus.TODO || task.getStatus() == TaskStatus.INPROGRESS;
+        // TASK/BUG: can only delete if status is BACKLOG, TODO or INPROGRESS
+        return task.getStatus() == TaskStatus.BACKLOG || task.getStatus() == TaskStatus.TODO || task.getStatus() == TaskStatus.INPROGRESS;
     }
 
     /**

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -724,13 +724,17 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
 
         // Validate delete constraints
         if (task.getTaskType() == TaskType.USER_STORY) {
-            // USER_STORY can only be deleted if it has no subtasks
-            if (task.getChildTasks() != null && !task.getChildTasks().isEmpty()) {
-                throw new ServiceException(ErrorConstants.USER_STORY_HAS_SUBTASKS_CANNOT_DELETE);
+            // USER_STORY can only be deleted if all subtasks are in TODO status
+            Collection<Task> children = task.getChildTasks();
+            if (children != null && !children.isEmpty()) {
+                boolean allTodo = children.stream().allMatch(child -> child.getStatus() == TaskStatus.TODO);
+                if (!allTodo) {
+                    throw new ServiceException(ErrorConstants.USER_STORY_SUBTASKS_NOT_TODO_CANNOT_DELETE);
+                }
             }
         } else {
-            // TASK or BUG can only be deleted if status is TODO or INPROGRESS
-            if (task.getStatus() != TaskStatus.TODO && task.getStatus() != TaskStatus.INPROGRESS) {
+            // TASK or BUG can only be deleted if status is BACKLOG, TODO or INPROGRESS
+            if (task.getStatus() != TaskStatus.BACKLOG && task.getStatus() != TaskStatus.TODO && task.getStatus() != TaskStatus.INPROGRESS) {
                 throw new ServiceException(ErrorConstants.TASK_STATUS_CANNOT_DELETE);
             }
         }

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -60,6 +60,7 @@ public final class ErrorConstants {
     public static final String BUG_CANNOT_CHANGE_TYPE = "error.task.bug.cannot.change.type";
     public static final String USER_STORY_CANNOT_CHANGE_TYPE = "error.task.user.story.cannot.change.type";
     public static final String USER_STORY_HAS_SUBTASKS_CANNOT_DELETE = "error.task.user.story.has.subtasks.delete";
+    public static final String USER_STORY_SUBTASKS_NOT_TODO_CANNOT_DELETE = "error.task.user.story.subtasks.not.todo.delete";
     public static final String TASK_STATUS_CANNOT_DELETE = "error.task.status.cannot.delete";
     
     // Project errors

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -96,7 +96,8 @@ error.task.invalid.status.transition=Invalid status transition
 error.task.bug.cannot.change.type=A BUG task cannot change its type
 error.task.user.story.cannot.change.type=A USER_STORY cannot change its type
 error.task.user.story.has.subtasks.delete=A USER_STORY cannot be deleted while it has subtasks
-error.task.status.cannot.delete=A task can only be deleted when its status is TODO or INPROGRESS
+error.task.user.story.subtasks.not.todo.delete=A USER_STORY can only be deleted when all its subtasks are in TODO status
+error.task.status.cannot.delete=A task can only be deleted when its status is BACKLOG, TODO or INPROGRESS
 
 # Project errors
 error.project.no.members=Project must have at least one member

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -96,7 +96,8 @@ error.task.invalid.status.transition=Transició d'estat no vàlida
 error.task.bug.cannot.change.type=Una tasca de tipus BUG no pot canviar el seu tipus
 error.task.user.story.cannot.change.type=Una USER_STORY no pot canviar el seu tipus
 error.task.user.story.has.subtasks.delete=Una USER_STORY no es pot eliminar mentre tingui subtasques
-error.task.status.cannot.delete=Una tasca només es pot eliminar quan el seu estat és TODO o INPROGRESS
+error.task.user.story.subtasks.not.todo.delete=Una USER_STORY només es pot eliminar quan totes les seves subtasques estan en estat TODO
+error.task.status.cannot.delete=Una tasca només es pot eliminar quan el seu estat és BACKLOG, TODO o INPROGRESS
 
 # Errors de projectes
 error.project.no.members=El projecte ha de tenir almenys un membre

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -96,7 +96,8 @@ error.task.invalid.status.transition=Transición de estado no válida
 error.task.bug.cannot.change.type=Una tarea de tipo BUG no puede cambiar su tipo
 error.task.user.story.cannot.change.type=Una USER_STORY no puede cambiar su tipo
 error.task.user.story.has.subtasks.delete=Una USER_STORY no se puede eliminar mientras tenga subtareas
-error.task.status.cannot.delete=Una tarea solo se puede eliminar cuando su estado es TODO o INPROGRESS
+error.task.user.story.subtasks.not.todo.delete=Una USER_STORY solo se puede eliminar cuando todas sus subtareas están en estado TODO
+error.task.status.cannot.delete=Una tarea solo se puede eliminar cuando su estado es BACKLOG, TODO o INPROGRESS
 
 # Errores de proyectos
 error.project.no.members=El proyecto debe tener al menos un miembro

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.*;
  * - canEditSprint: USER_STORY with subtasks cannot, DONE status blocked, PAST sprint escape allowed
  * - canEditType: USER_STORY and BUG cannot change type
  * - canEditEstimation: Only TASK/BUG can edit (USER_STORY is computed)
- * - canDelete: USER_STORY needs no subtasks, TASK/BUG needs TODO/INPROGRESS
+ * - canDelete: USER_STORY needs all subtasks in TODO, TASK/BUG needs BACKLOG/TODO/INPROGRESS
  * - canSelfAssign: Only unassigned, only students, only project members
  * - canUnassign: Only assignee or professor
  * - canAddSubtask: Only USER_STORY, only project members or professor
@@ -504,11 +504,23 @@ class AccessCheckerTaskPermissionsTest {
     class CanDeleteTaskTests {
 
         @Test
-        @DisplayName("USER_STORY with subtasks should NOT be deletable")
-        void userStoryWithSubtasks_shouldNotBeDeletable() {
-            Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.TODO);
-            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask));
-            
+        @DisplayName("USER_STORY with subtasks all in TODO SHOULD be deletable")
+        void userStoryWithSubtasksAllTodo_shouldBeDeletable() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
+            Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.TODO);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
+
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "student-id"));
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY with subtasks NOT all in TODO should NOT be deletable")
+        void userStoryWithSubtasksNotAllTodo_shouldNotBeDeletable() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
+            Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.INPROGRESS);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
+
             assertFalse(accessChecker.canDeleteTask(userStoryTask, "student-id"));
             assertFalse(accessChecker.canDeleteTask(userStoryTask, "professor-id"));
         }
@@ -518,6 +530,13 @@ class AccessCheckerTaskPermissionsTest {
         void userStoryWithoutSubtasks_shouldBeDeletable() {
             ReflectionTestUtils.setField(userStoryTask, "childTasks", new ArrayList<>());
             assertTrue(accessChecker.canDeleteTask(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in BACKLOG status SHOULD be deletable")
+        void taskInBacklogStatus_shouldBeDeletable() {
+            taskTask.setStatus(TaskStatus.BACKLOG);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
         @Test
@@ -914,8 +933,8 @@ class AccessCheckerTaskPermissionsTest {
             // Estimation never editable
             assertFalse(accessChecker.canEditEstimation(userStoryTask, "admin-id"));
             
-            // Delete blocked if has subtasks
-            Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.TODO);
+            // Delete blocked if has subtasks not in TODO
+            Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.INPROGRESS);
             ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask));
             assertFalse(accessChecker.canDeleteTask(userStoryTask, "admin-id"));
         }


### PR DESCRIPTION
## Summary

Tasks of type TASK or BUG can now be deleted when in BACKLOG status, in addition to TODO and INPROGRESS. USER_STORY deletion is now allowed when all subtasks are in TODO status, replacing the previous rule that required the user story to have no subtasks at all. Error messages and i18n resources were updated to reflect the new rules.

## Commits

- `cd7ec3c` feat(service): update task deletion permission rules for statuses
- `f9f39ac` feat(service): update task deletion rules for status constraints
- `b75e57f` feat(utils): update error constants with subtask status delete key
- `62d4449` chore(resources): update task deletion status error messages
- `bf5400c` chore(resources): update catalan task delete status error messages
- `9d05802` chore(resources): update spanish task delete status error messages
- `86fd734` test(service): update canDelete tests for backlog/todo status constraints

## Files changed

- `src/main/java/org/trackdev/api/service/AccessChecker.java`
- `src/main/java/org/trackdev/api/service/TaskService.java`
- `src/main/java/org/trackdev/api/utils/ErrorConstants.java`
- `src/main/resources/messages.properties`
- `src/main/resources/messages_ca.properties`
- `src/main/resources/messages_es.properties`
- `src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java`
