### PR TITLE
Add server-sent events support for real-time sprint task updates

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
@@ -95,11 +95,12 @@ public class JWTTokenRefreshFilter extends OncePerRequestFilter {
      * Skip token refresh for certain endpoints to avoid unnecessary overhead.
      */
     private boolean shouldSkipRefresh(String requestPath) {
-        return requestPath.startsWith("/auth/logout") 
+        return requestPath.startsWith("/auth/logout")
             || requestPath.startsWith("/auth/login")
             || requestPath.startsWith("/auth/recovery")
             || requestPath.startsWith("/swagger")
-            || requestPath.startsWith("/v3/api-docs");
+            || requestPath.startsWith("/v3/api-docs")
+            || requestPath.matches("/sprints/\\d+/events");
     }
     
     /**

--- a/src/main/java/org/trackdev/api/controller/SprintSseController.java
+++ b/src/main/java/org/trackdev/api/controller/SprintSseController.java
@@ -1,0 +1,35 @@
+package org.trackdev.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.trackdev.api.service.SseEmitterService;
+import org.trackdev.api.service.SprintService;
+
+import java.security.Principal;
+
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "7. Sprints")
+@RestController
+@RequestMapping(path = "/sprints")
+public class SprintSseController extends BaseController {
+
+    @Autowired
+    private SprintService sprintService;
+
+    @Autowired
+    private SseEmitterService sseEmitterService;
+
+    @Operation(summary = "Subscribe to sprint events", description = "SSE endpoint for real-time task updates on a sprint board")
+    @GetMapping(path = "/{id}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(Principal principal, @PathVariable(name = "id") Long id) {
+        String userId = super.getUserId(principal);
+        // This validates the sprint exists and the user has access
+        sprintService.getSprint(id, userId);
+        return sseEmitterService.subscribe(id, userId);
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/TaskEventDTO.java
+++ b/src/main/java/org/trackdev/api/dto/TaskEventDTO.java
@@ -1,0 +1,12 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+@Data
+public class TaskEventDTO {
+    private String eventType;
+    private Long taskId;
+    private String actorUserId;
+    private String actorFullName;
+    private TaskBasicDTO task;
+}

--- a/src/main/java/org/trackdev/api/service/SseEmitterService.java
+++ b/src/main/java/org/trackdev/api/service/SseEmitterService.java
@@ -1,0 +1,160 @@
+package org.trackdev.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.trackdev.api.dto.TaskBasicDTO;
+import org.trackdev.api.dto.TaskEventDTO;
+import org.trackdev.api.entity.Sprint;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.mapper.TaskMapper;
+
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+
+@Service
+public class SseEmitterService {
+
+    private static final Logger log = LoggerFactory.getLogger(SseEmitterService.class);
+    private static final long EMITTER_TIMEOUT = 30 * 60 * 1000L; // 30 minutes
+    private static final long HEARTBEAT_INTERVAL = 30L; // seconds
+
+    private final ConcurrentHashMap<Long, Set<SseConnection>> emitters = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService heartbeatScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "sse-heartbeat");
+        t.setDaemon(true);
+        return t;
+    });
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    private TaskMapper taskMapper;
+
+    public SseEmitterService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Publish a task event to all SSE subscribers on affected sprints.
+     * Collects sprint IDs from the task (and parent if applicable),
+     * builds the DTO, and broadcasts to each sprint channel.
+     */
+    public void publishTaskEvent(Task task, User actor, String eventType) {
+        Set<Long> affectedSprintIds = collectAffectedSprintIds(task);
+        if (affectedSprintIds.isEmpty()) {
+            return;
+        }
+
+        TaskEventDTO event = new TaskEventDTO();
+        event.setEventType(eventType);
+        event.setTaskId(task.getId());
+        event.setActorUserId(actor.getId());
+        event.setActorFullName(actor.getFullName());
+        if (!"task_deleted".equals(eventType)) {
+            TaskBasicDTO taskDTO = taskMapper.toBasicDTO(task);
+            event.setTask(taskDTO);
+        }
+
+        for (Long sprintId : affectedSprintIds) {
+            broadcast(sprintId, event);
+        }
+    }
+
+    private Set<Long> collectAffectedSprintIds(Task task) {
+        Set<Long> sprintIds = new HashSet<>();
+        if (task.getActiveSprints() != null) {
+            task.getActiveSprints().forEach(s -> sprintIds.add(s.getId()));
+        }
+        // For subtasks, also include parent's sprints (USER_STORY computed sprints)
+        if (task.getParentTask() != null && task.getParentTask().getActiveSprints() != null) {
+            task.getParentTask().getActiveSprints().forEach(s -> sprintIds.add(s.getId()));
+        }
+        return sprintIds;
+    }
+
+    public SseEmitter subscribe(Long sprintId, String userId) {
+        SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT);
+        SseConnection connection = new SseConnection(emitter, userId);
+
+        emitters.computeIfAbsent(sprintId, k -> ConcurrentHashMap.newKeySet()).add(connection);
+
+        // Schedule per-emitter heartbeat
+        ScheduledFuture<?> heartbeat = heartbeatScheduler.scheduleAtFixedRate(() -> {
+            try {
+                emitter.send(SseEmitter.event().name("heartbeat").data(""));
+            } catch (IOException e) {
+                emitter.completeWithError(e);
+            }
+        }, HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL, TimeUnit.SECONDS);
+
+        // Cleanup on completion, timeout, or error
+        Runnable cleanup = () -> {
+            heartbeat.cancel(false);
+            removeConnection(sprintId, connection);
+        };
+        emitter.onCompletion(cleanup);
+        emitter.onTimeout(cleanup);
+        emitter.onError(t -> cleanup.run());
+
+        // Send initial connected event
+        try {
+            emitter.send(SseEmitter.event().name("connected").data("{\"status\":\"connected\"}"));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        log.debug("SSE subscriber added for sprint {} (user {})", sprintId, userId);
+        return emitter;
+    }
+
+    public void broadcast(Long sprintId, TaskEventDTO event) {
+        Set<SseConnection> connections = emitters.get(sprintId);
+        if (connections == null || connections.isEmpty()) {
+            return;
+        }
+
+        String jsonData;
+        try {
+            jsonData = objectMapper.writeValueAsString(event);
+        } catch (IOException e) {
+            log.error("Failed to serialize TaskEventDTO", e);
+            return;
+        }
+
+        List<SseConnection> dead = new ArrayList<>();
+        for (SseConnection connection : connections) {
+            try {
+                connection.emitter().send(SseEmitter.event().name("task_event").data(jsonData));
+            } catch (IOException e) {
+                dead.add(connection);
+            }
+        }
+        dead.forEach(c -> removeConnection(sprintId, c));
+    }
+
+    private void removeConnection(Long sprintId, SseConnection connection) {
+        Set<SseConnection> connections = emitters.get(sprintId);
+        if (connections != null) {
+            connections.remove(connection);
+            if (connections.isEmpty()) {
+                emitters.remove(sprintId, connections);
+            }
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        heartbeatScheduler.shutdownNow();
+        emitters.values().forEach(connections ->
+                connections.forEach(c -> c.emitter().complete()));
+        emitters.clear();
+    }
+
+    private record SseConnection(SseEmitter emitter, String userId) {}
+}

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -61,6 +61,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
     @Lazy
     ProjectAnalysisService projectAnalysisService;
 
+    @Autowired
+    SseEmitterService sseEmitterService;
+
     @Transactional
     public Task createTask(Long projectId, String name, String description, TaskType type, String assigneeId, String userId) {
         Project project = projectService.get(projectId);
@@ -91,6 +94,8 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         // Record activity for task creation
         activityService.recordActivity(ActivityType.TASK_CREATED, user, task);
 
+        sseEmitterService.publishTaskEvent(task, user, "task_created");
+
         return task;
     }
 
@@ -119,9 +124,11 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         taskChangeService.store(change);
         
         // Record activity
-        activityService.recordActivity(ActivityType.TASK_ASSIGNED, user, task.getProject(), task, 
+        activityService.recordActivity(ActivityType.TASK_ASSIGNED, user, task.getProject(), task,
                 null, oldValue, user.getUsername());
-        
+
+        sseEmitterService.publishTaskEvent(task, user, "task_updated");
+
         return task;
     }
 
@@ -162,9 +169,11 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         taskChangeService.store(change);
         
         // Record activity
-        activityService.recordActivity(ActivityType.TASK_UNASSIGNED, user, task.getProject(), task, 
+        activityService.recordActivity(ActivityType.TASK_UNASSIGNED, user, task.getProject(), task,
                 null, oldValue, null);
-        
+
+        sseEmitterService.publishTaskEvent(task, user, "task_updated");
+
         return task;
     }
 
@@ -274,6 +283,10 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
 
         // Record activity for subtask creation
         activityService.recordActivity(ActivityType.TASK_CREATED, user, subtask);
+
+        sseEmitterService.publishTaskEvent(subtask, user, "task_created");
+        // Also publish parent update since its computed sprints/status may have changed
+        sseEmitterService.publishTaskEvent(parentTask, user, "task_updated");
 
         return subtask;
     }
