### PR TITLE
Allow professors to bypass task status transition rules

### DIFF
--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -424,9 +424,11 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             TaskStatus status = editTask.status.orElseThrow(
                     () -> new ServiceException(ErrorConstants.CAN_NOT_BE_NULL));
             
-            // Check if task is in a future sprint - cannot change status from TODO
             TaskStatus currentStatus = task.getStatus();
-            if (currentStatus == TaskStatus.TODO && status != TaskStatus.TODO) {
+            boolean isProfessor = accessChecker.isProfessorForTask(task, userId);
+
+            // Students only: cannot change status from TODO if task is in a future sprint
+            if (!isProfessor && currentStatus == TaskStatus.TODO && status != TaskStatus.TODO) {
                 Collection<Sprint> activeSprints = task.getActiveSprints();
                 if (activeSprints != null && !activeSprints.isEmpty()) {
                     // Check if ALL sprints are in DRAFT (future) status
@@ -437,14 +439,14 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
                     }
                 }
             }
-            
-            // Check if task can be moved to VERIFY
-            if (status == TaskStatus.VERIFY && !task.canMoveToVerify()) {
+
+            // Students only: cannot move to VERIFY without at least one PR
+            if (!isProfessor && status == TaskStatus.VERIFY && !task.canMoveToVerify()) {
                 throw new ServiceException(ErrorConstants.TASK_CANNOT_VERIFY_WITHOUT_PULL_REQUEST);
             }
-            
-            // Check if task can be moved to DONE
-            if (status == TaskStatus.DONE && !task.canMoveToDone()) {
+
+            // Students only: DONE requires merged PR, estimation points, and no open PRs
+            if (!isProfessor && status == TaskStatus.DONE && !task.canMoveToDone()) {
                 // Determine the specific reason for rejection
                 if (!task.hasAtLeastOneMergedPR()) {
                     throw new ServiceException(ErrorConstants.TASK_CANNOT_BE_DONE_WITHOUT_MERGED_PR);
@@ -460,7 +462,12 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             }
             
             TaskStatus oldStatus = task.getStatus();
-            task.setStatus(status);
+            // Professors bypass the transition graph and can move tasks to any status
+            if (isProfessor) {
+                task.forceSetStatus(status);
+            } else {
+                task.setStatus(status);
+            }
             changes.add(new TaskStatusChange(user, task, oldStatus.toString(), status.toString()));
             
             // If this is a subtask being set to DONE, check if parent USER_STORY should auto-complete

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -287,6 +287,13 @@ class AccessCheckerTaskPermissionsTest {
             taskTask.setFrozen(true);
             assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
         }
+
+        @Test
+        @DisplayName("TASK not assigned to professor SHOULD still be editable by professor")
+        void taskNotAssignedToProfessor_statusShouldBeEditableByProfessor() {
+            taskTask.setAssignee(otherStudentUser);
+            assertTrue(accessChecker.canEditStatus(taskTask, "professor-id"));
+        }
     }
 
     // =============================================================================

--- a/src/test/java/org/trackdev/api/service/TaskServiceStatusTransitionTest.java
+++ b/src/test/java/org/trackdev/api/service/TaskServiceStatusTransitionTest.java
@@ -1,0 +1,199 @@
+package org.trackdev.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.trackdev.api.entity.*;
+import org.trackdev.api.model.MergePatchTask;
+import org.trackdev.api.repository.TaskRepository;
+
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TaskService status transition business rules.
+ *
+ * Verifies:
+ * - Professors bypass student-only transition constraints (future sprint, VERIFY, DONE)
+ * - Cascade secondary effects on parent USER_STORY are always computed
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskServiceStatusTransitionTest {
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private UserService userService;
+    @Mock private AccessChecker accessChecker;
+    @Mock private TaskChangeService taskChangeService;
+    @Mock private ActivityService activityService;
+    @Mock private SseEmitterService sseEmitterService;
+
+    private TaskService taskService;
+
+    private User professor;
+    private Project project;
+    private Sprint draftSprint;
+
+    @BeforeEach
+    void setUp() {
+        taskService = new TaskService();
+        ReflectionTestUtils.setField(taskService, "repo", taskRepository);
+        ReflectionTestUtils.setField(taskService, "userService", userService);
+        ReflectionTestUtils.setField(taskService, "accessChecker", accessChecker);
+        ReflectionTestUtils.setField(taskService, "taskChangeService", taskChangeService);
+        ReflectionTestUtils.setField(taskService, "activityService", activityService);
+        ReflectionTestUtils.setField(taskService, "sseEmitterService", sseEmitterService);
+
+        professor = new User();
+        ReflectionTestUtils.setField(professor, "id", "professor-id");
+
+        project = new Project("Test Project");
+        ReflectionTestUtils.setField(project, "id", 1L);
+
+        draftSprint = new Sprint();
+        ReflectionTestUtils.setField(draftSprint, "id", 1L);
+        draftSprint.setStatus(SprintStatus.DRAFT);
+        draftSprint.setStartDate(ZonedDateTime.now().plusDays(7));
+        draftSprint.setEndDate(ZonedDateTime.now().plusDays(21));
+
+        lenient().when(userService.get("professor-id")).thenReturn(professor);
+        lenient().when(accessChecker.isProfessorForTask(any(), eq("professor-id"))).thenReturn(true);
+        lenient().when(taskRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private Task makeTask(Long id, TaskType type, TaskStatus status) {
+        Task task = new Task();
+        ReflectionTestUtils.setField(task, "id", id);
+        task.setName("task-" + id);
+        task.setType(type);
+        ReflectionTestUtils.setField(task, "status", status);
+        task.setFrozen(false);
+        task.setProject(project);
+        task.setReporter(professor);
+        task.setAssignee(professor);
+        ReflectionTestUtils.setField(task, "activeSprints", new ArrayList<>());
+        return task;
+    }
+
+    // =========================================================================
+    // Professor bypass tests
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Professor bypasses student-only transition constraints")
+    class ProfessorBypassTests {
+
+        @Test
+        @DisplayName("Professor can change status from TODO in a FUTURE sprint")
+        void professor_canChangeStatusFromTodoInFutureSprint() {
+            Task task = makeTask(10L, TaskType.TASK, TaskStatus.TODO);
+            ReflectionTestUtils.setField(task, "activeSprints", new ArrayList<>(List.of(draftSprint)));
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.INPROGRESS);
+
+            assertDoesNotThrow(() -> taskService.editTask(10L, patch, "professor-id"));
+            assertEquals(TaskStatus.INPROGRESS, task.getStatus());
+        }
+
+        @Test
+        @DisplayName("Professor can move a task to VERIFY without any PR")
+        void professor_canChangeStatusToVerifyWithoutPR() {
+            Task task = makeTask(10L, TaskType.TASK, TaskStatus.INPROGRESS);
+            // pullRequests is empty — student would be blocked
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.VERIFY);
+
+            assertDoesNotThrow(() -> taskService.editTask(10L, patch, "professor-id"));
+            assertEquals(TaskStatus.VERIFY, task.getStatus());
+        }
+
+        @Test
+        @DisplayName("Professor can move a task to DONE without a merged PR")
+        void professor_canChangeStatusToDoneWithoutMergedPR() {
+            Task task = makeTask(10L, TaskType.TASK, TaskStatus.VERIFY);
+            // No merged PR, no estimation — student would be blocked
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);
+
+            assertDoesNotThrow(() -> taskService.editTask(10L, patch, "professor-id"));
+            assertEquals(TaskStatus.DONE, task.getStatus());
+        }
+    }
+
+    // =========================================================================
+    // Cascade secondary-effect tests
+    // =========================================================================
+
+    @Nested
+    @DisplayName("USER_STORY cascade secondary effects")
+    class CascadeTests {
+
+        @Test
+        @DisplayName("Marking the last TODO subtask as DONE auto-completes the parent USER_STORY")
+        void professor_markingLastSubtaskDone_triggersUserStoryAutoDone() {
+            // Sibling subtask is already DONE
+            Task sibling = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+
+            // The task being changed is currently VERIFY
+            Task task = makeTask(10L, TaskType.TASK, TaskStatus.VERIFY);
+
+            // Parent USER_STORY whose status should flip to DONE
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.TODO);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(sibling, task)));
+
+            task.setParentTask(story);
+            sibling.setParentTask(story);
+
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);
+
+            taskService.editTask(10L, patch, "professor-id");
+
+            assertEquals(TaskStatus.DONE, task.getStatus(), "task should be DONE");
+            assertEquals(TaskStatus.DONE, story.getStatus(), "parent USER_STORY should auto-complete to DONE");
+        }
+
+        @Test
+        @DisplayName("Moving a subtask away from DONE reverts the parent USER_STORY to TODO")
+        void professor_markingSubtaskNonDone_revertsUserStoryToTodo() {
+            // Sibling is also DONE
+            Task sibling = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+
+            // The task being changed is currently DONE
+            Task task = makeTask(10L, TaskType.TASK, TaskStatus.DONE);
+
+            // Parent USER_STORY is currently DONE
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.DONE);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(sibling, task)));
+
+            task.setParentTask(story);
+            sibling.setParentTask(story);
+
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.INPROGRESS);
+
+            taskService.editTask(10L, patch, "professor-id");
+
+            assertEquals(TaskStatus.INPROGRESS, task.getStatus(), "task should be INPROGRESS");
+            assertEquals(TaskStatus.TODO, story.getStatus(), "parent USER_STORY should revert to TODO");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Updated TaskService so that professors can move tasks to any status without being constrained by student-only rules such as future sprint restrictions, PR requirements for VERIFY, and merged PR requirements for DONE. Added and updated unit tests covering professor status edit permissions and status transition bypass logic.

## Commits

- `0074835` feat(service): update task status transitions to bypass rules for professors
- `ac57278` test(service): update access checker tests for professor status edit
- `5e23727` test(service): add task service status transition unit tests
