### PR TITLE
Renumber migration for text and numeric_text attribute types

### DIFF
--- a/src/main/resources/db/migration/V17__add_text_and_numeric_text_attribute_types.sql
+++ b/src/main/resources/db/migration/V17__add_text_and_numeric_text_attribute_types.sql
@@ -1,1 +1,0 @@
-ALTER TABLE profile_attributes MODIFY COLUMN `type` enum('ENUM', 'FLOAT', 'INTEGER', 'STRING', 'LIST', 'TEXT', 'NUMERIC_TEXT') NOT NULL;

--- a/src/main/resources/db/migration/V18__add_text_and_numeric_text_attribute_types.sql
+++ b/src/main/resources/db/migration/V18__add_text_and_numeric_text_attribute_types.sql
@@ -1,0 +1,1 @@
+ALTER TABLE profile_attributes MODIFY COLUMN `type` enum('ENUM', 'FLOAT', 'INTEGER', 'STRING', 'LIST', 'TEXT', 'NUMERIC_TEXT') NOT NULL;


### PR DESCRIPTION
## Summary

Removed the V17 migration that added text and numeric_text types to the profile attributes enum and re-created it as V18. This renumbering ensures the migration ordering is correct relative to other migrations in the schema.

## Commits

- `30e4a62` chore(migration): remove v17 text and numeric_text attribute types migration
- `97ae7cb` chore(migration): add text and numeric_text types to profile attributes enum
