### PR TITLE
Add assignee id parameter to subtask creation

### DIFF
--- a/src/main/java/org/trackdev/api/controller/TaskController.java
+++ b/src/main/java/org/trackdev/api/controller/TaskController.java
@@ -213,7 +213,7 @@ public class TaskController extends CrudController<Task, TaskService> {
             throw new ControllerException(ErrorConstants.INVALID_TASK_NAME_LENGTH);
         }
         String userId = super.getUserId(principal);
-        Task subtask = service.createSubTask(id, request.name, request.description, userId, request.sprintId, request.type);
+        Task subtask = service.createSubTask(id, request.name, request.description, userId, request.sprintId, request.type, request.assigneeId);
 
         return new IdResponseDTO(subtask.getId());
     }
@@ -371,6 +371,8 @@ public class TaskController extends CrudController<Task, TaskService> {
         public Long sprintId;
 
         public TaskType type;
+
+        public String assigneeId;
     }
 
     static class SetAttributeValueRequest {

--- a/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
+++ b/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
@@ -737,7 +737,7 @@ public class DemoDataSeeder {
 
                     // Create subtask with sprint assignment - randomly assign TASK or BUG type
                     TaskType subtaskType = random.nextBoolean() ? TaskType.TASK : TaskType.BUG;
-                    Task subtask = taskService.createSubTask(story.getId(), subtaskName, null, assignee.getId(), sprint.getId(), subtaskType);
+                    Task subtask = taskService.createSubTask(story.getId(), subtaskName, null, assignee.getId(), sprint.getId(), subtaskType, assignee.getId());
                     assignOrderedTimestamp(subtask);
 
                     User subtaskAssignee;
@@ -950,7 +950,7 @@ public class DemoDataSeeder {
         // Create subtasks - use createSubTaskInternal with allowPastSprint=true for demo data
         for (int i = 0; i < subtaskNames.length; i++) {
             TaskType subtaskType = (i % 2 == 0) ? TaskType.TASK : TaskType.BUG; // Alternate TASK/BUG
-            Task subtask = taskService.createSubTaskInternal(story.getId(), subtaskNames[i], null, assignee.getId(), sprint.getId(), subtaskType, true);
+            Task subtask = taskService.createSubTaskInternal(story.getId(), subtaskNames[i], null, assignee.getId(), sprint.getId(), subtaskType, assignee.getId(), true);
             assignOrderedTimestamp(subtask);
 
             // Set subtask status
@@ -1266,7 +1266,7 @@ public class DemoDataSeeder {
 
         // Create subtask in past sprint using internal method that allows past sprint
         Task pastSprintTask = taskService.createSubTaskInternal(pastStory.getId(),
-            "PERMISSION TEST: Task in past sprint", null, alice.getId(), pastSprint.getId(), TaskType.TASK, true);
+            "PERMISSION TEST: Task in past sprint", null, alice.getId(), pastSprint.getId(), TaskType.TASK, alice.getId(), true);
         assignOrderedTimestamp(pastSprintTask);
         MergePatchTask pastTaskEdit = new MergePatchTask();
         pastTaskEdit.assignee = Optional.of(alice.getEmail());
@@ -1312,7 +1312,7 @@ public class DemoDataSeeder {
 
         // Add a subtask to make it non-deletable
         Task subtask1 = taskService.createSubTask(userStoryWithSubtasks.getId(),
-            "PERMISSION TEST: Subtask 1", null, alice.getId(), activeSprint.getId(), TaskType.TASK);
+            "PERMISSION TEST: Subtask 1", null, alice.getId(), activeSprint.getId(), TaskType.TASK, alice.getId());
         assignOrderedTimestamp(subtask1);
         MergePatchTask subtaskEdit = new MergePatchTask();
         subtaskEdit.assignee = Optional.of(alice.getEmail());

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -178,8 +178,8 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
     }
 
     @Transactional
-    public Task createSubTask(Long taskId, String name, String description, String userId, Long sprintId, TaskType type) {
-        return createSubTaskInternal(taskId, name, description, userId, sprintId, type, false);
+    public Task createSubTask(Long taskId, String name, String description, String userId, Long sprintId, TaskType type, String assigneeId) {
+        return createSubTaskInternal(taskId, name, description, userId, sprintId, type, assigneeId, false);
     }
 
     /**
@@ -187,7 +187,7 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
      * Used by DemoDataSeeder to create subtasks in past sprints for demo purposes.
      */
     @Transactional
-    public Task createSubTaskInternal(Long taskId, String name, String description, String userId, Long sprintId, TaskType type, boolean allowPastSprint) {
+    public Task createSubTaskInternal(Long taskId, String name, String description, String userId, Long sprintId, TaskType type, String assigneeId, boolean allowPastSprint) {
         Task parentTask = this.get(taskId);
         User user = userService.get(userId);
 
@@ -220,9 +220,13 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         }
         subtask.setParentTask(parentTask);
         
-        // Auto-assign subtask to the student who creates it
-        if (user.isUserType(UserType.STUDENT)) {
-            subtask.setAssignee(user);
+        // Set assignee if provided
+        if (assigneeId != null && !assigneeId.isBlank()) {
+            User assignee = userService.get(assigneeId);
+            if (!parentTask.getProject().isMember(assignee)) {
+                throw new ServiceException(ErrorConstants.UNAUTHORIZED);
+            }
+            subtask.setAssignee(assignee);
         }
         
         // Determine the target sprint FIRST, then set status based on sprint assignment


### PR DESCRIPTION
## Summary

Updated the subtask creation flow to accept an explicit assignee id instead of auto-assigning the creator. The controller now passes assigneeId from the request, the service validates the assignee is a project member before assignment, and the demo data seeder was updated to pass the assignee id to match the new method signatures.

## Commits

- `fb52afb` feat(controller): update subtask creation to pass assignee id
- `13f243a` feat(service): update demo data seeder to pass assignee id
- `598715e` feat(service): update subtask creation to accept assignee id
