### PR TITLE
Expose actuator endpoints without authentication

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
@@ -48,6 +48,7 @@ public class SecurityConfiguration {
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
             .authorizeHttpRequests(requests -> requests
+                .requestMatchers(HttpMethod.GET, "/actuator/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/recovery/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/forgot-password", "/auth/reset-password").permitAll()
                 .requestMatchers(HttpMethod.GET, "/auth/reset-password/validate").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,13 @@ trackdev:
     redirect-uri: ${DISCORD_REDIRECT_URI:http://localhost:8080/api/discord/callback}
     public-key: ${DISCORD_PUBLIC_KEY:}
 
+management:
+  server:
+    port: 8081
+  endpoint:
+    health:
+      show-details: always
+      
 ---
 # Profile: mysqldb
 spring:


### PR DESCRIPTION
## Summary

Security configuration was updated to permit all GET requests to `/actuator/**` without authentication. The management server configuration (port 8081 and health endpoint details) was moved from the `mysqldb` profile to the default profile so it applies in all environments.

## Commits

- `a676f4e` feat(configuration): update security to permit actuator endpoints
- `87d19c6` chore(resources): update management config to default profile
