### PR TITLE
Update parent user story status reconciliation when adding subtasks

### DIFF
--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -335,10 +335,22 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         parentTask.addChildTask(subtask);
         this.repo.save(subtask);
 
-        // If parent USER_STORY was DONE, revert to TODO since it now has a non-DONE subtask
-        if (parentTask.getStatus() == TaskStatus.DONE) {
-            parentTask.setStatus(TaskStatus.TODO);
+        // Reconcile parent USER_STORY status with the new subtask:
+        // - If the subtask enters a sprint, the parent cannot remain BACKLOG (domain invariant:
+        //   a USER_STORY with a sprinted subtask must be at least TODO).
+        // - If the parent was already DONE, adding any non-DONE subtask reverts it to TODO.
+        TaskStatus parentOldStatus = parentTask.getStatus();
+        TaskStatus parentNewStatus = parentOldStatus;
+        if (targetSprint != null && parentOldStatus == TaskStatus.BACKLOG) {
+            parentNewStatus = TaskStatus.TODO;
+        } else if (parentOldStatus == TaskStatus.DONE) {
+            parentNewStatus = TaskStatus.TODO;
+        }
+        if (parentNewStatus != parentOldStatus) {
+            parentTask.setStatus(parentNewStatus);
             repo.save(parentTask);
+            taskChangeService.store(new TaskStatusChange(user, parentTask,
+                    parentOldStatus.toString(), parentNewStatus.toString()));
         }
 
         // Record activity for subtask creation


### PR DESCRIPTION
## Summary

When a subtask is created with a sprint assigned, the parent user story now transitions from BACKLOG to TODO to maintain the domain invariant that a user story with sprinted subtasks must be at least TODO. The change also records an audit trail entry via taskChangeService whenever the parent status is automatically updated.

## Commits

- `e37d321` feat(service): update parent user story status on subtask creation
