### PR TITLE
Add text and numeric_text types to profile attributes enum

### DIFF
--- a/src/main/resources/db/migration/V17__add_text_and_numeric_text_attribute_types.sql
+++ b/src/main/resources/db/migration/V17__add_text_and_numeric_text_attribute_types.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profile_attributes MODIFY COLUMN `type` enum('ENUM', 'FLOAT', 'INTEGER', 'STRING', 'LIST', 'TEXT', 'NUMERIC_TEXT') NOT NULL;


### PR DESCRIPTION
## Summary

A database migration was added to extend the profile_attributes type enum column with two new attribute types: TEXT and NUMERIC_TEXT. This aligns the database schema with application-level support for these additional profile attribute types.

## Commits

- `ce00ff8` chore(migration): add text and numeric_text types to profile attributes enum
