### PR TITLE
Add automatic unlinking of removed tasks from pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin
 claude_docs/
 CLAUDE.md
 .mcp.json
+.gaviero

--- a/src/main/java/org/trackdev/api/controller/HookController.java
+++ b/src/main/java/org/trackdev/api/controller/HookController.java
@@ -165,18 +165,21 @@ public class HookController extends BaseController {
         // Extract task keys from PR body for linking
         String prBody = pr.body != null ? pr.body : "";
         Set<String> taskKeys = extractTaskKeys(prBody);
-        
+
+        // Unlink tasks whose keys are no longer in the PR description
+        pullRequestService.unlinkRemovedTasks(pullRequest.getUrl(), taskKeys);
+
         if (taskKeys.isEmpty()) {
             log.debug("No task keys found in PR #{}", pr.number);
             return ResponseEntity.ok(new WebhookResponse("ok", "No task keys found in PR description"));
         }
-        
+
         log.info("Found task keys in PR #{}: {}", pr.number, taskKeys);
-        
+
         // Link PR to each matching task (PR already created, just need to link)
         List<PullRequestDTO> linkedPRs = new ArrayList<>();
         List<String> errors = new ArrayList<>();
-        
+
         for (String taskKey : taskKeys) {
             try {
                 pullRequestService.linkPullRequestToTask(taskKey.toLowerCase(), pullRequest, action, senderLogin);

--- a/src/main/java/org/trackdev/api/entity/PullRequest.java
+++ b/src/main/java/org/trackdev/api/entity/PullRequest.java
@@ -125,6 +125,10 @@ public class PullRequest extends BaseEntityUUID {
         return this.tasks.contains(task);
     }
 
+    public void removeTask(Task task) {
+        this.tasks.remove(task);
+    }
+
     public String getUrl() {
         return url;
     }

--- a/src/main/java/org/trackdev/api/entity/Task.java
+++ b/src/main/java/org/trackdev/api/entity/Task.java
@@ -395,6 +395,11 @@ public class Task extends BaseEntityLong {
         pr.addTask(this);
     }
 
+    public void removePullRequest(PullRequest pr) {
+        this.pullRequests.remove(pr);
+        pr.removeTask(this);
+    }
+
     public List<TaskChange> getTaskChanges() {
         return taskChanges;
     }

--- a/src/main/java/org/trackdev/api/service/PullRequestService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestService.java
@@ -17,6 +17,7 @@ import org.trackdev.api.entity.GitHubRepo;
 import org.trackdev.api.entity.PullRequest;
 import org.trackdev.api.entity.Task;
 import org.trackdev.api.entity.TaskStatus;
+import org.trackdev.api.entity.TaskType;
 import org.trackdev.api.entity.User;
 import org.trackdev.api.entity.prchanges.PullRequestChange;
 import org.trackdev.api.entity.prchanges.PullRequestClosedChange;
@@ -172,10 +173,55 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
     }
 
     /**
+     * Unlink tasks from a PR whose task keys are no longer present in the PR description.
+     * If a task was in DONE state and loses its last PR, it is reverted to INPROGRESS.
+     * If the affected task has a parent USER_STORY in DONE, the parent is reverted to TODO.
+     *
+     * @param prUrl The PR URL (used to reload the PR within this transaction)
+     * @param currentTaskKeys The set of task keys currently found in the PR body
+     */
+    @Transactional
+    public void unlinkRemovedTasks(String prUrl, Set<String> currentTaskKeys) {
+        Optional<PullRequest> optPr = this.repo.findByUrl(prUrl);
+        if (optPr.isEmpty()) return;
+        PullRequest pr = optPr.get();
+
+        Set<String> normalizedKeys = new HashSet<>();
+        for (String key : currentTaskKeys) {
+            normalizedKeys.add(key.toLowerCase());
+        }
+
+        // Copy to avoid ConcurrentModificationException
+        Set<Task> linkedTasks = new HashSet<>(pr.getTasks());
+
+        for (Task task : linkedTasks) {
+            String taskKey = task.getTaskKey();
+            if (taskKey != null && !normalizedKeys.contains(taskKey.toLowerCase())) {
+                task.removePullRequest(pr);
+
+                if (task.getStatus() == TaskStatus.DONE && !task.hasPullRequest()) {
+                    task.forceSetStatus(TaskStatus.INPROGRESS);
+                    log.info("Task {} reverted from DONE to INPROGRESS (last PR unlinked)", taskKey);
+
+                    // If parent USER_STORY was DONE, revert it to TODO
+                    Task parent = task.getParentTask();
+                    if (parent != null && parent.getTaskType() == TaskType.USER_STORY
+                            && parent.getStatus() == TaskStatus.DONE) {
+                        parent.forceSetStatus(TaskStatus.TODO);
+                        log.info("Parent USER_STORY {} reverted from DONE to TODO", parent.getTaskKey());
+                    }
+                }
+
+                log.info("Unlinked PR {} from task {} (key no longer in PR description)", prUrl, taskKey);
+            }
+        }
+    }
+
+    /**
      * Link a pull request to a task by task key.
      * If the PR already exists (by URL), updates it. Otherwise creates a new one.
      * Records change history for tracking.
-     * 
+     *
      * @deprecated Use processWebhookEvent + linkPullRequestToTask instead
      * 
      * @param taskKey The task key (e.g., "a7k-1")


### PR DESCRIPTION
## Summary

When a pull request description is updated, tasks whose keys are no longer present in the PR body are now automatically unlinked. This includes reverting task status from DONE to INPROGRESS when the last PR is removed, and reverting parent USER_STORY status from DONE to TODO when a child task loses its completed status. Supporting methods were added to the PullRequest and Task entities to handle bidirectional relationship removal.

## Commits

- `437abb7` chore(): update gitignore to exclude .gaviero directory
- `bbadad7` feat(controller): update webhook to unlink removed tasks from pr
- `54a03c3` feat(entity): update pullrequest to add removeTask method
- `52ae967` feat(entity): update task to add removePullRequest method
- `a252d68` feat(service): update pullrequestservice to unlink removed tasks
