### PR TITLE
Update HTML sanitizer to pass through quotes unescaped

### DIFF
--- a/src/main/java/org/trackdev/api/utils/HtmlSanitizer.java
+++ b/src/main/java/org/trackdev/api/utils/HtmlSanitizer.java
@@ -34,8 +34,6 @@ public final class HtmlSanitizer {
                     sanitized.append("&gt;");
                     break;
                 case '"':
-                    sanitized.append("&quot;");
-                    break;
                 case '\'':
                     sanitized.append(c);
                     break;


### PR DESCRIPTION
## Summary

Modified the HtmlSanitizer to stop encoding double quote characters as HTML entities, instead passing them through as literal characters. This aligns the handling of double quotes with the existing behavior for single quotes, which were already passed through unescaped.

## Commits

- `629a688` feat(utils): update html sanitizer to pass through quotes unescaped
