### PR TITLE
Configure security filters to skip async dispatch requests

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/JWTAuthorizationFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/JWTAuthorizationFilter.java
@@ -38,6 +38,11 @@ public class JWTAuthorizationFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return true;
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
         // Skip JWT validation if already authenticated by PAT filter
         if (SecurityContextHolder.getContext().getAuthentication() != null

--- a/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/JWTTokenRefreshFilter.java
@@ -46,6 +46,11 @@ public class JWTTokenRefreshFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return true;
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/org/trackdev/api/configuration/PATAuthorizationFilter.java
+++ b/src/main/java/org/trackdev/api/configuration/PATAuthorizationFilter.java
@@ -37,6 +37,11 @@ public class PATAuthorizationFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return true;
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                      FilterChain chain) throws ServletException, IOException {
         String authHeader = request.getHeader(HEADER);

--- a/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
+++ b/src/main/java/org/trackdev/api/configuration/SecurityConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.http.HttpMethod;
+import jakarta.servlet.DispatcherType;
 
 /**
  * Spring Security Configuration
@@ -48,6 +49,7 @@ public class SecurityConfiguration {
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
             .authorizeHttpRequests(requests -> requests
+                .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                 .requestMatchers(HttpMethod.GET, "/actuator/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/recovery/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/forgot-password", "/auth/reset-password").permitAll()


### PR DESCRIPTION
## Summary

All three authentication filters (JWT, token refresh, and PAT) now override shouldNotFilterAsyncDispatch() to return true, preventing them from re-executing on async dispatched requests. The security configuration was also updated to permit all async dispatcher type requests without authentication.

## Commits

- `f99844b` feat(configuration): update jwt filter to skip async dispatch
- `6594e09` feat(configuration): update token refresh filter to skip async dispatch
- `a2fab99` feat(configuration): update pat filter to skip async dispatch
- `2e373c2` feat(configuration): update security to permit async dispatches
