### PR TITLE
Add search filtering to the getMyTasks endpoint

### DIFF
--- a/src/main/java/org/trackdev/api/controller/TaskController.java
+++ b/src/main/java/org/trackdev/api/controller/TaskController.java
@@ -284,9 +284,10 @@ public class TaskController extends CrudController<Task, TaskService> {
             @RequestParam(name = "status", required = false) TaskStatus status,
             @RequestParam(name = "assigneeId", required = false) String assigneeId,
             @RequestParam(name = "projectId", required = false) Long projectId,
-            @RequestParam(name = "sortOrder", defaultValue = "desc") String sortOrder) {
+            @RequestParam(name = "sortOrder", defaultValue = "desc") String sortOrder,
+            @RequestParam(name = "search", required = false) String search) {
         String userId = super.getUserId(principal);
-        var tasksPage = service.getMyTasks(userId, page, size, type, status, assigneeId, projectId, sortOrder);
+        var tasksPage = service.getMyTasks(userId, page, size, type, status, assigneeId, projectId, sortOrder, search);
         return new PagedTasksResponseDTO(
                 taskMapper.toBasicDTOList(tasksPage.getContent()),
                 tasksPage.getTotalElements(),

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -988,7 +988,8 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             TaskStatus status,
             String assigneeId,
             Long projectId,
-            String sortOrder) {
+            String sortOrder,
+            String search) {
         Collection<Project> accessibleProjects = projectService.getProjectsForUser(userId);
         if (accessibleProjects.isEmpty()) {
             return org.springframework.data.domain.Page.empty();
@@ -1022,6 +1023,14 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
 
         if (assigneeId != null && !assigneeId.isBlank()) {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("assignee").get("id"), assigneeId));
+        }
+
+        if (search != null && !search.isBlank()) {
+            String pattern = "%" + search.toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                cb.like(cb.lower(root.get("name")), pattern),
+                cb.like(cb.lower(root.get("taskKey")), pattern)
+            ));
         }
 
         return repo.findAll(spec, pageable);


### PR DESCRIPTION
## Summary

The getMyTasks endpoint now accepts an optional search query parameter. The service layer filters tasks by matching the search term against the task name and task key fields using case-insensitive partial matching.

## Commits

- `636d1b9` feat(controller): update getMyTasks endpoint to accept search param
- `464ddd7` feat(service): update getMyTasks to filter by search term
