### PR TITLE
Refactor production Flyway initialization to use test-migration profile

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/DataInitializer.java
+++ b/src/main/java/org/trackdev/api/configuration/DataInitializer.java
@@ -53,7 +53,6 @@ public class DataInitializer implements CommandLineRunner {
             // Production mode: Flyway was deferred by AfterMigrateCallback (no-op strategy).
             // Now JPA is ready, so we can run migrations in stages with data seeding in between.
             logger.info("Running production initialization (Flyway + data seeding)...");
-            runFlywayWithDataSeeding();
             ensureAdminUserExists();
         }
     }

--- a/src/main/java/org/trackdev/api/configuration/flywaydb/AfterMigrateCallback.java
+++ b/src/main/java/org/trackdev/api/configuration/flywaydb/AfterMigrateCallback.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  * we allow JPA to initialize first, then run: partial migration → seed → remaining migration.
  */
 @Component
-@Profile("prod")
+@Profile("test-migration")
 public class AfterMigrateCallback implements FlywayMigrationStrategy {
 
     @Override


### PR DESCRIPTION
## Summary

The AfterMigrateCallback no-op migration strategy was changed from the prod profile to a new test-migration profile, and DataInitializer was updated to skip calling the staged Flyway seeding logic in production, now only ensuring an admin user exists. This separates the staged migration-with-seeding flow into an explicit opt-in profile for controlled testing.

## Commits

- `27e96dc` feat(configuration): update data initializer to skip flyway seeding call
- `290b1fa` feat(flywaydb): update active profile to test-migration

## Files changed

- `src/main/java/org/trackdev/api/configuration/DataInitializer.java`
- `src/main/java/org/trackdev/api/configuration/flywaydb/AfterMigrateCallback.java`
