### PR TITLE
Update report service to include subtasks in project tasks

### DIFF
--- a/src/main/java/org/trackdev/api/service/ReportService.java
+++ b/src/main/java/org/trackdev/api/service/ReportService.java
@@ -307,8 +307,8 @@ public class ReportService extends BaseServiceLong<Report, ReportRepository> {
             result.setMagnitude(report.getMagnitude().name());
         }
         
-        // Get project tasks
-        Collection<Task> allTasks = project.getTasks();
+        // Get all project tasks including subtasks
+        Collection<Task> allTasks = project.getAllTasks();
         if (allTasks == null) {
             allTasks = Collections.emptyList();
         }


### PR DESCRIPTION
## Summary

Changed the report generation to use getAllTasks() instead of getTasks() so that subtasks are included when retrieving project tasks for reports. This ensures the report data accounts for the full task hierarchy rather than only top-level tasks.

## Commits

- `3149f2a` feat(service): update report to include subtasks in project tasks
