### PR TITLE
Allow student self-assign for non-done tasks in past sprints

### DIFF
--- a/src/main/java/org/trackdev/api/service/AccessChecker.java
+++ b/src/main/java/org/trackdev/api/service/AccessChecker.java
@@ -1036,8 +1036,9 @@ public class AccessChecker {
         if (task.isFrozen()) {
             return false;
         }
-        // If in past sprint only, cannot self-assign
-        if (isTaskInPastSprintOnly(task)) {
+        // If in past sprint only, cannot self-assign unless task is not DONE
+        // (unassigned, non-DONE tasks in a closed sprint can still be claimed by members)
+        if (isTaskInPastSprintOnly(task) && task.getStatus() == TaskStatus.DONE) {
             return false;
         }
         // Must be a project member

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
  * - canEditType: USER_STORY and BUG cannot change type
  * - canEditEstimation: Only TASK/BUG can edit (USER_STORY is computed)
  * - canDelete: USER_STORY needs all subtasks in TODO, TASK/BUG needs BACKLOG/TODO/INPROGRESS
- * - canSelfAssign: Only unassigned, only students, only project members
+ * - canSelfAssign: Only unassigned students; in closed sprints, DONE tasks are blocked but non-DONE tasks can be claimed
  * - canUnassign: Only assignee or professor
  * - canAddSubtask: Only USER_STORY, only project members or professor
  * - canFreeze: Only professors
@@ -700,11 +700,30 @@ class AccessCheckerTaskPermissionsTest {
         }
 
         @Test
-        @DisplayName("Task in PAST sprint should NOT allow self-assign")
-        void taskInPastSprint_shouldNotAllowSelfAssign() {
+        @DisplayName("Unassigned non-DONE task in PAST sprint SHOULD allow student self-assign")
+        void unassignedNotDoneTaskInPastSprint_shouldAllowStudentSelfAssign() {
             taskTask.setAssignee(null);
+            // status is TODO by default — not DONE
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertTrue(accessChecker.canSelfAssign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Unassigned DONE task in PAST sprint should NOT allow self-assign")
+        void unassignedDoneTaskInPastSprint_shouldNotAllowSelfAssign() {
+            taskTask.setAssignee(null);
+            ReflectionTestUtils.setField(taskTask, "status", TaskStatus.DONE);
             ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
             assertFalse(accessChecker.canSelfAssign(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Unassigned DONE task in ACTIVE sprint SHOULD allow self-assign")
+        void unassignedDoneTaskInActiveSprint_shouldAllowSelfAssign() {
+            taskTask.setAssignee(null);
+            ReflectionTestUtils.setField(taskTask, "status", TaskStatus.DONE);
+            // activeSprints default is activeSprint — no sprint override needed
+            assertTrue(accessChecker.canSelfAssign(taskTask, "student-id"));
         }
 
         @Test


### PR DESCRIPTION
## Summary

Updated the self-assign access check so that unassigned tasks in closed sprints can still be claimed by project members unless the task is already in DONE status. Added tests covering non-done and done tasks in past sprints, as well as done tasks in active sprints.

## Commits

- `5d1f8c2` feat(service): update self-assign to allow non-done tasks in past sprints
- `d53389d` test(service): update access checker tests for past sprint self-assign