@@ -601,6 +614,13 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             // Record corresponding activity
             recordActivityForChange(change, user, task);
         }
+        if (!changes.isEmpty()) {
+            sseEmitterService.publishTaskEvent(task, user, "task_updated");
+            // If task has a parent, also publish parent update (computed fields may have changed)
+            if (task.getParentTask() != null) {
+                sseEmitterService.publishTaskEvent(task.getParentTask(), user, "task_updated");
+            }
+        }
         return task;
     }
 
@@ -769,6 +789,14 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             if (!isProfessor && task.getStatus() == TaskStatus.DONE) {
                 throw new ServiceException(ErrorConstants.TASK_STATUS_CANNOT_DELETE);
             }
+        }
+
+        // Publish SSE event before deletion (while entity data is still available)
+        User actor = userService.get(userId);
+        sseEmitterService.publishTaskEvent(task, actor, "task_deleted");
+        // If deleting a subtask, also notify about parent update
+        if (task.getParentTask() != null) {
+            sseEmitterService.publishTaskEvent(task.getParentTask(), actor, "task_updated");
         }
 
         // Delete all related entities before deleting the task (foreign key constraints)


### PR DESCRIPTION
## Summary

Introduces an SSE infrastructure for broadcasting real-time task changes to sprint board subscribers. This includes a new SSE emitter service, a task event DTO, a sprint events controller endpoint, integration of event publishing into the task service, and a token refresh filter update to skip the SSE endpoint.

## Commits

- `197c2e0` feat(configuration): update token refresh filter to skip sprint sse events
- `38231cc` feat(service): update task service to publish sse events on changes
- `da43fc7` feat(controller): add sse endpoint for sprint task events
- `f8eae7d` feat(dto): add task event dto for sse notifications
- `db8d381` feat(service): add sse emitter service for sprint task events
