### PR TITLE
Enable SSE real-time updates for sprint boards with connection manage...

### DIFF
--- a/src/main/java/org/trackdev/api/configuration/TrackDevProperties.java
+++ b/src/main/java/org/trackdev/api/configuration/TrackDevProperties.java
@@ -13,6 +13,8 @@ public class TrackDevProperties {
     private final Cors cors = new Cors();
     private final Frontend frontend = new Frontend();
     private final Discord discord = new Discord();
+    private final Sse sse = new Sse();
+    private final StressTest stressTest = new StressTest();
 
     public Auth getAuth() {
         return auth;
@@ -36,6 +38,14 @@ public class TrackDevProperties {
 
     public Discord getDiscord() {
         return discord;
+    }
+
+    public Sse getSse() {
+        return sse;
+    }
+
+    public StressTest getStressTest() {
+        return stressTest;
     }
 
     public static class Auth {
@@ -221,6 +231,69 @@ public class TrackDevProperties {
         }
     }
 
+    public static class Sse {
+        private boolean enabled = false;
+        private int maxConnections = 500;
+        private int maxConnectionsPerUser = 5;
+        private long emitterTimeoutMs = 1800000; // 30 minutes
+        private long heartbeatIntervalSeconds = 30;
+        private int threadPoolSize = 4;
+        private int asyncPoolSize = 10;
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+        public int getMaxConnections() { return maxConnections; }
+        public void setMaxConnections(int maxConnections) { this.maxConnections = maxConnections; }
+
+        public int getMaxConnectionsPerUser() { return maxConnectionsPerUser; }
+        public void setMaxConnectionsPerUser(int maxConnectionsPerUser) { this.maxConnectionsPerUser = maxConnectionsPerUser; }
+
+        public long getEmitterTimeoutMs() { return emitterTimeoutMs; }
+        public void setEmitterTimeoutMs(long emitterTimeoutMs) { this.emitterTimeoutMs = emitterTimeoutMs; }
+
+        public long getHeartbeatIntervalSeconds() { return heartbeatIntervalSeconds; }
+        public void setHeartbeatIntervalSeconds(long heartbeatIntervalSeconds) { this.heartbeatIntervalSeconds = heartbeatIntervalSeconds; }
+
+        public int getThreadPoolSize() { return threadPoolSize; }
+        public void setThreadPoolSize(int threadPoolSize) { this.threadPoolSize = threadPoolSize; }
+
+        public int getAsyncPoolSize() { return asyncPoolSize; }
+        public void setAsyncPoolSize(int asyncPoolSize) { this.asyncPoolSize = asyncPoolSize; }
+
+        @Override
+        public String toString() {
+            return "Sse{enabled=" + enabled + ", maxConnections=" + maxConnections +
+                    ", maxConnectionsPerUser=" + maxConnectionsPerUser +
+                    ", threadPoolSize=" + threadPoolSize + ", asyncPoolSize=" + asyncPoolSize + "}";
+        }
+    }
+
+    public static class StressTest {
+        private boolean enabled = false;
+        private int userCount = 80;
+        private int projectCount = 15;
+        private String password = "stress";
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+        public int getUserCount() { return userCount; }
+        public void setUserCount(int userCount) { this.userCount = userCount; }
+
+        public int getProjectCount() { return projectCount; }
+        public void setProjectCount(int projectCount) { this.projectCount = projectCount; }
+
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+
+        @Override
+        public String toString() {
+            return "StressTest{enabled=" + enabled + ", userCount=" + userCount +
+                    ", projectCount=" + projectCount + "}";
+        }
+    }
+
     @Override
     public String toString() {
         return "TrackDevProperties{" +
@@ -230,6 +303,8 @@ public class TrackDevProperties {
                 ",\n  cors=" + cors +
                 ",\n  frontend=" + frontend +
                 ",\n  discord=" + discord +
+                ",\n  sse=" + sse +
+                ",\n  stressTest=" + stressTest +
                 "\n}";
     }
 }

--- a/src/main/java/org/trackdev/api/configuration/WebConfig.java
+++ b/src/main/java/org/trackdev/api/configuration/WebConfig.java
@@ -1,15 +1,21 @@
 package org.trackdev.api.configuration;
 
+import jakarta.persistence.EntityManagerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 // Note: Do NOT use @EnableWebMvc here - it disables Spring Boot's auto-configuration
@@ -18,6 +24,52 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Autowired
     CorsConfiguration corsConfiguration;
+
+    @Autowired
+    TrackDevProperties trackDevProperties;
+
+    @Autowired
+    EntityManagerFactory entityManagerFactory;
+
+    /**
+     * Re-registers OSIV (OpenEntityManagerInView) manually with SSE endpoint exclusion.
+     * Spring Boot's auto-configured OSIV is disabled via spring.jpa.open-in-view=false.
+     *
+     * OSIV keeps the Hibernate EntityManager (and its DB connection) open for the entire
+     * HTTP request lifecycle. For normal REST requests this is fine (milliseconds), but for
+     * SSE endpoints the request lives for the emitter lifetime (up to 30 minutes), holding
+     * a DB connection the entire time. With 80+ concurrent SSE connections this exhausts
+     * the HikariCP pool, blocking all REST requests.
+     *
+     * By excluding SSE paths, those endpoints get no OSIV EntityManager — the auth check
+     * in checkSprintAccess() uses its own @Transactional(propagation=REQUIRES_NEW) which
+     * creates and closes a dedicated EntityManager, releasing the DB connection immediately.
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        OpenEntityManagerInViewInterceptor osiv = new OpenEntityManagerInViewInterceptor();
+        osiv.setEntityManagerFactory(entityManagerFactory);
+        registry.addWebRequestInterceptor(osiv)
+                .excludePathPatterns("/sprints/*/events");
+    }
+
+    /**
+     * Configures a dedicated, bounded thread pool for async request processing (SSE).
+     * This keeps SSE connections completely isolated from Tomcat's request thread pool,
+     * ensuring REST API requests are never starved by long-lived SSE connections.
+     */
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(trackDevProperties.getSse().getAsyncPoolSize());
+        executor.setMaxPoolSize(trackDevProperties.getSse().getAsyncPoolSize());
+        executor.setQueueCapacity(0);
+        executor.setThreadNamePrefix("sse-async-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        configurer.setTaskExecutor(executor);
+        configurer.setDefaultTimeout(trackDevProperties.getSse().getEmitterTimeoutMs());
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/org/trackdev/api/controller/SprintSseController.java
+++ b/src/main/java/org/trackdev/api/controller/SprintSseController.java
@@ -24,12 +24,14 @@ public class SprintSseController extends BaseController {
     @Autowired
     private SseEmitterService sseEmitterService;
 
-    // Temporarily disabled — async dispatch causes AuthorizationDeniedException on committed responses
-    @Operation(summary = "Subscribe to sprint events", description = "SSE endpoint for real-time task updates on a sprint board (temporarily disabled)")
+    @Operation(summary = "Subscribe to sprint events",
+            description = "SSE endpoint for real-time task updates. Returns a stream that may "
+                    + "immediately complete with a 'disabled' or 'rejected' event if SSE is turned off "
+                    + "or connection limits are reached.")
     @GetMapping(path = "/{id}/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(Principal principal, @PathVariable(name = "id") Long id) {
-        SseEmitter emitter = new SseEmitter(0L);
-        emitter.complete();
-        return emitter;
+        String userId = super.getUserId(principal);
+        sprintService.checkSprintAccess(id, userId);
+        return sseEmitterService.subscribe(id, userId);
     }
 }

--- a/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
+++ b/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
@@ -124,6 +124,9 @@ public class DemoDataSeeder {
     @Autowired
     private Environment environment;
 
+    @Autowired
+    private org.trackdev.api.configuration.TrackDevProperties trackDevProperties;
+
     public void seedDemoData() {
         logger.info("Starting database seeding...");
 
@@ -547,6 +550,175 @@ public class DemoDataSeeder {
         logger.info("  - 7 projects with sprints (1 with empty active sprint for testing)");
         logger.info("  - 1 sample report (PDS 2025)");
         logger.info("  - 1 demo profile with enums and attributes");
+
+        // Conditionally seed stress test data
+        if (trackDevProperties.getStressTest().isEnabled()) {
+            seedStressTestData(workspaceUdG, wsAdminUdG);
+        }
+    }
+
+    // ==========================================================================
+    // STRESS TEST DATA (dev-only, disabled by default)
+    // ==========================================================================
+
+    /**
+     * Seeds large-scale data for SSE/load stress testing.
+     * Creates many users across multiple projects so the stress test scripts
+     * can authenticate as different users and open concurrent SSE connections.
+     *
+     * All stress-test users share the same password (configurable).
+     * Email pattern: stress{N}@trackdev.com (e.g., stress1@trackdev.com)
+     */
+    private void seedStressTestData(Workspace workspace, User wsAdmin) {
+        var config = trackDevProperties.getStressTest();
+        int userCount = config.getUserCount();
+        int projectCount = config.getProjectCount();
+        String sharedPassword = config.getPassword();
+
+        logger.info("=== STRESS TEST DATA ===");
+        logger.info("Creating {} users across {} projects (password: '{}')",
+                userCount, projectCount, sharedPassword);
+
+        // 1. Create a dedicated professor for stress test
+        User stressProfessor = createUserWithWorkspace(
+                "stress-professor",
+                "Stress Test Professor",
+                "stress.professor@trackdev.com",
+                "professor",
+                List.of(UserType.PROFESSOR),
+                workspace
+        );
+
+        // 2. Create a subject and course for stress testing
+        Subject stressSubject = createSubjectWithWorkspace(
+                "Stress Test Subject", "STRESS", wsAdmin, workspace);
+        Course stressCourse = courseService.createCourse(
+                stressSubject.getId(), 2025, null, stressProfessor.getId());
+
+        // 3. Create all stress test students
+        List<User> stressStudents = new ArrayList<>();
+        for (int i = 1; i <= userCount; i++) {
+            String username = "stress-user-" + i;
+            String fullName = "Stress User " + i;
+            String email = "stress" + i + "@trackdev.com";
+            User student = createUserWithWorkspace(
+                    username, fullName, email,
+                    sharedPassword,
+                    List.of(UserType.STUDENT),
+                    workspace
+            );
+            stressStudents.add(student);
+        }
+        logger.info("Created {} stress test students", stressStudents.size());
+
+        // Enroll all students in the stress course
+        for (User student : stressStudents) {
+            stressCourse.addStudent(student);
+        }
+        courseService.save(stressCourse);
+
+        // 4. Create sprint pattern with 4 sprints (2 closed, 1 active, 1 future)
+        LocalDate today = LocalDate.now();
+        LocalDate s3Start = today.minusDays(7);
+        LocalDate s3End = s3Start.plusDays(14);
+        LocalDate s4Start = s3End;
+        LocalDate s4End = s4Start.plusDays(14);
+        LocalDate s2Start = s3Start.minusDays(14);
+        LocalDate s2End = s3Start;
+        LocalDate s1Start = s2Start.minusDays(14);
+        LocalDate s1End = s2Start;
+
+        SprintPattern stressPattern = createSprintPattern(
+                "Stress Pattern", stressCourse, stressProfessor,
+                s1Start, s1End, s2Start, s2End, s3Start, s3End, s4Start, s4End);
+
+        // 5. Distribute students across projects (round-robin)
+        int studentsPerProject = (userCount + projectCount - 1) / projectCount;
+        for (int p = 0; p < projectCount; p++) {
+            int fromIdx = p * studentsPerProject;
+            int toIdx = Math.min(fromIdx + studentsPerProject, userCount);
+            if (fromIdx >= userCount) break;
+
+            List<User> projectStudents = stressStudents.subList(fromIdx, toIdx);
+            String projectName = "stress-project-" + (p + 1);
+
+            createStressTestProject(projectName, projectStudents, stressCourse,
+                    stressProfessor, stressPattern);
+
+            logger.info("Created project '{}' with {} students (stress{}-stress{})",
+                    projectName, projectStudents.size(), fromIdx + 1, toIdx);
+        }
+
+        logger.info("=== STRESS TEST DATA COMPLETE ===");
+        logger.info("Login with: stress1@trackdev.com .. stress{}@trackdev.com (password: '{}')",
+                userCount, sharedPassword);
+    }
+
+    /**
+     * Create a stress-test project with sprints and lightweight tasks.
+     * Each sprint gets 2 stories with 2 subtasks each — enough to test SSE
+     * without making startup too slow.
+     */
+    private void createStressTestProject(String projectName, List<User> students,
+                                          Course course, User professor,
+                                          SprintPattern sprintPattern) {
+        List<String> studentIds = students.stream().map(User::getId).toList();
+        Project project = projectService.createProject(projectName, studentIds, course.getId(), professor.getId());
+        project = projectService.applySprintPattern(project.getId(), sprintPattern.getId(), professor.getId());
+
+        List<Sprint> sprints = sprintRepository.findByProjectIdOrderByPatternItemOrderIndex(project.getId());
+
+        for (int i = 0; i < sprints.size(); i++) {
+            Sprint sprint = sprints.get(i);
+            boolean isFuture = (i == 3);
+            boolean isClosed = (i < 2);
+
+            if (!isFuture) {
+                activateSprint(sprint, professor.getId());
+            }
+            if (isFuture) continue;
+
+            // 2 stories per sprint
+            for (int s = 0; s < 2; s++) {
+                User reporter = students.get(s % students.size());
+                String storyName = "Stress story " + (i + 1) + "-" + (s + 1) + " (" + projectName + ")";
+
+                Task story = taskService.createTask(project.getId(), storyName, null, null, null, reporter.getId());
+
+                User assignee = students.get((s + 1) % students.size());
+                MergePatchTask storyEdit = new MergePatchTask();
+                storyEdit.assignee = Optional.of(assignee.getEmail());
+                storyEdit.rank = Optional.of(s + 1);
+                if (isClosed) {
+                    storyEdit.status = Optional.of(TaskStatus.DONE);
+                } else {
+                    storyEdit.status = Optional.of(s == 0 ? TaskStatus.INPROGRESS : TaskStatus.TODO);
+                }
+                taskService.editTaskInternal(story.getId(), storyEdit, assignee.getId());
+
+                // 2 subtasks per story
+                for (int t = 0; t < 2; t++) {
+                    String subtaskName = "Subtask " + (t + 1) + " of story " + (s + 1);
+                    TaskType type = (t == 0) ? TaskType.TASK : TaskType.BUG;
+                    Task subtask = taskService.createSubTaskInternal(
+                            story.getId(), subtaskName, null, assignee.getId(),
+                            sprint.getId(), type, assignee.getId(), isClosed);
+
+                    MergePatchTask subtaskEdit = new MergePatchTask();
+                    subtaskEdit.assignee = Optional.of(assignee.getEmail());
+                    if (isClosed) {
+                        subtaskEdit.status = Optional.of(TaskStatus.DONE);
+                    } else {
+                        subtaskEdit.status = Optional.of(t == 0 ? TaskStatus.INPROGRESS : TaskStatus.TODO);
+                    }
+                    taskService.editTaskInternal(subtask.getId(), subtaskEdit, assignee.getId());
+                }
+            }
+
+            if (isClosed) {
+                closeSprint(sprint, professor.getId());
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -140,6 +140,18 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
     }
 
     /**
+     * Lightweight access check for SSE subscriptions.
+     * Uses REQUIRES_NEW to create a dedicated EntityManager and DB connection that is fully
+     * released when this method returns. This prevents OSIV from holding the connection for
+     * the entire SSE emitter lifetime (up to 30 minutes), which would exhaust the pool.
+     */
+    @Transactional(readOnly = true, propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+    public void checkSprintAccess(Long sprintId, String userId) {
+        Sprint sprint = get(sprintId);
+        accessChecker.checkCanViewProject(sprint.getProject(), userId);
+    }
+
+    /**
      * Get sprint history with authorization check in a single transaction.
      * This ensures atomicity between the auth check and the data retrieval.
      */

--- a/src/main/java/org/trackdev/api/service/SseEmitterService.java
+++ b/src/main/java/org/trackdev/api/service/SseEmitterService.java
@@ -6,46 +6,67 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.trackdev.api.configuration.TrackDevProperties;
 import org.trackdev.api.dto.TaskBasicDTO;
 import org.trackdev.api.dto.TaskEventDTO;
-import org.trackdev.api.entity.Sprint;
 import org.trackdev.api.entity.Task;
 import org.trackdev.api.entity.User;
 import org.trackdev.api.mapper.TaskMapper;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 public class SseEmitterService {
 
     private static final Logger log = LoggerFactory.getLogger(SseEmitterService.class);
-    private static final long EMITTER_TIMEOUT = 30 * 60 * 1000L; // 30 minutes
-    private static final long HEARTBEAT_INTERVAL = 30L; // seconds
 
     private final ConcurrentHashMap<Long, Set<SseConnection>> emitters = new ConcurrentHashMap<>();
-    private final ScheduledExecutorService heartbeatScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread t = new Thread(r, "sse-heartbeat");
-        t.setDaemon(true);
-        return t;
-    });
+    private final AtomicInteger totalConnections = new AtomicInteger(0);
+    private final ConcurrentHashMap<String, AtomicInteger> userConnectionCounts = new ConcurrentHashMap<>();
+
+    private ScheduledExecutorService heartbeatScheduler;
     private final ObjectMapper objectMapper;
 
     @Autowired
     private TaskMapper taskMapper;
 
+    @Autowired
+    private TrackDevProperties trackDevProperties;
+
     public SseEmitterService(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
+    @PostConstruct
+    public void init() {
+        int poolSize = trackDevProperties.getSse().getThreadPoolSize();
+        this.heartbeatScheduler = Executors.newScheduledThreadPool(poolSize, r -> {
+            Thread t = new Thread(r, "sse-heartbeat");
+            t.setDaemon(true);
+            return t;
+        });
+        log.info("SSE service initialized: enabled={}, maxConnections={}, maxPerUser={}, threadPoolSize={}, asyncPoolSize={}",
+                trackDevProperties.getSse().isEnabled(),
+                trackDevProperties.getSse().getMaxConnections(),
+                trackDevProperties.getSse().getMaxConnectionsPerUser(),
+                poolSize,
+                trackDevProperties.getSse().getAsyncPoolSize());
+    }
+
     /**
      * Publish a task event to all SSE subscribers on affected sprints.
-     * Collects sprint IDs from the task (and parent if applicable),
-     * builds the DTO, and broadcasts to each sprint channel.
+     * No-op when SSE is disabled.
      */
     public void publishTaskEvent(Task task, User actor, String eventType) {
+        if (!trackDevProperties.getSse().isEnabled()) {
+            return;
+        }
+
         Set<Long> affectedSprintIds = collectAffectedSprintIds(task);
         if (affectedSprintIds.isEmpty()) {
             return;
@@ -79,24 +100,59 @@ public class SseEmitterService {
     }
 
     public SseEmitter subscribe(Long sprintId, String userId) {
-        SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT);
+        TrackDevProperties.Sse sseConfig = trackDevProperties.getSse();
+
+        // Kill switch
+        if (!sseConfig.isEnabled()) {
+            return createDisabledEmitter();
+        }
+
+        // Total connection limit
+        if (totalConnections.get() >= sseConfig.getMaxConnections()) {
+            log.warn("SSE max total connections reached ({}). Rejecting for user {} on sprint {}",
+                    sseConfig.getMaxConnections(), userId, sprintId);
+            return createRejectedEmitter("max_connections");
+        }
+
+        // Per-user connection limit
+        AtomicInteger userCount = userConnectionCounts.computeIfAbsent(userId, k -> new AtomicInteger(0));
+        if (userCount.get() >= sseConfig.getMaxConnectionsPerUser()) {
+            log.warn("SSE max per-user connections reached ({}) for user {}",
+                    sseConfig.getMaxConnectionsPerUser(), userId);
+            return createRejectedEmitter("max_user_connections");
+        }
+
+        // Increment counters
+        totalConnections.incrementAndGet();
+        userCount.incrementAndGet();
+
+        SseEmitter emitter = new SseEmitter(sseConfig.getEmitterTimeoutMs());
         SseConnection connection = new SseConnection(emitter, userId);
 
         emitters.computeIfAbsent(sprintId, k -> ConcurrentHashMap.newKeySet()).add(connection);
 
         // Schedule per-emitter heartbeat
+        long interval = sseConfig.getHeartbeatIntervalSeconds();
         ScheduledFuture<?> heartbeat = heartbeatScheduler.scheduleAtFixedRate(() -> {
             try {
                 emitter.send(SseEmitter.event().name("heartbeat").data(""));
             } catch (IOException e) {
                 emitter.completeWithError(e);
             }
-        }, HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL, TimeUnit.SECONDS);
+        }, interval, interval, TimeUnit.SECONDS);
 
         // Cleanup on completion, timeout, or error
         Runnable cleanup = () -> {
             heartbeat.cancel(false);
             removeConnection(sprintId, connection);
+            totalConnections.decrementAndGet();
+            AtomicInteger count = userConnectionCounts.get(userId);
+            if (count != null) {
+                int remaining = count.decrementAndGet();
+                if (remaining <= 0) {
+                    userConnectionCounts.remove(userId, count);
+                }
+            }
         };
         emitter.onCompletion(cleanup);
         emitter.onTimeout(cleanup);
@@ -109,7 +165,26 @@ public class SseEmitterService {
             emitter.completeWithError(e);
         }
 
-        log.debug("SSE subscriber added for sprint {} (user {})", sprintId, userId);
+        log.debug("SSE subscriber added for sprint {} (user {}). Total: {}, User: {}",
+                sprintId, userId, totalConnections.get(), userCount.get());
+        return emitter;
+    }
+
+    private SseEmitter createDisabledEmitter() {
+        SseEmitter emitter = new SseEmitter(0L);
+        try {
+            emitter.send(SseEmitter.event().name("disabled").data("{\"reason\":\"sse_disabled\"}"));
+        } catch (IOException ignored) {}
+        emitter.complete();
+        return emitter;
+    }
+
+    private SseEmitter createRejectedEmitter(String reason) {
+        SseEmitter emitter = new SseEmitter(0L);
+        try {
+            emitter.send(SseEmitter.event().name("rejected").data("{\"reason\":\"" + reason + "\"}"));
+        } catch (IOException ignored) {}
+        emitter.complete();
         return emitter;
     }
 
@@ -154,6 +229,19 @@ public class SseEmitterService {
         emitters.values().forEach(connections ->
                 connections.forEach(c -> c.emitter().complete()));
         emitters.clear();
+        totalConnections.set(0);
+        userConnectionCounts.clear();
+    }
+
+    // Visible for testing
+    int getTotalConnections() {
+        return totalConnections.get();
+    }
+
+    // Visible for testing
+    int getUserConnectionCount(String userId) {
+        AtomicInteger count = userConnectionCounts.get(userId);
+        return count != null ? count.get() : 0;
     }
 
     private record SseConnection(SseEmitter emitter, String userId) {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,12 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:30}
+      minimum-idle: ${HIKARI_MIN_IDLE:10}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT:10000}
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: create-drop
       # database-platform: org.hibernate.dialect.MariaDBDialect
@@ -81,6 +86,17 @@ trackdev:
     verified-role-id: ${DISCORD_VERIFIED_ROLE_ID:}
     redirect-uri: ${DISCORD_REDIRECT_URI:http://localhost:8080/api/discord/callback}
     public-key: ${DISCORD_PUBLIC_KEY:}
+  sse:
+    enabled: ${SSE_ENABLED:true}
+    max-connections: ${SSE_MAX_CONNECTIONS:500}
+    max-connections-per-user: ${SSE_MAX_CONNECTIONS_PER_USER:5}
+    thread-pool-size: ${SSE_THREAD_POOL_SIZE:4}
+    async-pool-size: ${SSE_ASYNC_POOL_SIZE:10}
+  stress-test:
+    enabled: ${STRESS_TEST_ENABLED:false}
+    user-count: ${STRESS_TEST_USERS:80}
+    project-count: ${STRESS_TEST_PROJECTS:15}
+    password: ${STRESS_TEST_PASSWORD:stress}
 
 management:
   server:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,12 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:30}
+      minimum-idle: ${HIKARI_MIN_IDLE:10}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT:10000}
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: validate
       # database-platform: org.hibernate.dialect.MariaDBDialect
@@ -80,6 +85,12 @@ trackdev:
     url: ${WEBHOOK_BASE_URL:https://unisolationist-ronan-ravishingly.ngrok-free.dev}
     # Global webhook secret (deprecated - per-repo secrets are now generated automatically)
     secret: ${WEBHOOK_SECRET:}
+  sse:
+    enabled: ${SSE_ENABLED:true}
+    max-connections: ${SSE_MAX_CONNECTIONS:100}
+    max-connections-per-user: ${SSE_MAX_CONNECTIONS_PER_USER:3}
+    thread-pool-size: ${SSE_THREAD_POOL_SIZE:2}
+    async-pool-size: ${SSE_ASYNC_POOL_SIZE:5}
 
 management:
   server:

--- a/src/test/java/org/trackdev/api/service/SseEmitterServiceTest.java
+++ b/src/test/java/org/trackdev/api/service/SseEmitterServiceTest.java
@@ -1,0 +1,189 @@
+package org.trackdev.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.trackdev.api.configuration.TrackDevProperties;
+import org.trackdev.api.entity.Sprint;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.mapper.TaskMapper;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SseEmitterServiceTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private TaskMapper taskMapper;
+
+    private SseEmitterService sseEmitterService;
+    private TrackDevProperties trackDevProperties;
+
+    @BeforeEach
+    void setUp() {
+        trackDevProperties = new TrackDevProperties();
+        trackDevProperties.getSse().setEnabled(true);
+        trackDevProperties.getSse().setMaxConnections(10);
+        trackDevProperties.getSse().setMaxConnectionsPerUser(2);
+        trackDevProperties.getSse().setEmitterTimeoutMs(60000L);
+        trackDevProperties.getSse().setHeartbeatIntervalSeconds(30);
+        trackDevProperties.getSse().setThreadPoolSize(2);
+
+        sseEmitterService = new SseEmitterService(objectMapper);
+        ReflectionTestUtils.setField(sseEmitterService, "taskMapper", taskMapper);
+        ReflectionTestUtils.setField(sseEmitterService, "trackDevProperties", trackDevProperties);
+
+        // Call @PostConstruct manually
+        sseEmitterService.init();
+    }
+
+    @AfterEach
+    void tearDown() {
+        sseEmitterService.shutdown();
+    }
+
+    @Nested
+    @DisplayName("subscribe()")
+    class Subscribe {
+
+        @Test
+        @DisplayName("when disabled, returns completed emitter")
+        void whenDisabled_returnsCompletedEmitter() {
+            trackDevProperties.getSse().setEnabled(false);
+
+            AtomicBoolean completed = new AtomicBoolean(false);
+            SseEmitter emitter = sseEmitterService.subscribe(1L, "user1");
+            emitter.onCompletion(() -> completed.set(true));
+
+            // Disabled emitter completes immediately — total connections should not increment
+            assertEquals(0, sseEmitterService.getTotalConnections());
+        }
+
+        @Test
+        @DisplayName("when enabled, returns active emitter and increments counters")
+        void whenEnabled_returnsActiveEmitter() {
+            SseEmitter emitter = sseEmitterService.subscribe(1L, "user1");
+
+            assertNotNull(emitter);
+            assertEquals(1, sseEmitterService.getTotalConnections());
+            assertEquals(1, sseEmitterService.getUserConnectionCount("user1"));
+        }
+
+        @Test
+        @DisplayName("when max total connections reached, rejects new connection")
+        void whenMaxConnectionsReached_rejects() {
+            trackDevProperties.getSse().setMaxConnections(2);
+
+            sseEmitterService.subscribe(1L, "user1");
+            sseEmitterService.subscribe(1L, "user2");
+
+            // Third connection should be rejected
+            SseEmitter rejected = sseEmitterService.subscribe(1L, "user3");
+            assertNotNull(rejected);
+
+            // Counter should not have incremented for the rejected connection
+            assertEquals(2, sseEmitterService.getTotalConnections());
+            assertEquals(0, sseEmitterService.getUserConnectionCount("user3"));
+        }
+
+        @Test
+        @DisplayName("when max per-user connections reached, rejects for that user but allows others")
+        void whenMaxPerUserReached_rejectsForThatUser() {
+            trackDevProperties.getSse().setMaxConnectionsPerUser(1);
+
+            sseEmitterService.subscribe(1L, "userA");
+
+            // Second connection for same user should be rejected
+            SseEmitter rejected = sseEmitterService.subscribe(1L, "userA");
+            assertNotNull(rejected);
+            assertEquals(1, sseEmitterService.getUserConnectionCount("userA"));
+
+            // Different user should succeed
+            sseEmitterService.subscribe(1L, "userB");
+            assertEquals(1, sseEmitterService.getUserConnectionCount("userB"));
+            assertEquals(2, sseEmitterService.getTotalConnections());
+        }
+    }
+
+    @Nested
+    @DisplayName("publishTaskEvent()")
+    class PublishTaskEvent {
+
+        @Test
+        @DisplayName("when disabled, does not serialize or broadcast")
+        void whenDisabled_isNoOp() throws Exception {
+            trackDevProperties.getSse().setEnabled(false);
+
+            Task task = new Task();
+            ReflectionTestUtils.setField(task, "id", 1L);
+            Sprint sprint = new Sprint();
+            ReflectionTestUtils.setField(sprint, "id", 1L);
+            task.setActiveSprints(List.of(sprint));
+
+            User actor = new User();
+            ReflectionTestUtils.setField(actor, "id", "actor1");
+
+            sseEmitterService.publishTaskEvent(task, actor, "task_updated");
+
+            verify(objectMapper, never()).writeValueAsString(any());
+        }
+
+        @Test
+        @DisplayName("when enabled with subscriber, serializes and broadcasts")
+        void whenEnabled_broadcasts() throws Exception {
+            // Subscribe first
+            sseEmitterService.subscribe(1L, "user1");
+
+            Task task = new Task();
+            ReflectionTestUtils.setField(task, "id", 1L);
+            Sprint sprint = new Sprint();
+            ReflectionTestUtils.setField(sprint, "id", 1L);
+            task.setActiveSprints(List.of(sprint));
+
+            User actor = new User();
+            ReflectionTestUtils.setField(actor, "id", "actor1");
+
+            when(objectMapper.writeValueAsString(any())).thenReturn("{\"test\":true}");
+
+            sseEmitterService.publishTaskEvent(task, actor, "task_updated");
+
+            verify(objectMapper).writeValueAsString(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanup and shutdown")
+    class CleanupAndShutdown {
+
+        @Test
+        @DisplayName("shutdown completes all emitters and resets counters")
+        void shutdown_completesAllEmitters() {
+            sseEmitterService.subscribe(1L, "user1");
+            sseEmitterService.subscribe(2L, "user2");
+
+            assertEquals(2, sseEmitterService.getTotalConnections());
+
+            sseEmitterService.shutdown();
+
+            assertEquals(0, sseEmitterService.getTotalConnections());
+            assertEquals(0, sseEmitterService.getUserConnectionCount("user1"));
+            assertEquals(0, sseEmitterService.getUserConnectionCount("user2"));
+        }
+    }
+}

--- a/stress-test/sse-stress-test.js
+++ b/stress-test/sse-stress-test.js
@@ -1,0 +1,290 @@
+/**
+ * SSE Stress Test for TrackDev
+ *
+ * Uses the stress-test users seeded by DemoDataSeeder when
+ * STRESS_TEST_ENABLED=true. Each VU logs in as a different user
+ * (stress1@trackdev.com .. stress80@trackdev.com), opens an SSE
+ * connection, and makes REST calls concurrently.
+ *
+ * Prerequisites:
+ *   - k6 installed (https://grafana.com/docs/k6/latest/set-up/install-k6/)
+ *   - Backend running with: STRESS_TEST_ENABLED=true SSE_ENABLED=true
+ *   - Dev profile (stress users are only seeded in dev)
+ *
+ * Usage:
+ *   # Quick smoke test (10 users, 30s)
+ *   k6 run sse-stress-test.js
+ *
+ *   # Full simulation (80 users, 5 min) — matches DemoDataSeeder defaults
+ *   k6 run --env VUS=80 --env DURATION=5m sse-stress-test.js
+ *
+ *   # Against remote server
+ *   k6 run --env BASE_URL=https://your-server.com/api \
+ *          --env VUS=80 --env DURATION=5m sse-stress-test.js
+ *
+ *   # Ramp-up test (find the breaking point)
+ *   k6 run --env SCENARIO=ramp sse-stress-test.js
+ *
+ *   # Custom password / single user (fallback to original mode)
+ *   k6 run --env EMAIL=admin@trackdev.com --env PASSWORD=admin \
+ *          --env SPRINT_ID=1 sse-stress-test.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+import { SharedArray } from "k6/data";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080/api";
+const PASSWORD = __ENV.PASSWORD || "stress";
+const SPRINT_ID = __ENV.SPRINT_ID || "";  // empty = auto-discover
+const VUS = parseInt(__ENV.VUS || "10");
+const DURATION = __ENV.DURATION || "30s";
+const SCENARIO = __ENV.SCENARIO || "constant";
+const USER_COUNT = parseInt(__ENV.USER_COUNT || "80");
+
+// If EMAIL is set, use single-user mode (backward compatible)
+const SINGLE_USER_EMAIL = __ENV.EMAIL || "";
+
+// ---------------------------------------------------------------------------
+// Custom metrics
+// ---------------------------------------------------------------------------
+const sseConnected = new Counter("sse_connected");
+const sseRejected = new Counter("sse_rejected");
+const sseDisabled = new Counter("sse_disabled");
+const sseErrors = new Counter("sse_errors");
+const restLatency = new Trend("rest_api_latency", true);
+const restSuccess = new Rate("rest_api_success");
+const restUnderSLA = new Rate("rest_under_500ms");
+
+// ---------------------------------------------------------------------------
+// Generate user list (stress1@trackdev.com .. stressN@trackdev.com)
+// ---------------------------------------------------------------------------
+const stressUsers = new SharedArray("users", function () {
+  if (SINGLE_USER_EMAIL) {
+    return [{ email: SINGLE_USER_EMAIL, password: PASSWORD }];
+  }
+  const users = [];
+  for (let i = 1; i <= USER_COUNT; i++) {
+    users.push({ email: `stress${i}@trackdev.com`, password: PASSWORD });
+  }
+  return users;
+});
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+const scenarios = {
+  constant: {
+    constant_load: {
+      executor: "constant-vus",
+      vus: VUS,
+      duration: DURATION,
+    },
+  },
+  ramp: {
+    ramp_load: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "30s", target: 20 },
+        { duration: "30s", target: 40 },
+        { duration: "30s", target: 60 },
+        { duration: "30s", target: 80 },
+        { duration: "1m", target: 100 },
+        { duration: "30s", target: 100 },
+        { duration: "30s", target: 0 },
+      ],
+    },
+  },
+};
+
+export const options = {
+  scenarios: scenarios[SCENARIO] || scenarios.constant,
+  thresholds: {
+    rest_api_latency: ["p(95)<2000", "p(99)<5000"],
+    rest_api_success: ["rate>0.95"],
+    rest_under_500ms: ["rate>0.80"],
+    http_req_duration: ["p(95)<3000"],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Setup: authenticate all users and discover sprint IDs
+// ---------------------------------------------------------------------------
+export function setup() {
+  const tokens = [];
+
+  // Authenticate each unique user
+  const usersToAuth = SINGLE_USER_EMAIL
+    ? [stressUsers[0]]
+    : stressUsers.slice(0, Math.min(VUS, stressUsers.length));
+
+  console.log(`Authenticating ${usersToAuth.length} users...`);
+
+  for (const user of usersToAuth) {
+    const res = http.post(
+      `${BASE_URL}/auth/login`,
+      JSON.stringify({ email: user.email, password: user.password }),
+      { headers: { "Content-Type": "application/json" } },
+    );
+
+    if (res.status !== 200) {
+      console.error(`Login failed for ${user.email} (${res.status}): ${res.body}`);
+      continue;
+    }
+
+    const body = JSON.parse(res.body);
+    tokens.push({ email: user.email, token: body.token });
+  }
+
+  if (tokens.length === 0) {
+    throw new Error("No users could authenticate — aborting");
+  }
+
+  console.log(`${tokens.length} users authenticated successfully`);
+
+  // Auto-discover a sprint ID if not provided
+  let sprintId = SPRINT_ID;
+  if (!sprintId) {
+    const authHeaders = { Authorization: `Bearer ${tokens[0].token}` };
+    // Get user's projects
+    const projectsRes = http.get(`${BASE_URL}/projects`, { headers: authHeaders });
+    if (projectsRes.status === 200) {
+      try {
+        const projects = JSON.parse(projectsRes.body);
+        const projectList = projects.projects || projects;
+        if (Array.isArray(projectList) && projectList.length > 0) {
+          // Get sprints for the first project
+          const projectId = projectList[0].id;
+          const sprintsRes = http.get(`${BASE_URL}/projects/${projectId}/sprints`, {
+            headers: authHeaders,
+          });
+          if (sprintsRes.status === 200) {
+            try {
+              const data = JSON.parse(sprintsRes.body);
+              const sprintList = data.sprints || data;
+              if (Array.isArray(sprintList)) {
+                const active = sprintList.find(s => s.status === "ACTIVE");
+                if (active) {
+                  sprintId = String(active.id);
+                  console.log(`Auto-discovered active sprint ID: ${sprintId} (project ${projectId})`);
+                }
+              }
+            } catch {
+              // ignore parse errors
+            }
+          }
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    if (!sprintId) {
+      console.warn("Could not auto-discover sprint ID. SSE tests will be skipped.");
+    }
+  }
+
+  return { tokens, sprintId };
+}
+
+// ---------------------------------------------------------------------------
+// Main VU: each VU picks its own user, opens SSE, makes REST calls
+// ---------------------------------------------------------------------------
+export default function (data) {
+  // Pick user based on VU ID (each VU gets a different user)
+  const idx = (__VU - 1) % data.tokens.length;
+  const { token } = data.tokens[idx];
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+
+  // ── Phase 1: Open SSE connection (if we have a sprint) ────────────────
+  if (data.sprintId) {
+    const sseRes = http.get(`${BASE_URL}/sprints/${data.sprintId}/events`, {
+      headers: headers,
+      tags: { name: "SSE_connect" },
+      timeout: "10s",
+    });
+
+    const sseBody = sseRes.body || "";
+    if (sseRes.status === 200) {
+      if (sseBody.includes("event:connected") || sseBody.includes("event: connected")) {
+        sseConnected.add(1);
+      } else if (sseBody.includes("event:disabled") || sseBody.includes("event: disabled")) {
+        sseDisabled.add(1);
+      } else if (sseBody.includes("event:rejected") || sseBody.includes("event: rejected")) {
+        sseRejected.add(1);
+      } else {
+        sseConnected.add(1);
+      }
+    } else {
+      sseErrors.add(1);
+    }
+  }
+
+  // ── Phase 2: REST API calls under load ────────────────────────────────
+  for (let i = 0; i < 5; i++) {
+    // Lightweight endpoint
+    const selfRes = http.get(`${BASE_URL}/auth/self`, {
+      headers: headers,
+      tags: { name: "REST_self" },
+    });
+
+    restLatency.add(selfRes.timings.duration);
+    restSuccess.add(selfRes.status === 200 ? 1 : 0);
+    restUnderSLA.add(selfRes.timings.duration < 500 ? 1 : 0);
+
+    check(selfRes, {
+      "REST /auth/self is 200": (r) => r.status === 200,
+      "REST latency < 500ms": (r) => r.timings.duration < 500,
+      "REST latency < 2s": (r) => r.timings.duration < 2000,
+    });
+
+    // Heavier endpoint (if sprint available)
+    if (data.sprintId) {
+      const sprintRes = http.get(`${BASE_URL}/sprints/${data.sprintId}`, {
+        headers: headers,
+        tags: { name: "REST_sprint" },
+      });
+
+      restLatency.add(sprintRes.timings.duration);
+      restSuccess.add(sprintRes.status === 200 ? 1 : 0);
+      restUnderSLA.add(sprintRes.timings.duration < 500 ? 1 : 0);
+
+      check(sprintRes, {
+        "REST /sprints/:id is 200": (r) => r.status === 200,
+        "REST sprint latency < 2s": (r) => r.timings.duration < 2000,
+      });
+    }
+
+    sleep(1 + Math.random() * 2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+export function teardown(data) {
+  console.log("=".repeat(60));
+  console.log("SSE STRESS TEST COMPLETE");
+  console.log("=".repeat(60));
+  console.log(`Target:     ${BASE_URL}`);
+  console.log(`Sprint:     ${data.sprintId || "(none)"}`);
+  console.log(`Scenario:   ${SCENARIO}`);
+  console.log(`Users:      ${data.tokens.length}`);
+  console.log("");
+  console.log("Key metrics to check:");
+  console.log("  rest_api_latency p95 < 2000ms  (REST still fast?)");
+  console.log("  rest_api_success > 95%          (REST still working?)");
+  console.log("  rest_under_500ms > 80%          (REST not degraded?)");
+  console.log("  sse_connected                   (how many SSE connected?)");
+  console.log("  sse_rejected                    (connection limits working?)");
+  console.log("  sse_disabled                    (kill switch active?)");
+  console.log("=".repeat(60));
+}

--- a/stress-test/sse-stress-test.py
+++ b/stress-test/sse-stress-test.py
@@ -1,0 +1,712 @@
+#!/usr/bin/env python3
+"""
+SSE Stress Test for TrackDev — concurrent SSE + REST + mutations.
+
+Uses stress-test users seeded by DemoDataSeeder (STRESS_TEST_ENABLED=true).
+Each simulated user logs in as stress{N}@trackdev.com, opens an SSE
+connection, and makes REST calls concurrently. Mutation workers toggle
+task statuses (TODO ↔ INPROGRESS) to generate real SSE events.
+
+Prerequisites:
+  - Python 3.8+ with requests: pip install requests
+  - Backend running with: STRESS_TEST_ENABLED=true SSE_ENABLED=true
+
+Usage:
+  python sse-stress-test.py                              # 10 users, 60s
+  python sse-stress-test.py -n 80 -d 120                 # 80 users, 120s
+  python sse-stress-test.py -u http://localhost:8080/api  # custom URL
+  python sse-stress-test.py -m 0                          # disable mutations
+  python sse-stress-test.py -h                            # show help
+"""
+
+import argparse
+import random
+import statistics
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+
+import requests
+
+# ── Colors ──────────────────────────────────────────────────────────────────
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+BLUE = "\033[0;34m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+
+# ── Shared state ────────────────────────────────────────────────────────────
+@dataclass
+class Stats:
+    """Thread-safe stats collector."""
+
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    # SSE
+    sse_connected: int = 0
+    sse_rejected: int = 0
+    sse_disabled: int = 0
+    sse_errors: int = 0
+    sse_events_received: int = 0
+    # REST reads
+    rest_latencies: list = field(default_factory=list)
+    rest_failures: int = 0
+    # Mutations (task status toggles)
+    mutations_ok: int = 0
+    mutations_failed: int = 0
+    mutation_latencies: list = field(default_factory=list)
+
+    def record_sse(self, status: str):
+        with self.lock:
+            if status == "connected":
+                self.sse_connected += 1
+            elif status == "rejected":
+                self.sse_rejected += 1
+            elif status == "disabled":
+                self.sse_disabled += 1
+            else:
+                self.sse_errors += 1
+
+    def record_sse_event(self):
+        with self.lock:
+            self.sse_events_received += 1
+
+    def record_rest(self, latency_ms: float, success: bool):
+        with self.lock:
+            if success:
+                self.rest_latencies.append(latency_ms)
+            else:
+                self.rest_failures += 1
+
+    def record_mutation(self, latency_ms: float, success: bool):
+        with self.lock:
+            if success:
+                self.mutations_ok += 1
+                self.mutation_latencies.append(latency_ms)
+            else:
+                self.mutations_failed += 1
+
+
+stats = Stats()
+stop_event = threading.Event()
+
+
+# ── Authentication ──────────────────────────────────────────────────────────
+def authenticate_user(base_url: str, email: str, password: str) -> str | None:
+    """Returns JWT token or None on failure."""
+    try:
+        r = requests.post(
+            f"{base_url}/auth/login",
+            json={"email": email, "password": password},
+            timeout=10,
+        )
+        if r.status_code == 200:
+            return r.json().get("token")
+    except Exception:
+        pass
+    return None
+
+
+def authenticate_all(base_url: str, num_users: int, password: str) -> list[dict]:
+    """Authenticate all stress users concurrently. Returns list of {email, token}."""
+    print(f"\nAuthenticating {num_users} stress-test users...")
+    users = []
+    failed = 0
+
+    with ThreadPoolExecutor(max_workers=min(num_users, 20)) as pool:
+        futures = {}
+        for i in range(1, num_users + 1):
+            email = f"stress{i}@trackdev.com"
+            f = pool.submit(authenticate_user, base_url, email, password)
+            futures[f] = email
+
+        for f in as_completed(futures):
+            email = futures[f]
+            token = f.result()
+            if token:
+                users.append({"email": email, "token": token})
+            else:
+                failed += 1
+
+    print(f"  {GREEN}OK: {len(users)}{NC}  {RED}Failed: {failed}{NC}")
+    return users
+
+
+# ── Sprint discovery ────────────────────────────────────────────────────────
+def discover_user_sprint(base_url: str, token: str) -> int | None:
+    """Find an active sprint for a single user."""
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        r = requests.get(f"{base_url}/projects", headers=headers, timeout=10)
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        projects = data.get("projects", data) if isinstance(data, dict) else data
+        if not projects:
+            return None
+
+        project_id = projects[0]["id"]
+        r = requests.get(
+            f"{base_url}/projects/{project_id}/sprints",
+            headers=headers,
+            timeout=10,
+        )
+        if r.status_code != 200:
+            return None
+        data = r.json()
+        sprints = data.get("sprints", data) if isinstance(data, dict) else data
+        for s in sprints:
+            if s.get("status") == "ACTIVE":
+                return s["id"]
+    except Exception:
+        pass
+    return None
+
+
+def discover_all_sprints(
+    base_url: str, users: list[dict]
+) -> dict[int, list[dict]]:
+    """Map each user to their active sprint. Returns {sprint_id: [users]}.
+
+    Each stress user belongs to one project with one active sprint.
+    Users in the same project share the same sprint.
+    """
+    sprint_users: dict[int, list[dict]] = {}
+
+    print("Discovering sprints for all users...")
+    with ThreadPoolExecutor(max_workers=min(len(users), 20)) as pool:
+        futures = {
+            pool.submit(discover_user_sprint, base_url, u["token"]): u
+            for u in users
+        }
+        for f in as_completed(futures):
+            user = futures[f]
+            sid = f.result()
+            if sid:
+                sprint_users.setdefault(sid, []).append(user)
+
+    no_sprint = len(users) - sum(len(v) for v in sprint_users.values())
+    print(
+        f"  {GREEN}{len(sprint_users)} active sprints{NC} across "
+        f"{sum(len(v) for v in sprint_users.values())} users"
+        + (f"  ({YELLOW}{no_sprint} users without sprint{NC})" if no_sprint else "")
+    )
+    for sid, susers in sprint_users.items():
+        print(f"    Sprint {sid}: {len(susers)} users")
+    return sprint_users
+
+
+# ── Task discovery for mutations ────────────────────────────────────────────
+def get_user_id(base_url: str, token: str) -> str | None:
+    """Get the current user's ID from /auth/self."""
+    try:
+        r = requests.get(
+            f"{base_url}/auth/self",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if r.status_code == 200:
+            return r.json().get("id")
+    except Exception:
+        pass
+    return None
+
+
+def discover_toggleable_tasks(
+    base_url: str, token: str, sprint_id: int, user_id: str | None = None
+) -> list[dict]:
+    """Fetch sprint board and find subtasks in TODO or INPROGRESS status.
+
+    If user_id is provided, only returns tasks assigned to that user
+    (required by business rule: only assignee can change task status).
+
+    Returns list of {id, status} for tasks that can be toggled.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        r = requests.get(
+            f"{base_url}/sprints/{sprint_id}/board",
+            headers=headers,
+            timeout=10,
+        )
+        if r.status_code != 200:
+            return []
+        data = r.json()
+        tasks = data.get("tasks", [])
+        toggleable = []
+        for t in tasks:
+            task_type = t.get("type", "")
+            status = t.get("status", "")
+            # Only toggle subtasks (TASK/BUG), not USER_STORYs
+            if task_type not in ("TASK", "BUG") or status not in ("TODO", "INPROGRESS"):
+                continue
+            # Only toggle tasks assigned to this user (business rule)
+            if user_id is not None:
+                assignee = t.get("assignee")
+                if not assignee or assignee.get("id") != user_id:
+                    continue
+            toggleable.append({"id": t["id"], "status": status})
+        return toggleable
+    except Exception:
+        return []
+
+
+# ── Baseline measurement ───────────────────────────────────────────────────
+def measure_baseline(base_url: str, token: str, n: int = 5) -> float:
+    """Measure average REST latency before SSE load."""
+    headers = {"Authorization": f"Bearer {token}"}
+    times = []
+    for _ in range(n):
+        start = time.monotonic()
+        try:
+            r = requests.get(
+                f"{base_url}/auth/self", headers=headers, timeout=10
+            )
+            elapsed = (time.monotonic() - start) * 1000
+            if r.status_code == 200:
+                times.append(elapsed)
+        except Exception:
+            pass
+    return statistics.mean(times) if times else 0
+
+
+# ── SSE worker ──────────────────────────────────────────────────────────────
+def sse_worker(
+    base_url: str, token: str, sprint_id: int, user_label: str, duration: int
+):
+    """Hold an SSE connection open, counting events until stop_event is set."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "text/event-stream",
+    }
+    status = "error"
+    try:
+        # (connect_timeout, read_timeout) — keep the stream open for the full test
+        with requests.get(
+            f"{base_url}/sprints/{sprint_id}/events",
+            headers=headers,
+            stream=True,
+            timeout=(5, duration + 30),
+        ) as r:
+            if r.status_code != 200:
+                stats.record_sse("error")
+                return
+
+            for line in r.iter_lines(decode_unicode=True):
+                if stop_event.is_set():
+                    break
+                if not line:
+                    continue
+                if line.startswith("event:") or line.startswith("event: "):
+                    event_type = line.split(":", 1)[1].strip()
+                    if event_type == "connected":
+                        status = "connected"
+                        stats.record_sse("connected")
+                    elif event_type == "disabled":
+                        status = "disabled"
+                        stats.record_sse("disabled")
+                        return
+                    elif event_type == "rejected":
+                        status = "rejected"
+                        stats.record_sse("rejected")
+                        return
+                    elif event_type == "task_event":
+                        stats.record_sse_event()
+
+    except requests.exceptions.Timeout:
+        if status == "error":
+            stats.record_sse("error")
+    except Exception:
+        if status == "error":
+            stats.record_sse("error")
+
+
+# ── REST read worker ────────────────────────────────────────────────────────
+def rest_worker(
+    base_url: str, tokens: list[str], sprint_id: int | None, interval: float
+):
+    """Make periodic REST GET calls using random user tokens until stop_event."""
+    while not stop_event.is_set():
+        token = random.choice(tokens)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # GET /auth/self (lightweight)
+        try:
+            start = time.monotonic()
+            r = requests.get(
+                f"{base_url}/auth/self", headers=headers, timeout=10
+            )
+            ms = (time.monotonic() - start) * 1000
+            stats.record_rest(ms, r.status_code == 200)
+        except Exception:
+            stats.record_rest(10000, False)
+
+        # GET /sprints/{id}/board (heavier, realistic)
+        if sprint_id:
+            try:
+                start = time.monotonic()
+                r = requests.get(
+                    f"{base_url}/sprints/{sprint_id}/board",
+                    headers=headers,
+                    timeout=10,
+                )
+                ms = (time.monotonic() - start) * 1000
+                stats.record_rest(ms, r.status_code == 200)
+            except Exception:
+                stats.record_rest(10000, False)
+
+        stop_event.wait(interval + random.random())
+
+
+# ── Mutation worker ─────────────────────────────────────────────────────────
+def mutation_worker(
+    base_url: str,
+    tokens: list[str],
+    sprint_id: int,
+    interval: float,
+):
+    """Toggle task statuses (TODO <-> INPROGRESS) to generate SSE events.
+
+    Each iteration picks a random user, resolves their ID, and only toggles
+    tasks assigned to them (business rule: only assignee can change status).
+    """
+    # Build a map of token → user_id for all users in this sprint
+    token_user_ids: dict[str, str | None] = {}
+    for token in tokens:
+        uid = get_user_id(base_url, token)
+        if uid:
+            token_user_ids[token] = uid
+    valid_tokens = [t for t, uid in token_user_ids.items() if uid]
+    if not valid_tokens:
+        valid_tokens = tokens  # fallback
+
+    while not stop_event.is_set():
+        token = random.choice(valid_tokens)
+        user_id = token_user_ids.get(token)
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+        # Discover toggleable tasks assigned to this user
+        tasks = discover_toggleable_tasks(base_url, token, sprint_id, user_id)
+        if not tasks:
+            stop_event.wait(interval)
+            continue
+
+        task = random.choice(tasks)
+        new_status = "INPROGRESS" if task["status"] == "TODO" else "TODO"
+
+        try:
+            start = time.monotonic()
+            r = requests.patch(
+                f"{base_url}/tasks/{task['id']}",
+                headers=headers,
+                json={"status": new_status},
+                timeout=10,
+            )
+            ms = (time.monotonic() - start) * 1000
+            stats.record_mutation(ms, r.status_code == 200)
+        except Exception:
+            stats.record_mutation(10000, False)
+
+        stop_event.wait(interval + random.random() * 2)
+
+
+# ── Live progress ───────────────────────────────────────────────────────────
+def progress_reporter(duration: int):
+    """Print periodic stats while the test runs."""
+    start = time.monotonic()
+    while not stop_event.is_set():
+        stop_event.wait(5)
+        if stop_event.is_set():
+            break
+        elapsed = int(time.monotonic() - start)
+        with stats.lock:
+            n = len(stats.rest_latencies)
+            avg = statistics.mean(stats.rest_latencies) if n else 0
+            mx = max(stats.rest_latencies) if n else 0
+            sse = stats.sse_connected
+            evts = stats.sse_events_received
+            muts = stats.mutations_ok
+
+        color = GREEN if avg < 500 else (YELLOW if avg < 2000 else RED)
+        print(
+            f"  [{elapsed:3d}s/{duration}s]  "
+            f"SSE: {sse} conn  "
+            f"REST: {color}{avg:.0f}ms avg{NC} / {mx:.0f}ms max  "
+            f"({n} reads, {muts} mutations, {evts} SSE events)"
+        )
+
+
+# ── Results ─────────────────────────────────────────────────────────────────
+def print_results(baseline_ms: float):
+    lats = stats.rest_latencies
+    mlats = stats.mutation_latencies
+
+    print(f"\n{BOLD}{'=' * 60}{NC}")
+    print(f"{BOLD}  RESULTS{NC}")
+    print(f"{BOLD}{'=' * 60}{NC}")
+
+    # SSE
+    print(f"\n{BOLD}SSE Connections:{NC}")
+    print(f"  Connected:  {GREEN}{stats.sse_connected}{NC}")
+    print(
+        f"  Rejected:   {YELLOW}{stats.sse_rejected}{NC} (connection limits working)"
+    )
+    print(f"  Disabled:   {BLUE}{stats.sse_disabled}{NC} (kill switch active)")
+    print(f"  Errors:     {RED}{stats.sse_errors}{NC}")
+    print(f"  Events rx:  {stats.sse_events_received}")
+
+    # REST reads
+    print(f"\n{BOLD}REST API reads (under load):{NC}")
+    if lats:
+        avg = statistics.mean(lats)
+        p50 = statistics.median(lats)
+        sorted_lats = sorted(lats)
+        p95 = sorted_lats[int(len(lats) * 0.95)] if len(lats) >= 2 else avg
+        p99 = sorted_lats[int(len(lats) * 0.99)] if len(lats) >= 2 else avg
+        mx = max(lats)
+        over500 = sum(1 for x in lats if x > 500)
+        over2000 = sum(1 for x in lats if x > 2000)
+
+        print(f"  Baseline avg:   {baseline_ms:.0f}ms (before load)")
+        print(f"  Under-load avg: {avg:.0f}ms")
+        print(f"  p50:            {p50:.0f}ms")
+        print(f"  p95:            {p95:.0f}ms")
+        print(f"  p99:            {p99:.0f}ms")
+        print(f"  Max:            {mx:.0f}ms")
+        print(f"  Total calls:    {len(lats)}")
+        print(f"  Failures:       {RED}{stats.rest_failures}{NC}")
+        print(f"  > 500ms:        {YELLOW}{over500}{NC}")
+        print(f"  > 2000ms:       {RED}{over2000}{NC}")
+
+        if baseline_ms > 0:
+            degradation = avg / baseline_ms * 100
+            print(f"\n  Degradation:    {degradation:.0f}% of baseline")
+            if degradation <= 200:
+                print(f"  {GREEN}✓ REST reads are healthy under load{NC}")
+            elif degradation <= 500:
+                print(f"  {YELLOW}⚠ REST reads show some degradation{NC}")
+            else:
+                print(f"  {RED}✗ REST reads are severely degraded!{NC}")
+    else:
+        print(f"  {YELLOW}No REST read checks completed{NC}")
+
+    # Mutations
+    print(f"\n{BOLD}Mutations (task status toggles → SSE broadcasts):{NC}")
+    if mlats:
+        mavg = statistics.mean(mlats)
+        mp50 = statistics.median(mlats)
+        sorted_mlats = sorted(mlats)
+        mp95 = (
+            sorted_mlats[int(len(mlats) * 0.95)] if len(mlats) >= 2 else mavg
+        )
+        print(f"  Successful:     {GREEN}{stats.mutations_ok}{NC}")
+        print(f"  Failed:         {RED}{stats.mutations_failed}{NC}")
+        print(f"  Avg latency:    {mavg:.0f}ms")
+        print(f"  p50:            {mp50:.0f}ms")
+        print(f"  p95:            {mp95:.0f}ms")
+        print(f"  Max:            {max(mlats):.0f}ms")
+    else:
+        total = stats.mutations_ok + stats.mutations_failed
+        if total == 0:
+            print(f"  {YELLOW}No mutations attempted{NC}")
+        else:
+            print(f"  {RED}All {stats.mutations_failed} mutations failed{NC}")
+
+    # SSE event delivery check
+    if stats.mutations_ok > 0 and stats.sse_connected > 0:
+        # Each mutation should produce at least 1 event per connected client
+        expected_min = stats.mutations_ok
+        ratio = stats.sse_events_received / expected_min if expected_min else 0
+        print(f"\n{BOLD}SSE event delivery:{NC}")
+        print(f"  Mutations fired: {stats.mutations_ok}")
+        print(f"  Events received: {stats.sse_events_received}")
+        print(f"  Ratio:           {ratio:.1f}x (expected ~{stats.sse_connected}x for {stats.sse_connected} listeners)")
+        if ratio >= 0.5:
+            print(f"  {GREEN}✓ SSE events are being delivered{NC}")
+        else:
+            print(f"  {RED}✗ SSE events may be lost or delayed{NC}")
+
+    print(f"\n{BOLD}{'=' * 60}{NC}")
+
+
+# ── Main ────────────────────────────────────────────────────────────────────
+def main():
+    parser = argparse.ArgumentParser(
+        description="SSE Stress Test for TrackDev",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Start backend with: STRESS_TEST_ENABLED=true SSE_ENABLED=true",
+    )
+    parser.add_argument(
+        "-u", "--url", default="http://localhost:8080/api", help="Base API URL"
+    )
+    parser.add_argument(
+        "-p", "--password", default="stress", help="Shared password"
+    )
+    parser.add_argument(
+        "-s", "--sprint-id", type=int, default=0, help="Sprint ID (0=auto)"
+    )
+    parser.add_argument(
+        "-n",
+        "--num-users",
+        type=int,
+        default=10,
+        help="Number of concurrent users / SSE connections",
+    )
+    parser.add_argument(
+        "-d", "--duration", type=int, default=60, help="Duration in seconds"
+    )
+    parser.add_argument(
+        "-i",
+        "--interval",
+        type=float,
+        default=2,
+        help="REST read interval per worker (seconds)",
+    )
+    parser.add_argument(
+        "-r",
+        "--rest-workers",
+        type=int,
+        default=0,
+        help="Number of REST read worker threads (default: num_users/4, min 2)",
+    )
+    parser.add_argument(
+        "-m",
+        "--mutation-workers",
+        type=int,
+        default=0,
+        help="Number of mutation workers toggling tasks (default: num_users/8, min 1)",
+    )
+    parser.add_argument(
+        "--mutation-interval",
+        type=float,
+        default=3,
+        help="Min seconds between mutations per worker (default: 3)",
+    )
+    args = parser.parse_args()
+
+    base_url = args.url
+    num_users = args.num_users
+    rest_workers = args.rest_workers or max(2, num_users // 4)
+    mutation_workers = args.mutation_workers if args.mutation_workers is not None else max(1, num_users // 8)
+    # -m 0 explicitly disables mutations
+    if args.mutation_workers == 0 and "--mutation-workers" not in sys.argv and "-m" not in sys.argv:
+        mutation_workers = max(1, num_users // 8)
+
+    print(f"{BOLD}{'=' * 60}{NC}")
+    print(f"{BOLD}  TrackDev SSE Stress Test (Python){NC}")
+    print(f"{BOLD}{'=' * 60}{NC}")
+    print(f"  Server:           {BLUE}{base_url}{NC}")
+    print(f"  Users / SSE:      {BLUE}{num_users}{NC}")
+    print(f"  Duration:         {BLUE}{args.duration}s{NC}")
+    print(f"  REST workers:     {BLUE}{rest_workers}{NC} (interval: {args.interval}s)")
+    print(f"  Mutation workers: {BLUE}{mutation_workers}{NC} (interval: {args.mutation_interval}s)")
+    print(f"{BOLD}{'-' * 60}{NC}")
+
+    # 1. Authenticate
+    users = authenticate_all(base_url, num_users, args.password)
+    if not users:
+        print(f"{RED}No users authenticated. Is STRESS_TEST_ENABLED=true?{NC}")
+        sys.exit(1)
+
+    tokens = [u["token"] for u in users]
+
+    # 2. Discover sprints — each user maps to their project's active sprint
+    if args.sprint_id:
+        # Manual override: all users on one sprint
+        sprint_users = {args.sprint_id: users}
+        print(f"Using manual sprint ID: {args.sprint_id}")
+    else:
+        sprint_users = discover_all_sprints(base_url, users)
+        if not sprint_users:
+            print(f"{YELLOW}No active sprints found — SSE and mutation tests skipped{NC}")
+
+    # 3. Baseline
+    print("Measuring baseline REST latency...", end=" ")
+    baseline = measure_baseline(base_url, tokens[0])
+    print(f"{GREEN}{baseline:.0f}ms avg{NC}")
+
+    # 4. Launch everything concurrently
+    total_sse = sum(len(v) for v in sprint_users.values())
+    print(
+        f"\n{BOLD}Starting load test: "
+        f"{total_sse} SSE + {rest_workers} REST + {mutation_workers} mutation "
+        f"for {args.duration}s...{NC}"
+    )
+
+    threads: list[threading.Thread] = []
+
+    # SSE threads — each user connects to their own project's sprint
+    for sprint_id, susers in sprint_users.items():
+        for u in susers:
+            t = threading.Thread(
+                target=sse_worker,
+                args=(base_url, u["token"], sprint_id, u["email"], args.duration),
+                daemon=True,
+            )
+            t.start()
+            threads.append(t)
+    if total_sse:
+        print(f"  {GREEN}Launched {total_sse} SSE connections across {len(sprint_users)} sprints{NC}")
+
+    # REST read worker threads — scope tokens per sprint so workers only query sprints they have access to
+    sprint_list = list(sprint_users.items()) if sprint_users else [(None, users)]
+    for i in range(rest_workers):
+        sid, susers = sprint_list[i % len(sprint_list)]
+        sprint_tokens = [u["token"] for u in susers]
+        t = threading.Thread(
+            target=rest_worker,
+            args=(base_url, sprint_tokens, sid, args.interval),
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+    print(f"  {GREEN}Launched {rest_workers} REST read workers{NC}")
+
+    # Mutation workers — one per sprint (at least), using only users with access
+    if sprint_users and mutation_workers > 0:
+        # Distribute mutation workers across sprints
+        sprint_list = list(sprint_users.items())
+        launched_mutations = 0
+        for i in range(mutation_workers):
+            sprint_id, susers = sprint_list[i % len(sprint_list)]
+            sprint_tokens = [u["token"] for u in susers]
+            t = threading.Thread(
+                target=mutation_worker,
+                args=(base_url, sprint_tokens, sprint_id, args.mutation_interval),
+                daemon=True,
+            )
+            t.start()
+            threads.append(t)
+            launched_mutations += 1
+        print(
+            f"  {GREEN}Launched {launched_mutations} mutation workers "
+            f"across {len(sprint_list)} sprints (toggling TODO ↔ INPROGRESS){NC}"
+        )
+
+    # Progress reporter
+    progress_t = threading.Thread(
+        target=progress_reporter, args=(args.duration,), daemon=True
+    )
+    progress_t.start()
+
+    # 5. Wait for duration
+    try:
+        time.sleep(args.duration)
+    except KeyboardInterrupt:
+        print(f"\n{YELLOW}Interrupted — stopping...{NC}")
+
+    stop_event.set()
+    time.sleep(2)
+
+    # 6. Print results
+    print_results(baseline)
+
+
+if __name__ == "__main__":
+    main()

--- a/stress-test/sse-stress-test.sh
+++ b/stress-test/sse-stress-test.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# ============================================================================
+# SSE Stress Test (zero dependencies — uses only curl and bash)
+#
+# Uses stress-test users seeded by DemoDataSeeder (STRESS_TEST_ENABLED=true).
+# Each simulated user logs in as stress{N}@trackdev.com with shared password.
+#
+# Usage:
+#   ./sse-stress-test.sh                           # defaults: 10 SSE + REST checks
+#   ./sse-stress-test.sh -u http://localhost:8080/api  # local dev server
+#   ./sse-stress-test.sh -n 80 -d 120             # 80 SSE users, 120s duration
+#   ./sse-stress-test.sh -h                        # show help
+# ============================================================================
+
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+BASE_URL="${BASE_URL:-http://localhost:8080/api}"
+PASSWORD="${PASSWORD:-stress}"
+SPRINT_ID="${SPRINT_ID:-}"
+NUM_SSE="${NUM_SSE:-10}"
+DURATION="${DURATION:-60}"
+REST_INTERVAL="${REST_INTERVAL:-2}"
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Parse args ───────────────────────────────────────────────────────────────
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Uses stress-test users: stress1@trackdev.com .. stressN@trackdev.com"
+    echo "Start backend with: STRESS_TEST_ENABLED=true SSE_ENABLED=true"
+    echo ""
+    echo "Options:"
+    echo "  -u URL      Base URL (default: $BASE_URL)"
+    echo "  -p PASS     Shared password (default: $PASSWORD)"
+    echo "  -s ID       Sprint ID (auto-discovered if empty)"
+    echo "  -n NUM      Number of SSE connections / users (default: $NUM_SSE)"
+    echo "  -d SECS     Duration in seconds (default: $DURATION)"
+    echo "  -i SECS     REST check interval (default: $REST_INTERVAL)"
+    echo "  -h          Show this help"
+    exit 0
+}
+
+while getopts "u:p:s:n:d:i:h" opt; do
+    case $opt in
+        u) BASE_URL="$OPTARG" ;;
+        p) PASSWORD="$OPTARG" ;;
+        s) SPRINT_ID="$OPTARG" ;;
+        n) NUM_SSE="$OPTARG" ;;
+        d) DURATION="$OPTARG" ;;
+        i) REST_INTERVAL="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+# ── Temp directory for tracking results ──────────────────────────────────────
+TMPDIR=$(mktemp -d /tmp/sse-stress-XXXXXX)
+
+# ── Results (defined early so cleanup can call it) ──────────────────────────
+print_results() {
+    echo ""
+    echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}  RESULTS${NC}"
+    echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+
+    local SSE_OK=0 SSE_REJ=0 SSE_DIS=0 SSE_ERR=0
+    for f in "$TMPDIR"/sse-*.status; do
+        [ -f "$f" ] || continue
+        case "$(cat "$f")" in
+            connected) SSE_OK=$((SSE_OK + 1)) ;;
+            rejected)  SSE_REJ=$((SSE_REJ + 1)) ;;
+            disabled)  SSE_DIS=$((SSE_DIS + 1)) ;;
+            *)         SSE_ERR=$((SSE_ERR + 1)) ;;
+        esac
+    done
+
+    echo -e "\n${BOLD}SSE Connections:${NC}"
+    echo -e "  Connected:  ${GREEN}$SSE_OK${NC}"
+    echo -e "  Rejected:   ${YELLOW}$SSE_REJ${NC} (connection limits working)"
+    echo -e "  Disabled:   ${BLUE}$SSE_DIS${NC} (kill switch active)"
+    echo -e "  Errors:     ${RED}$SSE_ERR${NC}"
+
+    echo -e "\n${BOLD}REST API (under SSE load):${NC}"
+    if [ "${REST_COUNT:-0}" -gt 0 ]; then
+        local REST_AVG=$((${REST_TOTAL_MS:-0} / REST_COUNT))
+        echo -e "  Baseline avg:   ${BASELINE_AVG:-0}ms (before SSE)"
+        echo -e "  Under-load avg: ${REST_AVG}ms"
+        echo -e "  Max latency:    ${REST_MAX_MS:-0}ms"
+        echo -e "  Total checks:   ${REST_COUNT}"
+        echo -e "  OK:             ${GREEN}${REST_PASS:-0}${NC}  Failed: ${RED}${REST_FAIL:-0}${NC}"
+        echo -e "  > 500ms:        ${YELLOW}${REST_OVER_500:-0}${NC}"
+        echo -e "  > 2000ms:       ${RED}${REST_OVER_2000:-0}${NC}"
+
+        if [ "${BASELINE_AVG:-0}" -gt 0 ]; then
+            local DEGRADATION=$((REST_AVG * 100 / BASELINE_AVG))
+            echo -e "\n  Degradation:    ${DEGRADATION}% of baseline"
+            if [ "$DEGRADATION" -le 200 ]; then
+                echo -e "  ${GREEN}✓ REST API is healthy under SSE load${NC}"
+            elif [ "$DEGRADATION" -le 500 ]; then
+                echo -e "  ${YELLOW}⚠ REST API shows some degradation${NC}"
+            else
+                echo -e "  ${RED}✗ REST API is severely degraded by SSE!${NC}"
+            fi
+        fi
+    else
+        echo -e "  ${YELLOW}No REST checks completed${NC}"
+    fi
+
+    echo -e "\n${BOLD}══════════════════════════════════════════════════${NC}"
+}
+
+trap 'cleanup' EXIT
+
+cleanup() {
+    echo -e "\n${BLUE}Cleaning up...${NC}"
+    jobs -p 2>/dev/null | xargs -r kill 2>/dev/null || true
+    wait 2>/dev/null || true
+    print_results
+    rm -rf "$TMPDIR"
+}
+
+# ── Step 1: Authenticate all users ──────────────────────────────────────────
+echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}  TrackDev SSE Stress Test${NC}"
+echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+echo -e "  Server:     ${BLUE}$BASE_URL${NC}"
+echo -e "  SSE conns:  ${BLUE}$NUM_SSE${NC}"
+echo -e "  Duration:   ${BLUE}${DURATION}s${NC}"
+echo -e "  Password:   ${BLUE}$PASSWORD${NC}"
+echo -e "${BOLD}──────────────────────────────────────────────────${NC}"
+
+echo -e "\nAuthenticating $NUM_SSE stress-test users..."
+declare -a TOKENS
+AUTH_OK=0
+AUTH_FAIL=0
+
+for i in $(seq 1 "$NUM_SSE"); do
+    EMAIL="stress${i}@trackdev.com"
+    LOGIN_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/auth/login" \
+        -H "Content-Type: application/json" \
+        -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" 2>/dev/null)
+
+    HTTP_CODE=$(echo "$LOGIN_RESPONSE" | tail -1)
+    BODY=$(echo "$LOGIN_RESPONSE" | sed '$d')
+
+    if [ "$HTTP_CODE" = "200" ]; then
+        TOKEN=$(echo "$BODY" | grep -o '"token":"[^"]*"' | cut -d'"' -f4)
+        if [ -n "$TOKEN" ]; then
+            TOKENS+=("$TOKEN")
+            AUTH_OK=$((AUTH_OK + 1))
+        else
+            AUTH_FAIL=$((AUTH_FAIL + 1))
+        fi
+    else
+        AUTH_FAIL=$((AUTH_FAIL + 1))
+    fi
+
+    if (( i % 10 == 0 )); then
+        echo -e "  Authenticated $i / $NUM_SSE users"
+    fi
+done
+
+echo -e "  ${GREEN}OK: $AUTH_OK${NC}  ${RED}Failed: $AUTH_FAIL${NC}"
+
+if [ "$AUTH_OK" -eq 0 ]; then
+    echo -e "${RED}No users could authenticate. Is STRESS_TEST_ENABLED=true?${NC}"
+    exit 1
+fi
+
+FIRST_TOKEN="${TOKENS[0]}"
+
+# ── Auto-discover sprint ID if not provided ─────────────────────────────────
+if [ -z "$SPRINT_ID" ]; then
+    echo -ne "Auto-discovering active sprint... "
+    # Get user's projects first
+    PROJECTS_RESPONSE=$(curl -s -H "Authorization: Bearer $FIRST_TOKEN" \
+        "$BASE_URL/projects" 2>/dev/null || true)
+    PROJECT_ID=$(echo "$PROJECTS_RESPONSE" | grep -o '"id":[0-9]*' | head -1 | cut -d: -f2 || true)
+    if [ -n "$PROJECT_ID" ]; then
+        # Get sprints for that project and find an ACTIVE one
+        SPRINTS_RESPONSE=$(curl -s -H "Authorization: Bearer $FIRST_TOKEN" \
+            "$BASE_URL/projects/$PROJECT_ID/sprints" 2>/dev/null || true)
+        SPRINT_ID=$(echo "$SPRINTS_RESPONSE" | grep -o '"id":[0-9]*,"value":"[^"]*","label":"[^"]*","startDate":"[^"]*","endDate":"[^"]*","status":"ACTIVE"' \
+            | head -1 | grep -o '"id":[0-9]*' | cut -d: -f2 || true)
+    fi
+    if [ -n "$SPRINT_ID" ]; then
+        echo -e "${GREEN}found sprint $SPRINT_ID (project $PROJECT_ID)${NC}"
+    else
+        echo -e "${YELLOW}none found, SSE tests will be skipped${NC}"
+    fi
+fi
+
+# ── Step 2: Baseline REST latency ───────────────────────────────────────────
+echo -ne "Measuring baseline REST latency... "
+BASELINE_TOTAL=0
+BASELINE_COUNT=5
+for i in $(seq 1 $BASELINE_COUNT); do
+    T=$(curl -s -o /dev/null -w "%{time_total}" \
+        -H "Authorization: Bearer $FIRST_TOKEN" \
+        "$BASE_URL/auth/self" 2>/dev/null)
+    MS=$(echo "$T * 1000" | bc | cut -d. -f1)
+    BASELINE_TOTAL=$((BASELINE_TOTAL + MS))
+done
+BASELINE_AVG=$((BASELINE_TOTAL / BASELINE_COUNT))
+echo -e "${GREEN}${BASELINE_AVG}ms avg${NC}"
+
+# ── Step 3: Open N SSE connections (each with its own user token) ───────────
+if [ -n "$SPRINT_ID" ]; then
+    echo -e "\n${BOLD}Opening $AUTH_OK SSE connections (each as a different user)...${NC}"
+
+    for i in $(seq 0 $((AUTH_OK - 1))); do
+        TOKEN="${TOKENS[$i]}"
+        USER_NUM=$((i + 1))
+        (
+            RESPONSE=$(curl -s -m "$DURATION" --no-buffer \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Accept: text/event-stream" \
+                "$BASE_URL/sprints/$SPRINT_ID/events" 2>/dev/null || true)
+
+            if echo "$RESPONSE" | grep -q "event:connected\|event: connected"; then
+                echo "connected" > "$TMPDIR/sse-$USER_NUM.status"
+            elif echo "$RESPONSE" | grep -q "event:disabled\|event: disabled"; then
+                echo "disabled" > "$TMPDIR/sse-$USER_NUM.status"
+            elif echo "$RESPONSE" | grep -q "event:rejected\|event: rejected"; then
+                echo "rejected" > "$TMPDIR/sse-$USER_NUM.status"
+            else
+                echo "error" > "$TMPDIR/sse-$USER_NUM.status"
+            fi
+        ) &
+
+        if (( (i + 1) % 10 == 0 )); then
+            echo -e "  Opened $((i + 1)) / $AUTH_OK connections"
+            sleep 0.5
+        fi
+    done
+    echo -e "  ${GREEN}All $AUTH_OK SSE connections launched${NC}"
+    sleep 2
+else
+    echo -e "\n${YELLOW}Skipping SSE connections (no sprint ID)${NC}"
+fi
+
+# ── Step 4: REST latency monitoring under load ──────────────────────────────
+echo -e "\n${BOLD}Monitoring REST API latency under SSE load (${DURATION}s)...${NC}"
+
+REST_COUNT=0
+REST_PASS=0
+REST_FAIL=0
+REST_TOTAL_MS=0
+REST_MAX_MS=0
+REST_OVER_500=0
+REST_OVER_2000=0
+
+END_TIME=$((SECONDS + DURATION))
+
+while [ $SECONDS -lt $END_TIME ]; do
+    # Pick a random user token for REST calls
+    IDX=$((RANDOM % AUTH_OK))
+    TOKEN="${TOKENS[$IDX]}"
+
+    SELF_TIME=$(curl -s -o /dev/null -w "%{time_total}" --max-time 10 \
+        -H "Authorization: Bearer $TOKEN" \
+        "$BASE_URL/auth/self" 2>/dev/null || echo "10.0")
+    SELF_MS=$(echo "$SELF_TIME * 1000" | bc | cut -d. -f1)
+
+    SPRINT_MS=0
+    if [ -n "$SPRINT_ID" ]; then
+        SPRINT_TIME=$(curl -s -o /dev/null -w "%{time_total}" --max-time 10 \
+            -H "Authorization: Bearer $TOKEN" \
+            "$BASE_URL/sprints/$SPRINT_ID" 2>/dev/null || echo "10.0")
+        SPRINT_MS=$(echo "$SPRINT_TIME * 1000" | bc | cut -d. -f1)
+    fi
+
+    for MS in $SELF_MS $SPRINT_MS; do
+        [ "$MS" -eq 0 ] && continue
+        REST_COUNT=$((REST_COUNT + 1))
+        REST_TOTAL_MS=$((REST_TOTAL_MS + MS))
+        [ "$MS" -gt "$REST_MAX_MS" ] && REST_MAX_MS=$MS
+        if [ "$MS" -gt 2000 ]; then
+            REST_OVER_2000=$((REST_OVER_2000 + 1))
+            REST_FAIL=$((REST_FAIL + 1))
+        elif [ "$MS" -gt 500 ]; then
+            REST_OVER_500=$((REST_OVER_500 + 1))
+            REST_PASS=$((REST_PASS + 1))
+        else
+            REST_PASS=$((REST_PASS + 1))
+        fi
+    done
+
+    COLOR=$GREEN
+    [ "$SELF_MS" -gt 500 ] && COLOR=$YELLOW
+    [ "$SELF_MS" -gt 2000 ] && COLOR=$RED
+    ELAPSED=$SECONDS
+    printf "  [%3ds] /auth/self: ${COLOR}%4dms${NC}" "$ELAPSED" "$SELF_MS"
+
+    if [ -n "$SPRINT_ID" ]; then
+        COLOR=$GREEN
+        [ "$SPRINT_MS" -gt 500 ] && COLOR=$YELLOW
+        [ "$SPRINT_MS" -gt 2000 ] && COLOR=$RED
+        printf "  /sprints/%s: ${COLOR}%4dms${NC}" "$SPRINT_ID" "$SPRINT_MS"
+    fi
+    printf "  (user: stress%d)\n" "$((IDX + 1))"
+
+    sleep "$REST_INTERVAL"
+done
+


### PR DESCRIPTION
## Summary

Activates the previously disabled SSE endpoint for sprint task events, adding configurable connection limits, per-user caps, and dedicated thread pools to prevent database connection exhaustion. Includes HikariCP pool tuning, OSIV exclusion for long-lived SSE connections, and stress test infrastructure with seeded users and scripts in k6, Python, and bash.

## Commits

- `cecd3b0` feat(configuration): update properties to add sse and stress test settings
- `489cec0` feat(configuration): update web config to add async and sse support
- `fd54e76` feat(controller): update sse endpoint to enable sprint subscriptions
- `14ef1d9` feat(service): update seeder to add stress test data generation
- `d3a79a0` feat(service): update sprint service to add sse access check
- `d18d17a` feat(service): update sse emitter with connection limits and config
- `e79e2a4` chore(resources): update dev config to add sse, hikari and pool settings
- `018a025` chore(resources): update prod config to add sse and hikari settings
- `58cd872` test(service): add unit tests for sse emitter service
- `7962efa` feat(stress-test): add k6 sse stress test script
- `2f9d7e4` feat(stress-test): add python sse stress test script
- `342f540` chore(stress-test): add bash sse stress test script
