### PR TITLE
Replace HTML escaping with input validation across all services

### DIFF
--- a/src/main/java/org/trackdev/api/service/CommentService.java
+++ b/src/main/java/org/trackdev/api/service/CommentService.java
@@ -24,9 +24,9 @@ public class CommentService extends BaseServiceLong<Comment, CommentRepository>{
     private UserService userService;
 
     public Comment addComment(String content, User author, Task task) {
-        // Sanitize HTML content to prevent XSS attacks
-        String sanitizedContent = HtmlSanitizer.sanitize(content);
-        Comment comment = new Comment(sanitizedContent, author, task);
+        // Validate content to prevent XSS attacks
+        HtmlSanitizer.validate(content);
+        Comment comment = new Comment(content, author, task);
         repo.save(comment);
         return comment;
     }
@@ -52,9 +52,9 @@ public class CommentService extends BaseServiceLong<Comment, CommentRepository>{
             throw new ServiceException(ErrorConstants.CANNOT_EDIT_OTHERS_COMMENT);
         }
         
-        // Sanitize and update content
-        String sanitizedContent = HtmlSanitizer.sanitize(newContent);
-        comment.setContent(sanitizedContent);
+        // Validate content to prevent XSS attacks
+        HtmlSanitizer.validate(newContent);
+        comment.setContent(newContent);
         return repo.save(comment);
     }
 

--- a/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
+++ b/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
@@ -59,8 +59,8 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         repo.save(conversation);
 
         // Create the first message
-        String sanitizedContent = HtmlSanitizer.sanitize(message);
-        PointsReviewMessage firstMessage = new PointsReviewMessage(sanitizedContent, initiator, conversation);
+        HtmlSanitizer.validate(message);
+        PointsReviewMessage firstMessage = new PointsReviewMessage(message, initiator, conversation);
         conversation.addMessage(firstMessage);
         messageRepository.save(firstMessage);
 
@@ -156,8 +156,8 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         accessChecker.checkCanPostInPointsReview(conversation, userId);
 
         User author = userService.get(userId);
-        String sanitizedContent = HtmlSanitizer.sanitize(content);
-        PointsReviewMessage message = new PointsReviewMessage(sanitizedContent, author, conversation);
+        HtmlSanitizer.validate(content);
+        PointsReviewMessage message = new PointsReviewMessage(content, author, conversation);
         conversation.addMessage(message);
         messageRepository.save(message);
 
@@ -176,8 +176,8 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
 
         accessChecker.checkCanEditPointsReviewMessage(message, userId);
 
-        String sanitizedContent = HtmlSanitizer.sanitize(content);
-        message.setContent(sanitizedContent);
+        HtmlSanitizer.validate(content);
+        message.setContent(content);
         return messageRepository.save(message);
     }
 

--- a/src/main/java/org/trackdev/api/service/PointsReviewService.java
+++ b/src/main/java/org/trackdev/api/service/PointsReviewService.java
@@ -11,6 +11,7 @@ import org.trackdev.api.entity.Task;
 import org.trackdev.api.entity.User;
 import org.trackdev.api.repository.PointsReviewRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,7 @@ public class PointsReviewService extends BaseServiceLong<PointsReview, PointsRev
 
     @Transactional
     public ResponseEntity addPointsReview(Integer points, String comment, User user, Task task){
+        HtmlSanitizer.validate(comment);
         if(task.getPointsReviewList().stream().filter(pointsReview1 -> pointsReview1.getUser().getId().equals(user.getId())).count() > 1){
             throw new ServiceException(ErrorConstants.TASK_ALREADY_REVIEWED);
         }

--- a/src/main/java/org/trackdev/api/service/ProfileService.java
+++ b/src/main/java/org/trackdev/api/service/ProfileService.java
@@ -9,6 +9,7 @@ import org.trackdev.api.entity.*;
 import org.trackdev.api.model.ProfileRequest;
 import org.trackdev.api.repository.*;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -77,6 +78,8 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
             throw new ServiceException(ErrorConstants.PROFILE_NAME_ALREADY_EXISTS);
         }
 
