### PR TITLE
Expose health endpoint on port 8081 in production config

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -89,3 +89,10 @@ spring:
       on-profile: mysqldb
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
+
+management:
+  server:
+    port: 8081
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## Summary

Updated the production application configuration to expose the health check endpoint on port 8081. This separates the health endpoint from the main application port, allowing infrastructure tools to monitor service health independently.

## Commits

- `cbc98d3` chore(resources): update prod config to expose health endpoint on port 8081
