### PR TITLE
Filter report tasks by type when element is TASK

### DIFF
--- a/src/main/java/org/trackdev/api/service/ReportService.java
+++ b/src/main/java/org/trackdev/api/service/ReportService.java
@@ -312,7 +312,14 @@ public class ReportService extends BaseServiceLong<Report, ReportRepository> {
         if (allTasks == null) {
             allTasks = Collections.emptyList();
         }
-        
+
+        // Filter tasks by type: when element is TASK, only include TASK and BUG (exclude USER_STORY)
+        if (report.getElement() == ReportElement.TASK) {
+            allTasks = allTasks.stream()
+                .filter(task -> task.getTaskType() == TaskType.TASK || task.getTaskType() == TaskType.BUG)
+                .collect(Collectors.toList());
+        }
+
         // Filter tasks by status if filters are provided
         final Collection<Task> filteredTasks;
         if (statusFilters != null && !statusFilters.isEmpty()) {


### PR DESCRIPTION
## Summary

When generating a report with element type TASK, the service now filters out USER_STORY tasks and only includes TASK and BUG types. This ensures reports scoped to tasks do not inadvertently include user stories in their results.

## Commits

- `10d5598` feat(service): update report to filter tasks by type for TASK element
