### PR TITLE
Remove related entities when deleting child tasks of a user story

### DIFF
--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -767,11 +767,18 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         task.getActiveSprints().stream().forEach(sprint -> sprint.removeTask(task));
         task.setActiveSprints(new ArrayList<>());
 
-        // If task is a parent (USER_STORY), delete child tasks (already validated above)
+        // If task is a parent (USER_STORY), delete child tasks and their related entities
         if (task.getParentTask() == null){
             Collection<Task> removeTask = task.getChildTasks();
-            removeTask.stream().forEach(childTask -> childTask.setParentTask(null));
-            removeTask.stream().forEach(childTask -> childTask.getActiveSprints().stream().forEach(sprint -> sprint.removeTask(childTask)));
+            for (Task childTask : removeTask) {
+                commentService.deleteByTask(childTask);
+                taskChangeService.deleteByTask(childTask);
+                activityService.deleteByTask(childTask);
+                taskAttributeValueService.deleteByTaskId(childTask.getId());
+                projectAnalysisService.deleteFilesByTask(childTask);
+                childTask.getActiveSprints().stream().forEach(sprint -> sprint.removeTask(childTask));
+                childTask.setParentTask(null);
+            }
             repo.deleteAll(removeTask);
         }
 


### PR DESCRIPTION
## Summary

When deleting a USER_STORY task, child tasks now have their comments, task changes, activities, attribute values, and project analysis files explicitly deleted before the tasks themselves are removed. Previously, only sprint associations and parent references were cleared, leaving orphaned related data in the database.

## Commits

- `c14782f` feat(service): update child task deletion to remove related entities
