### PR TITLE
Add TEXT attribute type support across entities, mappers, and services

### DIFF
--- a/src/main/java/org/trackdev/api/entity/AttributeType.java
+++ b/src/main/java/org/trackdev/api/entity/AttributeType.java
@@ -8,5 +8,6 @@ public enum AttributeType {
     ENUM,
     INTEGER,
     FLOAT,
-    LIST
+    LIST,
+    TEXT
 }

--- a/src/main/java/org/trackdev/api/entity/PullRequestAttributeValue.java
+++ b/src/main/java/org/trackdev/api/entity/PullRequestAttributeValue.java
@@ -37,6 +37,9 @@ public class PullRequestAttributeValue extends BaseEntityLong {
     @Column(length = VALUE_LENGTH)
     private String value;
 
+    @Column(name = "text_value", columnDefinition = "TEXT")
+    private String textValue;
+
     public PullRequestAttributeValue() {}
 
     public PullRequestAttributeValue(PullRequest pullRequest, ProfileAttribute attribute, String value) {
@@ -75,5 +78,13 @@ public class PullRequestAttributeValue extends BaseEntityLong {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getTextValue() {
+        return textValue;
+    }
+
+    public void setTextValue(String textValue) {
+        this.textValue = textValue;
     }
 }

--- a/src/main/java/org/trackdev/api/entity/StudentAttributeValue.java
+++ b/src/main/java/org/trackdev/api/entity/StudentAttributeValue.java
@@ -37,6 +37,9 @@ public class StudentAttributeValue extends BaseEntityLong {
     @Column(length = VALUE_LENGTH)
     private String value;
 
+    @Column(name = "text_value", columnDefinition = "TEXT")
+    private String textValue;
+
     public StudentAttributeValue() {}
 
     public StudentAttributeValue(User user, ProfileAttribute attribute, String value) {
@@ -75,5 +78,13 @@ public class StudentAttributeValue extends BaseEntityLong {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getTextValue() {
+        return textValue;
+    }
+
+    public void setTextValue(String textValue) {
+        this.textValue = textValue;
     }
 }

--- a/src/main/java/org/trackdev/api/entity/TaskAttributeValue.java
+++ b/src/main/java/org/trackdev/api/entity/TaskAttributeValue.java
@@ -41,6 +41,9 @@ public class TaskAttributeValue extends BaseEntityLong {
     @Column(length = VALUE_LENGTH)
     private String value;
 
+    @Column(name = "text_value", columnDefinition = "TEXT")
+    private String textValue;
+
     public TaskAttributeValue() {}
 
     public TaskAttributeValue(Task task, ProfileAttribute attribute, String value) {
@@ -79,5 +82,13 @@ public class TaskAttributeValue extends BaseEntityLong {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getTextValue() {
+        return textValue;
+    }
+
+    public void setTextValue(String textValue) {
+        this.textValue = textValue;
     }
 }

--- a/src/main/java/org/trackdev/api/mapper/PullRequestAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/PullRequestAttributeValueMapper.java
@@ -8,6 +8,7 @@ import org.trackdev.api.dto.EnumValueEntryDTO;
 import org.trackdev.api.dto.ListItemDTO;
 import org.trackdev.api.dto.PullRequestAttributeListValueDTO;
 import org.trackdev.api.dto.PullRequestAttributeValueDTO;
+import org.trackdev.api.entity.AttributeType;
 import org.trackdev.api.entity.EnumValueEntry;
 import org.trackdev.api.entity.ProfileAttribute;
 import org.trackdev.api.entity.PullRequestAttributeListValue;
@@ -23,11 +24,19 @@ public interface PullRequestAttributeValueMapper {
     @Mapping(target = "attributeName", source = "attribute.name")
     @Mapping(target = "attributeType", source = "attribute.type")
     @Mapping(target = "attributeAppliedBy", source = "attribute.appliedBy")
+    @Mapping(target = "value", expression = "java(getEffectiveValue(entity))")
     @Mapping(target = "enumValues", expression = "java(getEnumValues(entity))")
     PullRequestAttributeValueDTO toDTO(PullRequestAttributeValue entity);
 
     @IterableMapping(qualifiedByName = "toDTO")
     List<PullRequestAttributeValueDTO> toDTOList(List<PullRequestAttributeValue> entities);
+
+    default String getEffectiveValue(PullRequestAttributeValue entity) {
+        if (entity.getAttribute() != null && entity.getAttribute().getType() == AttributeType.TEXT) {
+            return entity.getTextValue();
+        }
+        return entity.getValue();
+    }
 
     default EnumValueEntryDTO[] getEnumValues(PullRequestAttributeValue entity) {
         if (entity.getAttribute() != null &&

--- a/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
@@ -8,6 +8,7 @@ import org.trackdev.api.dto.EnumValueEntryDTO;
 import org.trackdev.api.dto.ListItemDTO;
 import org.trackdev.api.dto.StudentAttributeListValueDTO;
 import org.trackdev.api.dto.StudentAttributeValueDTO;
+import org.trackdev.api.entity.AttributeType;
 import org.trackdev.api.entity.EnumValueEntry;
 import org.trackdev.api.entity.ProfileAttribute;
 import org.trackdev.api.entity.StudentAttributeListValue;
@@ -23,11 +24,19 @@ public interface StudentAttributeValueMapper {
     @Mapping(target = "attributeName", source = "attribute.name")
     @Mapping(target = "attributeType", source = "attribute.type")
     @Mapping(target = "attributeAppliedBy", source = "attribute.appliedBy")
+    @Mapping(target = "value", expression = "java(getEffectiveValue(entity))")
     @Mapping(target = "enumValues", expression = "java(getEnumValues(entity))")
     StudentAttributeValueDTO toDTO(StudentAttributeValue entity);
 
     @IterableMapping(qualifiedByName = "toDTO")
     List<StudentAttributeValueDTO> toDTOList(List<StudentAttributeValue> entities);
+
+    default String getEffectiveValue(StudentAttributeValue entity) {
+        if (entity.getAttribute() != null && entity.getAttribute().getType() == AttributeType.TEXT) {
+            return entity.getTextValue();
+        }
+        return entity.getValue();
+    }
 
     default EnumValueEntryDTO[] getEnumValues(StudentAttributeValue entity) {
         if (entity.getAttribute() != null &&

--- a/src/main/java/org/trackdev/api/mapper/TaskAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/TaskAttributeValueMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.trackdev.api.dto.EnumValueEntryDTO;
 import org.trackdev.api.dto.TaskAttributeValueDTO;
+import org.trackdev.api.entity.AttributeType;
 import org.trackdev.api.entity.EnumValueEntry;
 import org.trackdev.api.entity.TaskAttributeValue;
 
@@ -18,11 +19,19 @@ public interface TaskAttributeValueMapper {
     @Mapping(target = "attributeName", source = "attribute.name")
     @Mapping(target = "attributeType", source = "attribute.type")
     @Mapping(target = "attributeAppliedBy", source = "attribute.appliedBy")
+    @Mapping(target = "value", expression = "java(getEffectiveValue(entity))")
     @Mapping(target = "enumValues", expression = "java(getEnumValues(entity))")
     TaskAttributeValueDTO toDTO(TaskAttributeValue entity);
 
     @IterableMapping(qualifiedByName = "toDTO")
     List<TaskAttributeValueDTO> toDTOList(List<TaskAttributeValue> entities);
+
+    default String getEffectiveValue(TaskAttributeValue entity) {
+        if (entity.getAttribute() != null && entity.getAttribute().getType() == AttributeType.TEXT) {
+            return entity.getTextValue();
+        }
+        return entity.getValue();
+    }
 
     default EnumValueEntryDTO[] getEnumValues(TaskAttributeValue entity) {
         if (entity.getAttribute() != null &&

--- a/src/main/java/org/trackdev/api/service/PullRequestAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestAttributeValueService.java
@@ -155,7 +155,9 @@ public class PullRequestAttributeValueService extends BaseServiceLong<PullReques
         }
 
         checkAuthorization(attribute, user, pr);
-        HtmlSanitizer.validate(value);
+        if (attribute.getType() != AttributeType.TEXT) {
+            HtmlSanitizer.validate(value);
+        }
         validateAttributeValue(attribute, value);
 
         Optional<PullRequestAttributeValue> existing = repo().findByPullRequestIdAndAttributeId(prId, attributeId);
@@ -163,9 +165,17 @@ public class PullRequestAttributeValueService extends BaseServiceLong<PullReques
         PullRequestAttributeValue attributeValue;
         if (existing.isPresent()) {
             attributeValue = existing.get();
-            attributeValue.setValue(value);
         } else {
-            attributeValue = new PullRequestAttributeValue(pr, attribute, value);
+            attributeValue = new PullRequestAttributeValue(pr, attribute, null);
+        }
+
+        // Store in the appropriate column based on type
+        if (attribute.getType() == AttributeType.TEXT) {
+            attributeValue.setTextValue(value);
+            attributeValue.setValue(null);
+        } else {
+            attributeValue.setValue(value);
+            attributeValue.setTextValue(null);
         }
 
         return save(attributeValue);
@@ -383,6 +393,7 @@ public class PullRequestAttributeValueService extends BaseServiceLong<PullReques
                 }
                 break;
             case STRING:
+            case TEXT:
             default:
                 break;
         }

--- a/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
@@ -181,7 +181,9 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         }
 
         checkAuthorization(attribute, requestingUser, targetUserId);
-        HtmlSanitizer.validate(value);
+        if (attribute.getType() != AttributeType.TEXT) {
+            HtmlSanitizer.validate(value);
+        }
         validateAttributeValue(attribute, value);
 
         User targetUser = userService.get(targetUserId);
@@ -190,9 +192,17 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         StudentAttributeValue attributeValue;
         if (existing.isPresent()) {
             attributeValue = existing.get();
-            attributeValue.setValue(value);
         } else {
-            attributeValue = new StudentAttributeValue(targetUser, attribute, value);
+            attributeValue = new StudentAttributeValue(targetUser, attribute, null);
+        }
+
+        // Store in the appropriate column based on type
+        if (attribute.getType() == AttributeType.TEXT) {
+            attributeValue.setTextValue(value);
+            attributeValue.setValue(null);
+        } else {
+            attributeValue.setValue(value);
+            attributeValue.setTextValue(null);
         }
 
         return save(attributeValue);
@@ -409,6 +419,7 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
                 }
                 break;
             case STRING:
+            case TEXT:
             default:
                 break;
         }

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -1137,7 +1137,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         checkAttributeValueAuthorization(attribute, user, task);
 
         // Validate value based on type
-        HtmlSanitizer.validate(value);
+        if (attribute.getType() != AttributeType.TEXT) {
+            HtmlSanitizer.validate(value);
+        }
         validateAttributeValue(attribute, value);
 
         // Find or create the attribute value
@@ -1147,9 +1149,17 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         TaskAttributeValue attributeValue;
         if (existingValue.isPresent()) {
             attributeValue = existingValue.get();
-            attributeValue.setValue(value);
         } else {
-            attributeValue = new TaskAttributeValue(task, attribute, value);
+            attributeValue = new TaskAttributeValue(task, attribute, null);
+        }
+
+        // Store in the appropriate column based on type
+        if (attribute.getType() == AttributeType.TEXT) {
+            attributeValue.setTextValue(value);
+            attributeValue.setValue(null);
+        } else {
+            attributeValue.setValue(value);
+            attributeValue.setTextValue(null);
         }
 
         return taskAttributeValueService.save(attributeValue);
@@ -1253,8 +1263,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
                 }
                 break;
             case STRING:
+            case TEXT:
             default:
-                // No validation needed for strings
+                // No validation needed for strings or text
                 break;
         }
     }

--- a/src/main/resources/db/migration/V16__text_attribute_type.sql
+++ b/src/main/resources/db/migration/V16__text_attribute_type.sql
@@ -1,0 +1,3 @@
+ALTER TABLE task_attribute_values ADD COLUMN text_value TEXT;
+ALTER TABLE student_attribute_values ADD COLUMN text_value TEXT;
+ALTER TABLE pull_request_attribute_values ADD COLUMN text_value TEXT;


### PR DESCRIPTION
## Summary

Introduces a new TEXT attribute type to the AttributeType enum and adds a text_value column to task, student, and pull request attribute value tables via a Flyway migration. The mappers are updated to return textValue for TEXT-typed attributes, and the services now store values in the appropriate column based on type while skipping HTML sanitization for TEXT fields.

## Commits

- `2e8f13e` feat(entity): update AttributeType enum to add TEXT value
- `30b7e35` feat(entity): update PullRequestAttributeValue to add textValue field
- `a126e18` feat(entity): update StudentAttributeValue to add textValue field
- `c404d69` feat(entity): update TaskAttributeValue to add textValue field
- `c950e38` feat(mapper): update PullRequestAttributeValueMapper to map textValue for TEXT type
- `e6752a1` feat(mapper): update StudentAttributeValueMapper to map textValue for TEXT type
- `139ca7e` feat(mapper): update TaskAttributeValueMapper to map textValue for TEXT type
- `ca3e42e` feat(service): update PullRequestAttributeValueService to handle TEXT type
- `c3de91e` feat(service): update StudentAttributeValueService to handle TEXT type
- `7e872d7` feat(service): update TaskService to handle TEXT attribute type
- `0cbd90a` chore(migration): add text_value column to attribute value tables