+        HtmlSanitizer.validate(request.name);
+        HtmlSanitizer.validate(request.description);
         Profile profile = new Profile(request.name, request.description, owner);
         profile = repo.save(profile);
 
@@ -108,6 +111,8 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
             throw new ServiceException(ErrorConstants.PROFILE_NAME_ALREADY_EXISTS);
         }
 
+        HtmlSanitizer.validate(request.name);
+        HtmlSanitizer.validate(request.description);
         profile.setName(request.name);
         profile.setDescription(request.description);
 

--- a/src/main/java/org/trackdev/api/service/PullRequestAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestAttributeValueService.java
@@ -9,6 +9,7 @@ import org.trackdev.api.entity.*;
 import org.trackdev.api.repository.PullRequestAttributeListValueRepository;
 import org.trackdev.api.repository.PullRequestAttributeValueRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -154,6 +155,7 @@ public class PullRequestAttributeValueService extends BaseServiceLong<PullReques
         }
 
         checkAuthorization(attribute, user, pr);
+        HtmlSanitizer.validate(value);
         validateAttributeValue(attribute, value);
 
         Optional<PullRequestAttributeValue> existing = repo().findByPullRequestIdAndAttributeId(prId, attributeId);

--- a/src/main/java/org/trackdev/api/service/ReportService.java
+++ b/src/main/java/org/trackdev/api/service/ReportService.java
@@ -11,6 +11,7 @@ import org.trackdev.api.entity.*;
 import org.trackdev.api.model.MergePatchReport;
 import org.trackdev.api.repository.ReportRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -53,6 +54,7 @@ public class ReportService extends BaseServiceLong<Report, ReportRepository> {
             throw new ServiceException("Report name cannot exceed " + Report.NAME_LENGTH + " characters");
         }
         
+        HtmlSanitizer.validate(name);
         Report report = new Report(name.trim(), user);
         repo.save(report);
         
@@ -107,6 +109,7 @@ public class ReportService extends BaseServiceLong<Report, ReportRepository> {
                 if (name.length() > Report.NAME_LENGTH) {
                     throw new ServiceException("Report name cannot exceed " + Report.NAME_LENGTH + " characters");
                 }
+                HtmlSanitizer.validate(name);
                 report.setName(name.trim());
             }
         }

--- a/src/main/java/org/trackdev/api/service/SprintPatternService.java
+++ b/src/main/java/org/trackdev/api/service/SprintPatternService.java
@@ -11,6 +11,7 @@ import org.trackdev.api.entity.SprintPatternItem;
 import org.trackdev.api.model.SprintPatternRequest;
 import org.trackdev.api.repository.SprintPatternRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.HashSet;
 import java.util.List;
@@ -57,11 +58,13 @@ public class SprintPatternService extends BaseServiceLong<SprintPattern, SprintP
         Course course = courseService.get(courseId);
         accessChecker.checkCanManageCourse(course, userId);
 
+        HtmlSanitizer.validate(request.name);
         SprintPattern pattern = new SprintPattern(request.name, course);
