### PR TITLE
Remove future sprint restriction from task sprint assignment

### DIFF
--- a/src/main/java/org/trackdev/api/service/AccessChecker.java
+++ b/src/main/java/org/trackdev/api/service/AccessChecker.java
@@ -874,22 +874,6 @@ public class AccessChecker {
     }
 
     /**
-     * Check if a TASK or BUG is in a future (DRAFT) sprint only.
-     * Returns false for USER_STORY or tasks with no sprints.
-     */
-    public boolean isTaskInFutureSprintOnly(org.trackdev.api.entity.Task task) {
-        if (task.getTaskType() == TaskType.USER_STORY) {
-            return false;
-        }
-        Collection<Sprint> sprints = task.getActiveSprints();
-        if (sprints == null || sprints.isEmpty()) {
-            return false;
-        }
-        // Check if ALL sprints are DRAFT (future)
-        return sprints.stream().allMatch(sprint -> sprint.getEffectiveStatus() == SprintStatus.DRAFT);
-    }
-
-    /**
      * Compute canEditStatus permission.
      * USER_STORY cannot have status changed manually.
      * TASK/BUG in past sprint only cannot change status (unless professor).

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -559,11 +559,6 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
                 throw new ServiceException(ErrorConstants.CANNOT_REASSIGN_DONE_TASK);
             }
             
-            // Task in FUTURE sprint can only be moved to backlog (not to another sprint)
-            if (!sprintsIds.isEmpty() && accessChecker.isTaskInFutureSprintOnly(task)) {
-                throw new ServiceException(ErrorConstants.TASK_IN_FUTURE_SPRINT_ONLY_TO_BACKLOG);
-            }
-            
             // Validate sprint is active or future (not closed)
             Collection<Sprint> sprints = sprintService.getSprintsByIds(sprintsIds);
             for (Sprint sprint : sprints) {

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -102,7 +102,6 @@ public final class ErrorConstants {
     public static final String TASK_CAN_ONLY_BE_IN_ONE_SPRINT = "error.sprint.task.one.sprint";
     public static final String CANNOT_REASSIGN_DONE_TASK = "error.sprint.done.task.reassign";
     public static final String SPRINT_NOT_ACTIVE_OR_FUTURE = "error.sprint.not.active.or.future";
-    public static final String TASK_IN_FUTURE_SPRINT_ONLY_TO_BACKLOG = "error.task.future.sprint.only.backlog";
     public static final String SPRINT_END_DATE_BEFORE_START = "error.sprint.end.before.start";
     public static final String SPRINT_PATTERN_ALREADY_APPLIED = "error.sprint.pattern.already.applied";
     public static final String SPRINT_PATTERN_NOT_IN_COURSE = "error.sprint.pattern.not.in.course";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -139,7 +139,6 @@ error.sprint.user.story.assignment=USER_STORY can only be assigned to a sprint w
 error.sprint.task.one.sprint=A task can only be assigned to one sprint at a time
 error.sprint.done.task.reassign=Tasks in DONE status cannot be reassigned to another sprint
 error.sprint.not.active.or.future=Tasks can only be assigned to active or future sprints
-error.task.future.sprint.only.backlog=A task in a future sprint can only be moved to the backlog
 error.sprint.end.before.start=Sprint end date must be after start date
 error.sprint.pattern.already.applied=A sprint pattern has already been applied to this project
 error.sprint.pattern.not.in.course=Sprint pattern does not belong to the project's course

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -139,7 +139,6 @@ error.sprint.user.story.assignment=Una USER_STORY només es pot assignar a un sp
 error.sprint.task.one.sprint=Una tasca només pot estar assignada a un sprint alhora
 error.sprint.done.task.reassign=Les tasques en estat DONE no es poden reassignar a un altre sprint
 error.sprint.not.active.or.future=Les tasques només es poden assignar a sprints actius o futurs
-error.task.future.sprint.only.backlog=Una tasca en un sprint futur només es pot moure al backlog
 error.sprint.end.before.start=La data de fi de l'sprint ha de ser posterior a la data d'inici
 error.sprint.pattern.already.applied=Ja s'ha aplicat un patró d'sprint a aquest projecte
 error.sprint.pattern.not.in.course=El patró d'sprint no pertany al curs del projecte

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -139,7 +139,6 @@ error.sprint.user.story.assignment=Una USER_STORY solo se puede asignar a un spr
 error.sprint.task.one.sprint=Una tarea solo puede estar asignada a un sprint a la vez
 error.sprint.done.task.reassign=Las tareas en estado DONE no se pueden reasignar a otro sprint
 error.sprint.not.active.or.future=Las tareas solo se pueden asignar a sprints activos o futuros
-error.task.future.sprint.only.backlog=Una tarea en un sprint futuro solo se puede mover al backlog
 error.sprint.end.before.start=La fecha de fin del sprint debe ser posterior a la fecha de inicio
 error.sprint.pattern.already.applied=Ya se ha aplicado un patrón de sprint a este proyecto
 error.sprint.pattern.not.in.course=El patrón de sprint no pertenece al curso del proyecto

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -239,57 +239,6 @@ class AccessCheckerTaskPermissionsTest {
     }
 
     // =============================================================================
-    // isTaskInFutureSprintOnly Tests
-    // =============================================================================
-
-    @Nested
-    @DisplayName("isTaskInFutureSprintOnly")
-    class IsTaskInFutureSprintOnlyTests {
-
-        @Test
-        @DisplayName("USER_STORY should never be considered in future sprint only")
-        void userStory_shouldNeverBeInFutureSprintOnly() {
-            ReflectionTestUtils.setField(userStoryTask, "activeSprints", List.of(draftSprint));
-            assertFalse(accessChecker.isTaskInFutureSprintOnly(userStoryTask));
-        }
-
-        @Test
-        @DisplayName("TASK in DRAFT sprint should be in future sprint only")
-        void taskInDraftSprint_shouldBeInFutureSprintOnly() {
-            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(draftSprint));
-            assertTrue(accessChecker.isTaskInFutureSprintOnly(taskTask));
-        }
-
-        @Test
-        @DisplayName("TASK in ACTIVE sprint should NOT be in future sprint only")
-        void taskInActiveSprint_shouldNotBeInFutureSprintOnly() {
-            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(activeSprint));
-            assertFalse(accessChecker.isTaskInFutureSprintOnly(taskTask));
-        }
-
-        @Test
-        @DisplayName("TASK in CLOSED sprint should NOT be in future sprint only")
-        void taskInClosedSprint_shouldNotBeInFutureSprintOnly() {
-            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
-            assertFalse(accessChecker.isTaskInFutureSprintOnly(taskTask));
-        }
-
-        @Test
-        @DisplayName("TASK with no sprints should NOT be in future sprint only")
-        void taskWithNoSprints_shouldNotBeInFutureSprintOnly() {
-            ReflectionTestUtils.setField(taskTask, "activeSprints", new ArrayList<>());
-            assertFalse(accessChecker.isTaskInFutureSprintOnly(taskTask));
-        }
-
-        @Test
-        @DisplayName("BUG in DRAFT sprint should be in future sprint only")
-        void bugInDraftSprint_shouldBeInFutureSprintOnly() {
-            ReflectionTestUtils.setField(bugTask, "activeSprints", List.of(draftSprint));
-            assertTrue(accessChecker.isTaskInFutureSprintOnly(bugTask));
-        }
-    }
-
-    // =============================================================================
     // canEditStatus Tests
     // =============================================================================
 
@@ -400,6 +349,28 @@ class AccessCheckerTaskPermissionsTest {
         void frozenTask_shouldNotEditSprintByStudent() {
             taskTask.setFrozen(true);
             assertFalse(accessChecker.canEditSprint(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in FUTURE (DRAFT) sprint SHOULD edit sprint by assignee student")
+        void taskInFutureSprintTodo_shouldEditSprintByAssignee() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(draftSprint));
+            ReflectionTestUtils.setField(taskTask, "status", TaskStatus.TODO);
+            assertTrue(accessChecker.canEditSprint(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in FUTURE (DRAFT) sprint SHOULD edit sprint by professor")
+        void taskInFutureSprint_shouldEditSprintByProfessor() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(draftSprint));
+            assertTrue(accessChecker.canEditSprint(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("TASK in FUTURE sprint should NOT edit sprint by non-assignee student")
+        void taskInFutureSprint_shouldNotEditSprintByNonAssignee() {
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(draftSprint));
+            assertFalse(accessChecker.canEditSprint(taskTask, "other-student-id"));
         }
     }
 

--- a/src/test/java/org/trackdev/api/service/TaskServiceSprintAssignmentTest.java
+++ b/src/test/java/org/trackdev/api/service/TaskServiceSprintAssignmentTest.java
@@ -1,0 +1,103 @@
+package org.trackdev.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.entity.*;
+import org.trackdev.api.model.MergePatchTask;
+import org.trackdev.api.repository.TaskRepository;
+import org.trackdev.api.utils.ErrorConstants;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TaskService sprint assignment business rules.
+ * Tests the service-layer validation for changing a task's sprint assignment.
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskServiceSprintAssignmentTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private AccessChecker accessChecker;
+
+    @Mock
+    private SprintService sprintService;
+
+    private TaskService taskService;
+
+    private Task task;
+    private User user;
+    private Project project;
+    private Sprint draftSprint;
+    private Sprint closedSprint;
+
+    @BeforeEach
+    void setUp() {
+        taskService = new TaskService();
+        ReflectionTestUtils.setField(taskService, "repo", taskRepository);
+        ReflectionTestUtils.setField(taskService, "userService", userService);
+        ReflectionTestUtils.setField(taskService, "accessChecker", accessChecker);
+        ReflectionTestUtils.setField(taskService, "sprintService", sprintService);
+
+        user = new User();
+        ReflectionTestUtils.setField(user, "id", "user-1");
+
+        project = new Project("Test Project");
+        ReflectionTestUtils.setField(project, "id", 1L);
+
+        draftSprint = new Sprint();
+        ReflectionTestUtils.setField(draftSprint, "id", 1L);
+        draftSprint.setStatus(SprintStatus.DRAFT);
+        draftSprint.setStartDate(ZonedDateTime.now().plusDays(7));
+        draftSprint.setEndDate(ZonedDateTime.now().plusDays(21));
+
+        closedSprint = new Sprint();
+        ReflectionTestUtils.setField(closedSprint, "id", 2L);
+        closedSprint.setStatus(SprintStatus.CLOSED);
+        closedSprint.setStartDate(ZonedDateTime.now().minusDays(21));
+        closedSprint.setEndDate(ZonedDateTime.now().minusDays(7));
+
+        task = new Task();
+        ReflectionTestUtils.setField(task, "id", 10L);
+        task.setName("Test task");
+        task.setType(TaskType.TASK);
+        ReflectionTestUtils.setField(task, "status", TaskStatus.TODO);
+        task.setFrozen(false);
+        task.setProject(project);
+        task.setAssignee(user);
+        task.setReporter(user);
+        ReflectionTestUtils.setField(task, "activeSprints", new ArrayList<>(List.of(draftSprint)));
+
+        lenient().when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+        lenient().when(userService.get("user-1")).thenReturn(user);
+    }
+
+    @Test
+    @DisplayName("Task in FUTURE sprint cannot be moved to a CLOSED sprint")
+    void taskInFutureSprint_cannotBeMovedToClosedSprint() {
+        when(sprintService.getSprintsByIds(any())).thenReturn(List.of(closedSprint));
+
+        MergePatchTask patch = new MergePatchTask();
+        patch.activeSprints = Optional.of(List.of(2L));
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> taskService.editTask(10L, patch, "user-1"));
+        assertEquals(ErrorConstants.SPRINT_NOT_ACTIVE_OR_FUTURE, ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

Tasks in future (draft) sprints are no longer restricted to only being moved to the backlog. The change removes the future sprint check from AccessChecker and TaskService, deletes the associated error constant and its i18n messages in English, Catalan, and Spanish, updates related tests, and adds new unit tests for task sprint assignment logic.

## Commits

- `7f9ab43` feat(service): update access checker to remove unused future sprint check
- `1f9ee56` feat(service): update task sprint assignment to remove future sprint restriction
- `2e3255b` feat(utils): update error constants to remove future sprint error key
- `f6e2b95` chore(resources): update messages to remove future sprint error text
- `fc0b494` chore(resources): update catalan messages to remove future sprint error
- `067f67f` chore(resources): update spanish messages to remove future sprint error
- `2058b74` test(service): update access checker tests to remove future sprint checks
- `9196529` test(service): add task service sprint assignment unit tests
