### PR TITLE
Add bidirectional linked tasks feature to task management API

### DIFF
--- a/src/main/java/org/trackdev/api/controller/TaskController.java
+++ b/src/main/java/org/trackdev/api/controller/TaskController.java
@@ -94,12 +94,15 @@ public class TaskController extends CrudController<Task, TaskService> {
     @GetMapping(path = "/{id}")
     public TaskDetailDTO getTask(Principal principal, @PathVariable(name = "id") Long id) {
         String userId = super.getUserId(principal);
-        // Authorization check is now inside the service method
         Task task = service.getTask(id, userId);
+        return buildTaskDetailDTO(task, userId);
+    }
+
+    private TaskDetailDTO buildTaskDetailDTO(Task task, String userId) {
         List<PointsReview> pointsReview = pointsReviewService.getPointsReview(userId);
         TaskDetailDTO dto = taskMapper.toDetailDTO(task);
         dto.setPointsReview(pointsReview);
-        
+
         // Compute all permission flags based on current user context
         dto.setCanEdit(accessChecker.canEditTask(task, userId));
         dto.setCanEditStatus(accessChecker.canEditStatus(task, userId));
@@ -112,12 +115,15 @@ public class TaskController extends CrudController<Task, TaskService> {
         dto.setCanAddSubtask(accessChecker.canAddSubtask(task, userId));
         dto.setCanFreeze(accessChecker.canFreeze(task, userId));
         dto.setCanComment(accessChecker.canComment(task, userId));
+        dto.setCanManageLinks(accessChecker.canManageLinks(task, userId));
+        dto.setLinkedTasks(taskMapper.toShallowLinkedTaskDTOs(task.getLinkedTasks()));
 
         // Points review flags
+        Long taskId = task.getId();
         dto.setCanStartPointsReview(accessChecker.canStartPointsReview(task, userId)
-                && !pointsReviewConversationService.hasExistingConversation(id, userId));
+                && !pointsReviewConversationService.hasExistingConversation(taskId, userId));
         dto.setCanViewPointsReviews(accessChecker.canViewPointsReviews(task, userId));
-        dto.setPointsReviewConversationCount(pointsReviewConversationService.countConversationsForTask(id));
+        dto.setPointsReviewConversationCount(pointsReviewConversationService.countConversationsForTask(taskId));
 
         return dto;
     }
@@ -241,6 +247,26 @@ public class TaskController extends CrudController<Task, TaskService> {
         String userId = super.getUserId(principal);
         Task task = service.unassignTask(id, userId);
         return taskMapper.toCompleteDTO(task);
+    }
+
+    @Operation(summary = "Link a task to another task", description = "Creates a bidirectional link between two tasks. Only the assignee or professor can manage links.")
+    @PutMapping("/{id}/linked-tasks/{linkedTaskId}")
+    public TaskDetailDTO addLinkedTask(Principal principal,
+                                       @PathVariable(name = "id") Long id,
+                                       @PathVariable(name = "linkedTaskId") Long linkedTaskId) {
+        String userId = super.getUserId(principal);
+        Task task = service.addLinkedTask(id, linkedTaskId, userId);
+        return buildTaskDetailDTO(task, userId);
+    }
+
+    @Operation(summary = "Unlink a task from another task", description = "Removes the bidirectional link between two tasks. Only the assignee or professor can manage links.")
+    @DeleteMapping("/{id}/linked-tasks/{linkedTaskId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeLinkedTask(Principal principal,
+                                  @PathVariable(name = "id") Long id,
+                                  @PathVariable(name = "linkedTaskId") Long linkedTaskId) {
+        String userId = super.getUserId(principal);
+        service.removeLinkedTask(id, linkedTaskId, userId);
     }
 
     @Operation(summary = "Get list of tasks status", description = "Get list of tasks status")

--- a/src/main/java/org/trackdev/api/dto/TaskDetailDTO.java
+++ b/src/main/java/org/trackdev/api/dto/TaskDetailDTO.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import org.trackdev.api.entity.PointsReview;
 
 import java.util.List;
+import java.util.ArrayList;
 
 /**
  * DTO for Task detail view - includes project and points review at root level
@@ -51,6 +52,16 @@ public class TaskDetailDTO extends TaskWithProjectDTO {
     
     /** Whether the current user can add comments */
     private boolean canComment;
+
+    /** Whether the current user can add/remove linked tasks */
+    private boolean canManageLinks;
+
+    // =============================================================================
+    // LINKED TASKS
+    // =============================================================================
+
+    /** Tasks linked to this task (informational, bidirectional links) */
+    private List<TaskBasicDTO> linkedTasks = new ArrayList<>();
 
     // =============================================================================
     // POINTS REVIEW FLAGS

--- a/src/main/java/org/trackdev/api/entity/Task.java
+++ b/src/main/java/org/trackdev/api/entity/Task.java
@@ -100,6 +100,14 @@ public class Task extends BaseEntityLong {
     @OneToMany(mappedBy = "task", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<TaskChange> taskChanges = new ArrayList<>();
 
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "tasks_linked_tasks",
+        joinColumns = @JoinColumn(name = "task_id"),
+        inverseJoinColumns = @JoinColumn(name = "linked_task_id")
+    )
+    private Set<Task> linkedTasks = new HashSet<>();
+
     // -- CONSTRUCTORS
 
     public Task() {}
@@ -417,6 +425,18 @@ public class Task extends BaseEntityLong {
     public void removePullRequest(PullRequest pr) {
         this.pullRequests.remove(pr);
         pr.removeTask(this);
+    }
+
+    public Set<Task> getLinkedTasks() {
+        return linkedTasks;
+    }
+
+    public void addLinkedTask(Task other) {
+        this.linkedTasks.add(other);
+    }
+
+    public void removeLinkedTask(Task other) {
+        this.linkedTasks.remove(other);
     }
 
     public List<TaskChange> getTaskChanges() {

--- a/src/main/java/org/trackdev/api/mapper/TaskMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/TaskMapper.java
@@ -15,6 +15,7 @@ import org.trackdev.api.entity.TaskStatus;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 @Mapper(componentModel = "spring", uses = {UserMapper.class, SprintMapper.class, CommentMapper.class, ProjectMapper.class, PullRequestMapper.class})
 public interface TaskMapper {
@@ -91,6 +92,9 @@ public interface TaskMapper {
     @Mapping(target = "canStartPointsReview", ignore = true)
     @Mapping(target = "canViewPointsReviews", ignore = true)
     @Mapping(target = "pointsReviewConversationCount", ignore = true)
+    // Linked tasks - set in controller using shallow mapping
+    @Mapping(target = "linkedTasks", ignore = true)
+    @Mapping(target = "canManageLinks", ignore = true)
     TaskDetailDTO toDetailDTO(Task task);
 
     /**
@@ -112,6 +116,10 @@ public interface TaskMapper {
     @Named("childTasksToBasicDTO")
     @IterableMapping(qualifiedByName = "taskToShallowBasicDTO")
     Collection<TaskBasicDTO> childTasksToBasicDTO(Collection<Task> tasks);
+
+    @Named("linkedTasksToShallowDTOs")
+    @IterableMapping(qualifiedByName = "taskToShallowBasicDTO")
+    List<TaskBasicDTO> toShallowLinkedTaskDTOs(Set<Task> tasks);
 
     @IterableMapping(qualifiedByName = "taskToBasicDTO")
     List<TaskBasicDTO> toBasicDTOList(List<Task> tasks);

--- a/src/main/java/org/trackdev/api/service/AccessChecker.java
+++ b/src/main/java/org/trackdev/api/service/AccessChecker.java
@@ -1072,6 +1072,24 @@ public class AccessChecker {
     }
 
     /**
+     * Compute canManageLinks permission.
+     * Only the assignee (or a professor) can add/remove linked tasks.
+     * Not blocked by closed sprint — linking is informational, not a work-state change.
+     */
+    public boolean canManageLinks(org.trackdev.api.entity.Task task, String userId) {
+        boolean isProfessor = isProfessorForTask(task, userId);
+        // If frozen, only professor can manage links
+        if (task.isFrozen() && !isProfessor) {
+            return false;
+        }
+        if (isProfessor) {
+            return true;
+        }
+        // Only the assignee can manage links
+        return isTaskAssignee(task, userId);
+    }
+
+    /**
      * Compute canAddSubtask permission.
      * Only USER_STORY can have subtasks. Any project member can add.
      */

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -182,6 +182,52 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         return task;
     }
 
+    /**
+     * Link two tasks together (bidirectional).
+     * Only the assignee or a professor can manage links.
+     */
+    @Transactional
+    public Task addLinkedTask(Long taskId, Long linkedTaskId, String userId) {
+        if (taskId.equals(linkedTaskId)) {
+            throw new ServiceException(ErrorConstants.TASK_SELF_LINK);
+        }
+        Task task = get(taskId);
+        Task linkedTask = get(linkedTaskId);
+
+        if (!accessChecker.canManageLinks(task, userId)) {
+            throw new ServiceException(ErrorConstants.CANNOT_MANAGE_LINKS);
+        }
+
+        if (task.getLinkedTasks().contains(linkedTask)) {
+            throw new ServiceException(ErrorConstants.TASK_ALREADY_LINKED);
+        }
+
+        task.addLinkedTask(linkedTask);
+        linkedTask.addLinkedTask(task);
+        repo.save(task);
+        repo.save(linkedTask);
+        return task;
+    }
+
+    /**
+     * Remove a bidirectional link between two tasks.
+     * Only the assignee or a professor can manage links.
+     */
+    @Transactional
+    public void removeLinkedTask(Long taskId, Long linkedTaskId, String userId) {
+        Task task = get(taskId);
+        Task linkedTask = get(linkedTaskId);
+
+        if (!accessChecker.canManageLinks(task, userId)) {
+            throw new ServiceException(ErrorConstants.CANNOT_MANAGE_LINKS);
+        }
+
+        task.removeLinkedTask(linkedTask);
+        linkedTask.removeLinkedTask(task);
+        repo.save(task);
+        repo.save(linkedTask);
+    }
+
     @Transactional
     public Task createSubTask(Long taskId, String name, String description, String userId, Long sprintId, TaskType type, String assigneeId) {
         return createSubTaskInternal(taskId, name, description, userId, sprintId, type, assigneeId, false);

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -66,6 +66,9 @@ public final class ErrorConstants {
     public static final String USER_STORY_SUBTASKS_NOT_TODO_CANNOT_DELETE = "error.task.user.story.subtasks.not.todo.delete";
     public static final String TASK_STATUS_CANNOT_DELETE = "error.task.status.cannot.delete";
     public static final String USER_STORY_SUBTASKS_NOT_ASSIGNED_CANNOT_DELETE = "error.task.user.story.subtasks.not.assigned.delete";
+    public static final String TASK_SELF_LINK = "error.task.self.link";
+    public static final String TASK_ALREADY_LINKED = "error.task.already.linked";
+    public static final String CANNOT_MANAGE_LINKS = "error.task.links.permission";
     
     // Project errors
     public static final String PRJ_WITHOUT_MEMBERS = "error.project.no.members";

--- a/src/main/resources/db/migration/V19__linked_tasks.sql
+++ b/src/main/resources/db/migration/V19__linked_tasks.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tasks_linked_tasks (
+    task_id BIGINT NOT NULL,
+    linked_task_id BIGINT NOT NULL,
+    PRIMARY KEY (task_id, linked_task_id),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY (linked_task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -736,6 +736,52 @@ class AccessCheckerTaskPermissionsTest {
     }
 
     // =============================================================================
+    // canManageLinks Tests
+    // =============================================================================
+
+    @Nested
+    @DisplayName("canManageLinks")
+    class CanManageLinksTests {
+
+        @Test
+        @DisplayName("Assignee SHOULD be able to manage links")
+        void assignee_canManageLinks() {
+            taskTask.setAssignee(studentUser);
+            assertTrue(accessChecker.canManageLinks(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Non-assignee student should NOT manage links")
+        void nonAssigneeStudent_cannotManageLinks() {
+            taskTask.setAssignee(studentUser);
+            assertFalse(accessChecker.canManageLinks(taskTask, "other-student-id"));
+        }
+
+        @Test
+        @DisplayName("Professor SHOULD be able to manage links regardless of assignee")
+        void professor_canManageLinks() {
+            taskTask.setAssignee(studentUser);
+            assertTrue(accessChecker.canManageLinks(taskTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("Frozen task should NOT allow assignee to manage links")
+        void frozenTask_assigneeCannotManageLinks() {
+            taskTask.setAssignee(studentUser);
+            taskTask.setFrozen(true);
+            assertFalse(accessChecker.canManageLinks(taskTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("Task in PAST sprint should still allow assignee to manage links")
+        void taskInPastSprint_assigneeCanStillManageLinks() {
+            taskTask.setAssignee(studentUser);
+            ReflectionTestUtils.setField(taskTask, "activeSprints", List.of(closedSprint));
+            assertTrue(accessChecker.canManageLinks(taskTask, "student-id"));
+        }
+    }
+
+    // =============================================================================
     // canUnassign Tests
     // =============================================================================
 

--- a/src/test/java/org/trackdev/api/service/TaskServiceLinkedTasksTest.java
+++ b/src/test/java/org/trackdev/api/service/TaskServiceLinkedTasksTest.java
@@ -1,0 +1,149 @@
+package org.trackdev.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.TaskStatus;
+import org.trackdev.api.entity.TaskType;
+import org.trackdev.api.repository.TaskRepository;
+import org.trackdev.api.utils.ErrorConstants;
+
+import java.util.HashSet;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TaskService linked task management.
+ *
+ * Verifies:
+ * - Adding a link creates a bidirectional relationship (both tasks reference each other)
+ * - Removing a link clears both sides
+ * - Self-linking is rejected
+ * - Duplicate links are rejected
+ * - Only authorised users (assignee or professor) can manage links
+ */
+@ExtendWith(MockitoExtension.class)
+class TaskServiceLinkedTasksTest {
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private AccessChecker accessChecker;
+    @Mock private UserService userService;
+
+    private TaskService taskService;
+
+    private Task task;
+    private Task linkedTask;
+
+    private static final Long TASK_ID = 10L;
+    private static final Long LINKED_TASK_ID = 20L;
+    private static final String USER_ID = "user-1";
+
+    @BeforeEach
+    void setUp() {
+        taskService = new TaskService();
+        ReflectionTestUtils.setField(taskService, "repo", taskRepository);
+        ReflectionTestUtils.setField(taskService, "accessChecker", accessChecker);
+        ReflectionTestUtils.setField(taskService, "userService", userService);
+
+        task = new Task();
+        ReflectionTestUtils.setField(task, "id", TASK_ID);
+        task.setType(TaskType.TASK);
+        ReflectionTestUtils.setField(task, "status", TaskStatus.TODO);
+        task.setFrozen(false);
+        ReflectionTestUtils.setField(task, "linkedTasks", new HashSet<>());
+
+        linkedTask = new Task();
+        ReflectionTestUtils.setField(linkedTask, "id", LINKED_TASK_ID);
+        linkedTask.setType(TaskType.TASK);
+        ReflectionTestUtils.setField(linkedTask, "status", TaskStatus.DONE);
+        linkedTask.setFrozen(false);
+        ReflectionTestUtils.setField(linkedTask, "linkedTasks", new HashSet<>());
+
+        lenient().when(taskRepository.findById(TASK_ID)).thenReturn(Optional.of(task));
+        lenient().when(taskRepository.findById(LINKED_TASK_ID)).thenReturn(Optional.of(linkedTask));
+        lenient().when(accessChecker.canManageLinks(any(), eq(USER_ID))).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("addLinkedTask creates a bidirectional link between both tasks")
+    void addLinkedTask_createsBidirectionalLink() {
+        taskService.addLinkedTask(TASK_ID, LINKED_TASK_ID, USER_ID);
+
+        assertTrue(task.getLinkedTasks().contains(linkedTask),
+                "task should contain linkedTask in its linkedTasks set");
+        assertTrue(linkedTask.getLinkedTasks().contains(task),
+                "linkedTask should contain task in its linkedTasks set (bidirectional)");
+        verify(taskRepository).save(task);
+        verify(taskRepository).save(linkedTask);
+    }
+
+    @Test
+    @DisplayName("addLinkedTask throws when task tries to link to itself")
+    void addLinkedTask_selfLink_throwsServiceException() {
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> taskService.addLinkedTask(TASK_ID, TASK_ID, USER_ID));
+        assertEquals(ErrorConstants.TASK_SELF_LINK, ex.getMessage());
+        verify(taskRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("addLinkedTask throws when the link already exists")
+    void addLinkedTask_alreadyLinked_throwsServiceException() {
+        // Pre-link the two tasks
+        task.addLinkedTask(linkedTask);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> taskService.addLinkedTask(TASK_ID, LINKED_TASK_ID, USER_ID));
+        assertEquals(ErrorConstants.TASK_ALREADY_LINKED, ex.getMessage());
+        verify(taskRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("removeLinkedTask removes the link from both tasks")
+    void removeLinkedTask_removesBidirectionalLink() {
+        // Establish the link first
+        task.addLinkedTask(linkedTask);
+        linkedTask.addLinkedTask(task);
+
+        taskService.removeLinkedTask(TASK_ID, LINKED_TASK_ID, USER_ID);
+
+        assertFalse(task.getLinkedTasks().contains(linkedTask),
+                "task should no longer contain linkedTask");
+        assertFalse(linkedTask.getLinkedTasks().contains(task),
+                "linkedTask should no longer contain task (bidirectional removal)");
+        verify(taskRepository).save(task);
+        verify(taskRepository).save(linkedTask);
+    }
+
+    @Test
+    @DisplayName("addLinkedTask throws when user is not authorised to manage links")
+    void addLinkedTask_unauthorizedUser_throws() {
+        when(accessChecker.canManageLinks(task, USER_ID)).thenReturn(false);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> taskService.addLinkedTask(TASK_ID, LINKED_TASK_ID, USER_ID));
+        assertEquals(ErrorConstants.CANNOT_MANAGE_LINKS, ex.getMessage());
+        verify(taskRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("removeLinkedTask throws when user is not authorised to manage links")
+    void removeLinkedTask_notAssignee_throws() {
+        task.addLinkedTask(linkedTask);
+        linkedTask.addLinkedTask(task);
+        when(accessChecker.canManageLinks(task, USER_ID)).thenReturn(false);
+
+        ServiceException ex = assertThrows(ServiceException.class,
+                () -> taskService.removeLinkedTask(TASK_ID, LINKED_TASK_ID, USER_ID));
+        assertEquals(ErrorConstants.CANNOT_MANAGE_LINKS, ex.getMessage());
+        verify(taskRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary

Implements bidirectional task linking with REST endpoints to create and remove links between tasks. Includes a new join table migration, access control so only assignees and professors can manage links, error handling for self-links and duplicates, and unit tests for both the service and permission logic.

## Commits

- `2929c4d` feat(controller): update task detail to support linked tasks
- `735aee8` feat(dto): update task detail with linked tasks fields
- `a9358c8` feat(entity): update task with linked tasks relationship
- `88ec51e` feat(mapper): update task mapper with linked tasks mapping
- `b29afd6` feat(service): update access checker with manage links permission
- `71b7a84` feat(service): update task service with link/unlink methods
- `15ee9ad` feat(utils): update error constants with linked tasks messages
- `b487685` test(service): update access checker tests with manage links cases
- `c18e8f0` chore(migration): add linked tasks join table migration
- `a942820` test(service): add linked tasks unit tests for task service
