### PR TITLE
Move management endpoint config to prod-level scope

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -81,6 +81,13 @@ trackdev:
     # Global webhook secret (deprecated - per-repo secrets are now generated automatically)
     secret: ${WEBHOOK_SECRET:}
 
+management:
+  server:
+    port: 8081
+  endpoint:
+    health:
+      show-details: always
+      
 ---
 # Profile: mysqldb
 spring:
@@ -89,10 +96,3 @@ spring:
       on-profile: mysqldb
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
-
-management:
-  server:
-    port: 8081
-  endpoint:
-    health:
-      show-details: always


### PR DESCRIPTION
## Summary

The management server port and health endpoint configuration were nested under the mysqldb Spring profile, making them inactive unless that profile was active. They are now moved to the top-level prod configuration so the settings apply regardless of which sub-profile is used.

## Commits

- `41847bd` chore(resources): move management config out of mysqldb profile