-        
+
         if (request.items != null) {
             int index = 0;
             for (SprintPatternRequest.SprintPatternItemRequest itemReq : request.items) {
+                HtmlSanitizer.validate(itemReq.name);
                 SprintPatternItem item = new SprintPatternItem(
                     itemReq.name,
                     itemReq.startDate,
@@ -85,6 +88,7 @@ public class SprintPatternService extends BaseServiceLong<SprintPattern, SprintP
         SprintPattern pattern = get(patternId);
         accessChecker.checkCanManageCourse(pattern.getCourse(), userId);
 
+        HtmlSanitizer.validate(request.name);
         pattern.setName(request.name);
 
         if (request.items != null) {
@@ -98,7 +102,8 @@ public class SprintPatternService extends BaseServiceLong<SprintPattern, SprintP
             int index = 0;
             for (SprintPatternRequest.SprintPatternItemRequest itemReq : request.items) {
                 int orderIndex = itemReq.orderIndex != null ? itemReq.orderIndex : index;
-                
+                HtmlSanitizer.validate(itemReq.name);
+
                 if (itemReq.id != null && existingItemsMap.containsKey(itemReq.id)) {
                     // Update existing item
                     SprintPatternItem existingItem = existingItemsMap.get(itemReq.id);

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.utils.HtmlSanitizer;
 import org.trackdev.api.entity.Project;
 import org.trackdev.api.entity.Sprint;
 import org.trackdev.api.entity.SprintStatus;
@@ -86,6 +87,7 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
         if(editSprint.name != null) {
             String name = editSprint.name.orElseThrow(
                     () -> new ServiceException(ErrorConstants.CAN_NOT_BE_NULL));
+            HtmlSanitizer.validate(name);
             if(!name.equals(sprint.getName())) {
                 sprint.setName(name);
                 changes.add(new SprintNameChange(user, sprint, name));

--- a/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
@@ -9,6 +9,7 @@ import org.trackdev.api.entity.*;
 import org.trackdev.api.repository.StudentAttributeListValueRepository;
 import org.trackdev.api.repository.StudentAttributeValueRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -180,6 +181,7 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         }
 
         checkAuthorization(attribute, requestingUser, targetUserId);
+        HtmlSanitizer.validate(value);
         validateAttributeValue(attribute, value);
 
         User targetUser = userService.get(targetUserId);

--- a/src/main/java/org/trackdev/api/service/SubjectService.java
+++ b/src/main/java/org/trackdev/api/service/SubjectService.java
@@ -10,6 +10,7 @@ import org.trackdev.api.entity.Subject;
 import org.trackdev.api.entity.User;
 import org.trackdev.api.repository.SubjectRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +46,8 @@ public class SubjectService extends BaseServiceLong<Subject, SubjectRepository> 
     public Subject createSubject(String name, String acronym, String loggedInUserId) {
         User owner = userService.get(loggedInUserId);
         accessChecker.checkCanCreateSubject(owner);
+        HtmlSanitizer.validate(name);
+        HtmlSanitizer.validate(acronym);
         Subject subject = new Subject(name, acronym, owner);
         // Set workspace from owner's workspace (required for workspace admins)
         if (owner.getWorkspace() != null) {
@@ -59,9 +62,11 @@ public class SubjectService extends BaseServiceLong<Subject, SubjectRepository> 
         Subject subject = getSubject(id);
         accessChecker.checkCanManageSubject(subject, loggedInUserId);
         if (name != null) {
+            HtmlSanitizer.validate(name);
             subject.setName(name);
         }
         if (acronym != null) {
+            HtmlSanitizer.validate(acronym);
             subject.setAcronym(acronym);
         }
         repo.save(subject);

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -69,9 +69,10 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         Project project = projectService.get(projectId);
         User user = userService.get(userId);
         accessChecker.checkCanViewProject(project, userId);
-        // Sanitize task name to prevent XSS attacks
-        String sanitizedName = HtmlSanitizer.sanitize(name);
-        Task task = new Task(sanitizedName, user);
+        // Validate input to prevent XSS attacks
+        HtmlSanitizer.validate(name);
+        HtmlSanitizer.validate(description);
+        Task task = new Task(name, user);
         // Set type - default to USER_STORY if not provided
         task.setType(type != null ? type : TaskType.USER_STORY);
         // Set description if provided
@@ -203,9 +204,10 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
 
         // Any project member (or professor/admin) can create subtasks
         accessChecker.checkCanCreateSubtask(parentTask, userId);
-        // Sanitize subtask name to prevent XSS attacks
-        String sanitizedName = HtmlSanitizer.sanitize(name);
-        Task subtask = new Task(sanitizedName, user);
+        // Validate input to prevent XSS attacks
+        HtmlSanitizer.validate(name);
+        HtmlSanitizer.validate(description);
+        Task subtask = new Task(name, user);
 
         // Set description if provided
         if (description != null && !description.isBlank()) {
@@ -322,17 +324,16 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             String oldName = task.getName();
             String name = editTask.name.orElseThrow(
                     () -> new ServiceException(ErrorConstants.CAN_NOT_BE_NULL));
-            // Sanitize task name to prevent XSS attacks
-            String sanitizedName = HtmlSanitizer.sanitize(name);
-            task.setName(sanitizedName);
-            changes.add(new TaskNameChange(user, task, oldName, sanitizedName));
+            // Validate task name to prevent XSS attacks
+            HtmlSanitizer.validate(name);
+            task.setName(name);
+            changes.add(new TaskNameChange(user, task, oldName, name));
         }
         if(editTask.description != null) {
-            // Sanitize description to prevent XSS attacks
-            String sanitizedDescription = editTask.description.isPresent() 
-                    ? HtmlSanitizer.sanitize(editTask.description.get()) 
-                    : null;
-            task.setDescription(sanitizedDescription);
+            // Validate description to prevent XSS attacks
+            String description = editTask.description.orElse(null);
+            HtmlSanitizer.validate(description);
+            task.setDescription(description);
         }
         if(editTask.type != null) {
             TaskType newType = editTask.type.orElseThrow(
@@ -696,10 +697,13 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         if(editTask.name != null) {
             String name = editTask.name.orElseThrow(
                     () -> new ServiceException(ErrorConstants.CAN_NOT_BE_NULL));
+            HtmlSanitizer.validate(name);
             task.setName(name);
         }
         if(editTask.description != null) {
-            task.setDescription(editTask.description.orElse(null));
+            String description = editTask.description.orElse(null);
+            HtmlSanitizer.validate(description);
+            task.setDescription(description);
         }
         if(editTask.reporter != null) {
             if (editTask.reporter.isPresent()) {
@@ -1133,6 +1137,7 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         checkAttributeValueAuthorization(attribute, user, task);
 
         // Validate value based on type
+        HtmlSanitizer.validate(value);
         validateAttributeValue(attribute, value);
 
         // Find or create the attribute value

--- a/src/main/java/org/trackdev/api/service/WorkspaceService.java
+++ b/src/main/java/org/trackdev/api/service/WorkspaceService.java
@@ -7,6 +7,7 @@ import org.trackdev.api.controller.exceptions.EntityNotFound;
 import org.trackdev.api.entity.Workspace;
 import org.trackdev.api.repository.WorkspaceRepository;
 import org.trackdev.api.utils.ErrorConstants;
+import org.trackdev.api.utils.HtmlSanitizer;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,7 @@ public class WorkspaceService extends BaseServiceLong<Workspace, WorkspaceReposi
     @Transactional
     public Workspace createWorkspace(String name, String userId) {
         accessChecker.checkCanCreateWorkspace(userId);
+        HtmlSanitizer.validate(name);
         Workspace workspace = new Workspace(name);
         repo.save(workspace);
         return workspace;
@@ -51,6 +53,7 @@ public class WorkspaceService extends BaseServiceLong<Workspace, WorkspaceReposi
         Workspace workspace = getWorkspace(id);
         accessChecker.checkCanManageWorkspace(workspace, userId);
         if (name != null) {
+            HtmlSanitizer.validate(name);
             workspace.setName(name);
         }
         repo.save(workspace);

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -200,5 +200,8 @@ public final class ErrorConstants {
     public static final String PAT_EXPIRATION_IN_PAST = "error.pat.expiration.past";
     public static final String PAT_ALREADY_REVOKED = "error.pat.already.revoked";
 
+    // Input validation errors
+    public static final String INPUT_CONTAINS_HTML = "error.input.contains.html";
+
     public static final String EMPTY = "";
 }

--- a/src/main/java/org/trackdev/api/utils/HtmlSanitizer.java
+++ b/src/main/java/org/trackdev/api/utils/HtmlSanitizer.java
@@ -1,8 +1,10 @@
 package org.trackdev.api.utils;
 
+import org.trackdev.api.controller.exceptions.EntityException;
+
 /**
- * Utility class for sanitizing HTML content to prevent XSS attacks.
- * Escapes potentially dangerous HTML characters in user-provided content.
+ * Utility class for validating user-provided text content to prevent XSS attacks.
+ * Rejects input containing dangerous HTML patterns instead of escaping characters.
  */
 public final class HtmlSanitizer {
 
@@ -11,45 +13,20 @@ public final class HtmlSanitizer {
     }
 
     /**
-     * Sanitizes a string by escaping HTML special characters.
-     * This prevents XSS attacks by converting characters like < > " ' & 
-     * into their HTML entity equivalents.
+     * Validates that a string does not contain dangerous HTML content.
+     * Throws an exception if potentially dangerous patterns are detected.
      *
-     * @param input The input string to sanitize
-     * @return The sanitized string with HTML characters escaped, or null if input is null
+     * @param input The input string to validate
+     * @throws EntityException if the input contains dangerous HTML patterns
      */
-    public static String sanitize(String input) {
-        if (input == null) {
-            return null;
+    public static void validate(String input) {
+        if (input != null && containsHtml(input)) {
+            throw new EntityException(ErrorConstants.INPUT_CONTAINS_HTML);
         }
-        
-        StringBuilder sanitized = new StringBuilder(input.length());
-        for (int i = 0; i < input.length(); i++) {
-            char c = input.charAt(i);
-            switch (c) {
-                case '<':
-                    sanitized.append("&lt;");
-                    break;
-                case '>':
-                    sanitized.append("&gt;");
-                    break;
-                case '"':
-                case '\'':
-                    sanitized.append(c);
-                    break;
-                case '&':
-                    sanitized.append("&amp;");
-                    break;
-                default:
-                    sanitized.append(c);
-            }
-        }
-        return sanitized.toString();
     }
 
     /**
      * Checks if a string contains potentially dangerous HTML content.
-     * Useful for validation without modification.
      *
      * @param input The input string to check
      * @return true if the string contains HTML-like content
@@ -60,7 +37,7 @@ public final class HtmlSanitizer {
         }
         // Check for common XSS patterns
         String lower = input.toLowerCase();
-        return lower.contains("<script") || 
+        return lower.contains("<script") ||
                lower.contains("<img") ||
                lower.contains("javascript:") ||
                lower.contains("onerror") ||

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -221,3 +221,6 @@ error.points.review.participant.exists=This user is already a participant in the
 # PAT errors
 error.pat.expiration.past=Expiration date must be in the future
 error.pat.already.revoked=This token has already been revoked
+
+# Input validation errors
+error.input.contains.html=The input contains potentially dangerous HTML content

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -222,3 +222,6 @@ error.points.review.participant.exists=Aquest usuari ja és participant de la co
 # Errors de PAT
 error.pat.expiration.past=La data de caducitat ha de ser en el futur
 error.pat.already.revoked=Aquest token ja ha estat revocat
+
+# Errors de validació d'entrada
+error.input.contains.html=L'entrada conté contingut HTML potencialment perillós

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -221,3 +221,6 @@ error.points.review.participant.exists=Este usuario ya es participante de la con
 # Errores de PAT
 error.pat.expiration.past=La fecha de caducidad debe ser en el futuro
 error.pat.already.revoked=Este token ya ha sido revocado
+
+# Errores de validación de entrada
+error.input.contains.html=La entrada contiene contenido HTML potencialmente peligroso


### PR DESCRIPTION
## Summary

The HtmlSanitizer utility was changed from escaping dangerous HTML characters to rejecting input that contains HTML patterns, throwing an EntityException with a new error constant. All 12 service classes were updated to use the new validate method instead of sanitize, and i18n error messages were added in English, Catalan, and Spanish.

## Commits

- `2d0908f` feat(service): update comment html handling from sanitize to validate
- `c160eaa` feat(service): update message html handling from sanitize to validate
- `e6fce75` feat(service): update points review to validate html input
- `735cccd` feat(service): update profile to validate html input
- `dc40f02` feat(service): update pr attribute value to validate html input
- `2e7ddbe` feat(service): update report to validate html input
- `02354d4` feat(service): update sprint pattern to validate html input
- `305a01a` feat(service): update sprint edit to validate html input
- `9014544` feat(service): update student attribute value to validate html input
- `ec89070` feat(service): update subject to validate html input
- `f020830` feat(service): update task html handling from sanitize to validate
- `776d6b8` feat(service): update workspace to validate html input
- `2005f77` feat(utils): update error constants with html validation key
- `051b297` feat(utils): update html sanitizer from escaping to validation
- `a713547` chore(resources): update messages with html validation error text
- `8424ee2` chore(resources): update catalan messages with html validation error
- `13ab781` chore(resources): update spanish messages with html validation error
