### PR TITLE
Enforce role-based task delete rules and auto-transition on sprint as...

### DIFF
--- a/src/main/java/org/trackdev/api/service/AccessChecker.java
+++ b/src/main/java/org/trackdev/api/service/AccessChecker.java
@@ -331,22 +331,16 @@ public class AccessChecker {
 
     /**
      * Check if user can delete a task. Allowed for:
+     * - Professor (course owner, subject owner) or Admin
      * - Task assignee
-     * - Task reporter (creator)
-     * - Professor (course owner, subject owner)
-     * - Admin
      */
     public void checkCanDeleteTask(org.trackdev.api.entity.Task task, String userId) {
-        // Task assignee can delete
-        if (isTaskAssignee(task, userId)) {
-            return;
-        }
-        // Task reporter can delete their own task
-        if (isTaskReporter(task, userId)) {
-            return;
-        }
         // Professor (course owner, subject owner) or admin can delete
         if (isProfessorForTask(task, userId)) {
+            return;
+        }
+        // Task assignee can delete
+        if (isTaskAssignee(task, userId)) {
             return;
         }
         throw new ServiceException(ErrorConstants.UNAUTHORIZED);
@@ -1009,20 +1003,27 @@ public class AccessChecker {
         if (isTaskInPastSprintOnly(task) && !isProfessor) {
             return false;
         }
-        // Professor, assignee, or reporter can delete
-        if (!isProfessor && !isTaskAssignee(task, userId) && !isTaskReporter(task, userId)) {
+        // Professor can delete any task regardless of state or assignee
+        if (isProfessor) {
+            return true;
+        }
+        // Student: must be assignee (not just reporter)
+        if (!isTaskAssignee(task, userId)) {
             return false;
         }
-        // USER_STORY: can only delete if all subtasks are in TODO status
+        // USER_STORY + student: all subtasks must be TODO and assigned to this student
         if (task.getTaskType() == TaskType.USER_STORY) {
             Collection<org.trackdev.api.entity.Task> children = task.getChildTasks();
             if (children == null || children.isEmpty()) {
                 return true;
             }
-            return children.stream().allMatch(child -> child.getStatus() == TaskStatus.TODO);
+            return children.stream().allMatch(child ->
+                    child.getStatus() == TaskStatus.TODO
+                    && child.getAssignee() != null
+                    && child.getAssignee().getId().equals(userId));
         }
-        // TASK/BUG: can only delete if status is BACKLOG, TODO or INPROGRESS
-        return task.getStatus() == TaskStatus.BACKLOG || task.getStatus() == TaskStatus.TODO || task.getStatus() == TaskStatus.INPROGRESS;
+        // TASK/BUG + student: cannot delete if status is DONE
+        return task.getStatus() != TaskStatus.DONE;
     }
 
     /**

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -531,7 +531,13 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             task.setActiveSprints(sprints);
             sprints.stream().forEach(sprint -> sprint.addTask(task, user));
             changes.add(new TaskActiveSprintsChange(user, task, oldValues, newValues));
-            
+
+            // Auto-transition BACKLOG → TODO when assigning to a sprint
+            if (!sprintsIds.isEmpty() && task.getStatus() == TaskStatus.BACKLOG) {
+                task.forceSetStatus(TaskStatus.TODO);
+                changes.add(new TaskStatusChange(user, task, TaskStatus.BACKLOG.toString(), TaskStatus.TODO.toString()));
+            }
+
             // For USER_STORY: cascade sprint assignment to all subtasks
             if (task.getTaskType() == TaskType.USER_STORY && task.getChildTasks() != null) {
                 for (Task subtask : task.getChildTasks()) {
@@ -540,6 +546,10 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
                     // Assign to new sprints
                     subtask.setActiveSprints(new ArrayList<>(sprints));
                     sprints.stream().forEach(sprint -> sprint.addTask(subtask, user));
+                    // Auto-transition subtasks BACKLOG → TODO
+                    if (subtask.getStatus() == TaskStatus.BACKLOG) {
+                        subtask.forceSetStatus(TaskStatus.TODO);
+                    }
                     repo.save(subtask);
                 }
             }
@@ -722,19 +732,26 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         // Only task assignee, reporter, professor, or admin can delete tasks
         accessChecker.checkCanDeleteTask(task, userId);
 
-        // Validate delete constraints
+        // Validate delete constraints (professor can delete any task)
+        boolean isProfessor = accessChecker.isProfessorForTask(task, userId);
         if (task.getTaskType() == TaskType.USER_STORY) {
-            // USER_STORY can only be deleted if all subtasks are in TODO status
             Collection<Task> children = task.getChildTasks();
-            if (children != null && !children.isEmpty()) {
+            if (!isProfessor && children != null && !children.isEmpty()) {
+                // Student: all subtasks must be in TODO status
                 boolean allTodo = children.stream().allMatch(child -> child.getStatus() == TaskStatus.TODO);
                 if (!allTodo) {
                     throw new ServiceException(ErrorConstants.USER_STORY_SUBTASKS_NOT_TODO_CANNOT_DELETE);
                 }
+                // Student: all subtasks must be assigned to this student
+                boolean allAssigned = children.stream().allMatch(child ->
+                        child.getAssignee() != null && child.getAssignee().getId().equals(userId));
+                if (!allAssigned) {
+                    throw new ServiceException(ErrorConstants.USER_STORY_SUBTASKS_NOT_ASSIGNED_CANNOT_DELETE);
+                }
             }
         } else {
-            // TASK or BUG can only be deleted if status is BACKLOG, TODO or INPROGRESS
-            if (task.getStatus() != TaskStatus.BACKLOG && task.getStatus() != TaskStatus.TODO && task.getStatus() != TaskStatus.INPROGRESS) {
+            // TASK or BUG: student cannot delete if status is DONE
+            if (!isProfessor && task.getStatus() == TaskStatus.DONE) {
                 throw new ServiceException(ErrorConstants.TASK_STATUS_CANNOT_DELETE);
             }
         }

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -62,6 +62,7 @@ public final class ErrorConstants {
     public static final String USER_STORY_HAS_SUBTASKS_CANNOT_DELETE = "error.task.user.story.has.subtasks.delete";
     public static final String USER_STORY_SUBTASKS_NOT_TODO_CANNOT_DELETE = "error.task.user.story.subtasks.not.todo.delete";
     public static final String TASK_STATUS_CANNOT_DELETE = "error.task.status.cannot.delete";
+    public static final String USER_STORY_SUBTASKS_NOT_ASSIGNED_CANNOT_DELETE = "error.task.user.story.subtasks.not.assigned.delete";
     
     // Project errors
     public static final String PRJ_WITHOUT_MEMBERS = "error.project.no.members";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -97,7 +97,8 @@ error.task.bug.cannot.change.type=A BUG task cannot change its type
 error.task.user.story.cannot.change.type=A USER_STORY cannot change its type
 error.task.user.story.has.subtasks.delete=A USER_STORY cannot be deleted while it has subtasks
 error.task.user.story.subtasks.not.todo.delete=A USER_STORY can only be deleted when all its subtasks are in TODO status
-error.task.status.cannot.delete=A task can only be deleted when its status is BACKLOG, TODO or INPROGRESS
+error.task.status.cannot.delete=A task cannot be deleted when its status is DONE
+error.task.user.story.subtasks.not.assigned.delete=A USER_STORY can only be deleted when all its subtasks are assigned to you
 
 # Project errors
 error.project.no.members=Project must have at least one member

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -97,7 +97,8 @@ error.task.bug.cannot.change.type=Una tasca de tipus BUG no pot canviar el seu t
 error.task.user.story.cannot.change.type=Una USER_STORY no pot canviar el seu tipus
 error.task.user.story.has.subtasks.delete=Una USER_STORY no es pot eliminar mentre tingui subtasques
 error.task.user.story.subtasks.not.todo.delete=Una USER_STORY només es pot eliminar quan totes les seves subtasques estan en estat TODO
-error.task.status.cannot.delete=Una tasca només es pot eliminar quan el seu estat és BACKLOG, TODO o INPROGRESS
+error.task.status.cannot.delete=Una tasca no es pot eliminar quan el seu estat és DONE
+error.task.user.story.subtasks.not.assigned.delete=Una USER_STORY només es pot eliminar quan totes les seves subtasques estan assignades a tu
 
 # Errors de projectes
 error.project.no.members=El projecte ha de tenir almenys un membre

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -97,7 +97,8 @@ error.task.bug.cannot.change.type=Una tarea de tipo BUG no puede cambiar su tipo
 error.task.user.story.cannot.change.type=Una USER_STORY no puede cambiar su tipo
 error.task.user.story.has.subtasks.delete=Una USER_STORY no se puede eliminar mientras tenga subtareas
 error.task.user.story.subtasks.not.todo.delete=Una USER_STORY solo se puede eliminar cuando todas sus subtareas están en estado TODO
-error.task.status.cannot.delete=Una tarea solo se puede eliminar cuando su estado es BACKLOG, TODO o INPROGRESS
+error.task.status.cannot.delete=Una tarea no se puede eliminar cuando su estado es DONE
+error.task.user.story.subtasks.not.assigned.delete=Una USER_STORY solo se puede eliminar cuando todas sus subtareas están asignadas a ti
 
 # Errores de proyectos
 error.project.no.members=El proyecto debe tener al menos un miembro

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -158,7 +158,7 @@ class AccessCheckerTaskPermissionsTest {
         ReflectionTestUtils.setField(task, "id", id);
         task.setName(name);
         task.setType(type);
-        task.setStatus(status);
+        ReflectionTestUtils.setField(task, "status", status);
         task.setProject(project);
         task.setReporter(studentUser);
         task.setAssignee(studentUser);
@@ -368,14 +368,14 @@ class AccessCheckerTaskPermissionsTest {
         @Test
         @DisplayName("TASK in DONE status should NOT edit sprint (student)")
         void taskInDoneStatus_shouldNotEditSprintByStudent() {
-            taskTask.setStatus(TaskStatus.DONE);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.DONE);
             assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
         }
 
         @Test
         @DisplayName("TASK in DONE status SHOULD edit sprint by professor")
         void taskInDoneStatus_shouldEditSprintByProfessor() {
-            taskTask.setStatus(TaskStatus.DONE);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.DONE);
             assertTrue(accessChecker.canEditSprint(taskTask, "professor-id"));
         }
 
@@ -383,7 +383,7 @@ class AccessCheckerTaskPermissionsTest {
         @DisplayName("TASK in PAST sprint (not DONE) SHOULD edit sprint to escape")
         void taskInPastSprintNotDone_shouldEditSprintToEscape() {
             ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
-            taskTask.setStatus(TaskStatus.INPROGRESS);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.INPROGRESS);
             assertTrue(accessChecker.canEditSprint(taskTask, "student-id"));
         }
 
@@ -391,7 +391,7 @@ class AccessCheckerTaskPermissionsTest {
         @DisplayName("TASK in PAST sprint with DONE status should NOT edit sprint (student)")
         void taskInPastSprintDone_shouldNotEditSprintByStudent() {
             ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
-            taskTask.setStatus(TaskStatus.DONE);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.DONE);
             assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
         }
 
@@ -515,14 +515,23 @@ class AccessCheckerTaskPermissionsTest {
         }
 
         @Test
-        @DisplayName("USER_STORY with subtasks NOT all in TODO should NOT be deletable")
-        void userStoryWithSubtasksNotAllTodo_shouldNotBeDeletable() {
+        @DisplayName("USER_STORY with subtasks NOT all in TODO should NOT be deletable by student")
+        void userStoryWithSubtasksNotAllTodo_shouldNotBeDeletableByStudent() {
             Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
             Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.INPROGRESS);
             ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
 
             assertFalse(accessChecker.canDeleteTask(userStoryTask, "student-id"));
-            assertFalse(accessChecker.canDeleteTask(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY with subtasks NOT all in TODO SHOULD be deletable by professor")
+        void userStoryWithSubtasksNotAllTodo_shouldBeDeletableByProfessor() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
+            Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.INPROGRESS);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
+
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "professor-id"));
         }
 
         @Test
@@ -535,35 +544,35 @@ class AccessCheckerTaskPermissionsTest {
         @Test
         @DisplayName("TASK in BACKLOG status SHOULD be deletable")
         void taskInBacklogStatus_shouldBeDeletable() {
-            taskTask.setStatus(TaskStatus.BACKLOG);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.BACKLOG);
             assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
         @Test
         @DisplayName("TASK in TODO status SHOULD be deletable")
         void taskInTodoStatus_shouldBeDeletable() {
-            taskTask.setStatus(TaskStatus.TODO);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO);
             assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
         @Test
         @DisplayName("TASK in INPROGRESS status SHOULD be deletable")
         void taskInInProgressStatus_shouldBeDeletable() {
-            taskTask.setStatus(TaskStatus.INPROGRESS);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.INPROGRESS);
             assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
         @Test
-        @DisplayName("TASK in VERIFY status should NOT be deletable")
-        void taskInVerifyStatus_shouldNotBeDeletable() {
-            taskTask.setStatus(TaskStatus.VERIFY);
-            assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
+        @DisplayName("TASK in VERIFY status SHOULD be deletable by student")
+        void taskInVerifyStatus_shouldBeDeletableByStudent() {
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.VERIFY);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
         @Test
         @DisplayName("TASK in DONE status should NOT be deletable")
         void taskInDoneStatus_shouldNotBeDeletable() {
-            taskTask.setStatus(TaskStatus.DONE);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.DONE);
             assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
@@ -578,7 +587,7 @@ class AccessCheckerTaskPermissionsTest {
         @DisplayName("Frozen TASK in TODO SHOULD be deletable by professor")
         void frozenTaskInTodo_shouldBeDeletableByProfessor() {
             taskTask.setFrozen(true);
-            taskTask.setStatus(TaskStatus.TODO);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO);
             assertTrue(accessChecker.canDeleteTask(taskTask, "professor-id"));
         }
 
@@ -595,7 +604,7 @@ class AccessCheckerTaskPermissionsTest {
             // Student is reporter but not assignee
             taskTask.setReporter(studentUser);
             taskTask.setAssignee(null);  // Unassigned
-            taskTask.setStatus(TaskStatus.TODO);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO);
             assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
@@ -605,7 +614,7 @@ class AccessCheckerTaskPermissionsTest {
             // Student was assignee, now unassigned
             taskTask.setReporter(studentUser);  // Still reporter
             taskTask.setAssignee(null);  // No longer assignee
-            taskTask.setStatus(TaskStatus.TODO);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO);
             assertFalse(accessChecker.canDeleteTask(taskTask, "student-id"));
         }
 
@@ -613,8 +622,65 @@ class AccessCheckerTaskPermissionsTest {
         @DisplayName("Current assignee SHOULD be able to delete (TODO status)")
         void currentAssignee_shouldDelete() {
             taskTask.setAssignee(studentUser);
-            taskTask.setStatus(TaskStatus.TODO);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO);
             assertTrue(accessChecker.canDeleteTask(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY + student: subtasks TODO but not all assigned to student should NOT be deletable")
+        void userStorySubtasksTodoButNotAssigned_shouldNotBeDeletableByStudent() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
+            Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.TODO);
+            subtask2.setAssignee(otherStudentUser);  // Assigned to someone else
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
+
+            assertFalse(accessChecker.canDeleteTask(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY + student: subtasks TODO and all assigned to student SHOULD be deletable")
+        void userStorySubtasksTodoAndAssigned_shouldBeDeletableByStudent() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
+            Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.TODO);
+            // Both subtasks assigned to studentUser (default from createTask)
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
+
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY + professor: subtasks in mixed states SHOULD be deletable")
+        void userStoryMixedSubtasks_shouldBeDeletableByProfessor() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.DONE);
+            Task subtask2 = createTask(11L, "Subtask 2", TaskType.TASK, TaskStatus.INPROGRESS);
+            subtask2.setAssignee(otherStudentUser);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1, subtask2));
+
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in DONE status SHOULD be deletable by professor")
+        void taskInDoneStatus_shouldBeDeletableByProfessor() {
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.DONE);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in VERIFY status SHOULD be deletable by professor")
+        void taskInVerifyStatus_shouldBeDeletableByProfessor() {
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.VERIFY);
+            assertTrue(accessChecker.canDeleteTask(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY + student: subtask with null assignee should NOT be deletable")
+        void userStorySubtaskUnassigned_shouldNotBeDeletableByStudent() {
+            Task subtask1 = createTask(10L, "Subtask 1", TaskType.TASK, TaskStatus.TODO);
+            subtask1.setAssignee(null);  // Unassigned subtask
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask1));
+
+            assertFalse(accessChecker.canDeleteTask(userStoryTask, "student-id"));
         }
     }
 
@@ -882,7 +948,7 @@ class AccessCheckerTaskPermissionsTest {
         @DisplayName("Task in PAST sprint - professor CAN still edit")
         void taskInPastSprint_professorCanStillEdit() {
             ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
-            taskTask.setStatus(TaskStatus.TODO); // Ensure TODO for delete test
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO); // Ensure TODO for delete test
             
             assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
             assertTrue(accessChecker.canEditType(taskTask, "professor-id"));
@@ -910,7 +976,7 @@ class AccessCheckerTaskPermissionsTest {
         @DisplayName("Frozen task - professor CAN still edit")
         void frozenTask_professorCanStillEdit() {
             taskTask.setFrozen(true);
-            taskTask.setStatus(TaskStatus.TODO);
+            ReflectionTestUtils.setField(taskTask, "status",TaskStatus.TODO);
             
             assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
             assertTrue(accessChecker.canEditSprint(taskTask, "professor-id"));
@@ -933,10 +999,10 @@ class AccessCheckerTaskPermissionsTest {
             // Estimation never editable
             assertFalse(accessChecker.canEditEstimation(userStoryTask, "admin-id"));
             
-            // Delete blocked if has subtasks not in TODO
+            // Admin (professor-equivalent) can delete USER_STORY regardless of subtask state
             Task subtask = createTask(10L, "Subtask", TaskType.TASK, TaskStatus.INPROGRESS);
             ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(subtask));
-            assertFalse(accessChecker.canDeleteTask(userStoryTask, "admin-id"));
+            assertTrue(accessChecker.canDeleteTask(userStoryTask, "admin-id"));
         }
 
         @Test


### PR DESCRIPTION
## Summary

Task delete permissions were tightened so professors can delete any task regardless of state or assignee, while students can only delete tasks assigned to themselves and not in DONE status; for user stories, all subtasks must be in TODO and assigned to the same student. Sprint assignment now auto-transitions tasks and subtasks from BACKLOG to TODO when a sprint is assigned. New error constants and i18n messages were added to support the updated validation errors.

## Commits

- `57f8d0a` feat(service): update task delete permission checks for student and professor
- `19a80a6` feat(service): update task delete and sprint assignment logic
- `f589f8b` feat(utils): update error constants with subtask assignment delete key
- `51f3214` chore(resources): update task delete error messages
- `d1e7c30` chore(resources): update task delete error messages in catalan
- `8d6bb7a` chore(resources): update task delete error messages in spanish
- `2c4eac6` test(service): update task status mutation to use ReflectionTestUtils
