### PR TITLE
Add project export endpoints for team, tasks, and pull requests

### DIFF
--- a/src/main/java/org/trackdev/api/controller/ProjectController.java
+++ b/src/main/java/org/trackdev/api/controller/ProjectController.java
@@ -80,6 +80,9 @@ public class ProjectController extends BaseController {
     @Autowired
     org.trackdev.api.service.TaskService taskService;
 
+    @Autowired
+    org.trackdev.api.service.ProjectExportService projectExportService;
+
     @Operation(summary = "Get all projects", description = "Get all projects")
     @GetMapping
     public ProjectsResponseDTO getProjects(Principal principal) {
@@ -275,6 +278,32 @@ public class ProjectController extends BaseController {
             ));
         }
         return summaries;
+    }
+
+    // ============== Project Export Endpoints (professor/admin only) ==============
+
+    @Operation(summary = "Export project team", description = "Full team info for the project including profile attribute values. Only course owners (professors) and admins can access.")
+    @GetMapping(path = "/{projectId}/export/team")
+    public org.trackdev.api.dto.export.TeamExportDTO exportTeam(Principal principal,
+                                                                @PathVariable(name = "projectId") Long projectId) {
+        String userId = super.getUserId(principal);
+        return projectExportService.exportTeam(projectId, userId);
+    }
+
+    @Operation(summary = "Export project tasks", description = "All tasks (all sprints, all types, including subtasks) with relations and profile attribute values. Only course owners (professors) and admins can access.")
+    @GetMapping(path = "/{projectId}/export/tasks")
+    public org.trackdev.api.dto.export.TasksExportDTO exportTasks(Principal principal,
+                                                                  @PathVariable(name = "projectId") Long projectId) {
+        String userId = super.getUserId(principal);
+        return projectExportService.exportTasks(projectId, userId);
+    }
+
+    @Operation(summary = "Export project pull requests", description = "All pull requests linked to any task in the project with author, task references, and profile attribute values. Only course owners (professors) and admins can access.")
+    @GetMapping(path = "/{projectId}/export/pull-requests")
+    public org.trackdev.api.dto.export.PullRequestsExportDTO exportPullRequests(Principal principal,
+                                                                                 @PathVariable(name = "projectId") Long projectId) {
+        String userId = super.getUserId(principal);
+        return projectExportService.exportPullRequests(projectId, userId);
     }
 
     // ============== Project Reports Endpoints ==============

--- a/src/main/java/org/trackdev/api/dto/export/PullRequestExportDTO.java
+++ b/src/main/java/org/trackdev/api/dto/export/PullRequestExportDTO.java
@@ -1,0 +1,20 @@
+package org.trackdev.api.dto.export;
+
+import lombok.Data;
+import org.trackdev.api.dto.PullRequestAttributeValueDTO;
+import org.trackdev.api.dto.PullRequestDTO;
+
+import java.util.List;
+
+@Data
+public class PullRequestExportDTO {
+    private PullRequestDTO pullRequest;
+    private List<TaskRef> tasks;
+    private List<PullRequestAttributeValueDTO> attributeValues;
+
+    @Data
+    public static class TaskRef {
+        private Long id;
+        private String taskKey;
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/export/PullRequestsExportDTO.java
+++ b/src/main/java/org/trackdev/api/dto/export/PullRequestsExportDTO.java
@@ -1,0 +1,11 @@
+package org.trackdev.api.dto.export;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PullRequestsExportDTO {
+    private Long projectId;
+    private List<PullRequestExportDTO> pullRequests;
+}

--- a/src/main/java/org/trackdev/api/dto/export/TaskExportDTO.java
+++ b/src/main/java/org/trackdev/api/dto/export/TaskExportDTO.java
@@ -1,0 +1,13 @@
+package org.trackdev.api.dto.export;
+
+import lombok.Data;
+import org.trackdev.api.dto.TaskAttributeValueDTO;
+import org.trackdev.api.dto.TaskBasicDTO;
+
+import java.util.List;
+
+@Data
+public class TaskExportDTO {
+    private TaskBasicDTO task;
+    private List<TaskAttributeValueDTO> attributeValues;
+}

--- a/src/main/java/org/trackdev/api/dto/export/TasksExportDTO.java
+++ b/src/main/java/org/trackdev/api/dto/export/TasksExportDTO.java
@@ -1,0 +1,11 @@
+package org.trackdev.api.dto.export;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TasksExportDTO {
+    private Long projectId;
+    private List<TaskExportDTO> tasks;
+}

--- a/src/main/java/org/trackdev/api/dto/export/TeamExportDTO.java
+++ b/src/main/java/org/trackdev/api/dto/export/TeamExportDTO.java
@@ -1,0 +1,11 @@
+package org.trackdev.api.dto.export;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TeamExportDTO {
+    private Long projectId;
+    private List<TeamMemberExportDTO> members;
+}

--- a/src/main/java/org/trackdev/api/dto/export/TeamMemberExportDTO.java
+++ b/src/main/java/org/trackdev/api/dto/export/TeamMemberExportDTO.java
@@ -1,0 +1,15 @@
+package org.trackdev.api.dto.export;
+
+import lombok.Data;
+import org.trackdev.api.dto.StudentAttributeValueDTO;
+import org.trackdev.api.dto.UserSummaryDTO;
+
+import java.util.List;
+import java.util.Set;
+
+@Data
+public class TeamMemberExportDTO {
+    private UserSummaryDTO user;
+    private Set<String> roles;
+    private List<StudentAttributeValueDTO> attributeValues;
+}

--- a/src/main/java/org/trackdev/api/mapper/ProjectExportMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/ProjectExportMapper.java
@@ -1,0 +1,84 @@
+package org.trackdev.api.mapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.trackdev.api.dto.PullRequestDTO;
+import org.trackdev.api.dto.StudentAttributeValueDTO;
+import org.trackdev.api.dto.TaskAttributeValueDTO;
+import org.trackdev.api.dto.TaskBasicDTO;
+import org.trackdev.api.dto.UserSummaryDTO;
+import org.trackdev.api.dto.export.PullRequestExportDTO;
+import org.trackdev.api.dto.export.TaskExportDTO;
+import org.trackdev.api.dto.export.TeamMemberExportDTO;
+import org.trackdev.api.entity.PullRequest;
+import org.trackdev.api.entity.PullRequestAttributeValue;
+import org.trackdev.api.entity.Role;
+import org.trackdev.api.entity.StudentAttributeValue;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.TaskAttributeValue;
+import org.trackdev.api.entity.User;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class ProjectExportMapper {
+
+    @Autowired
+    UserMapper userMapper;
+
+    @Autowired
+    TaskMapper taskMapper;
+
+    @Autowired
+    PullRequestMapper pullRequestMapper;
+
+    @Autowired
+    TaskAttributeValueMapper taskAttributeValueMapper;
+
+    @Autowired
+    PullRequestAttributeValueMapper pullRequestAttributeValueMapper;
+
+    @Autowired
+    StudentAttributeValueMapper studentAttributeValueMapper;
+
+    public TeamMemberExportDTO toTeamMemberExportDTO(User user, List<StudentAttributeValue> attrs) {
+        TeamMemberExportDTO dto = new TeamMemberExportDTO();
+        UserSummaryDTO summary = userMapper.toSummaryDTO(user);
+        dto.setUser(summary);
+        Set<Role> roles = user.getRoles();
+        dto.setRoles(roles == null ? Collections.emptySet()
+                : roles.stream().map(r -> r.getUserType().name()).collect(Collectors.toSet()));
+        dto.setAttributeValues(attrs == null ? Collections.emptyList()
+                : studentAttributeValueMapper.toDTOList(attrs));
+        return dto;
+    }
+
+    public TaskExportDTO toTaskExportDTO(Task task, List<TaskAttributeValue> attrs) {
+        TaskExportDTO dto = new TaskExportDTO();
+        TaskBasicDTO basic = taskMapper.toBasicDTO(task);
+        dto.setTask(basic);
+        dto.setAttributeValues(attrs == null ? Collections.emptyList()
+                : taskAttributeValueMapper.toDTOList(attrs));
+        return dto;
+    }
+
+    public PullRequestExportDTO toPullRequestExportDTO(PullRequest pr, List<PullRequestAttributeValue> attrs) {
+        PullRequestExportDTO dto = new PullRequestExportDTO();
+        PullRequestDTO prDto = pullRequestMapper.toDTO(pr);
+        dto.setPullRequest(prDto);
+        List<PullRequestExportDTO.TaskRef> taskRefs = pr.getTasks() == null ? Collections.emptyList()
+                : pr.getTasks().stream().map(t -> {
+                    PullRequestExportDTO.TaskRef ref = new PullRequestExportDTO.TaskRef();
+                    ref.setId(t.getId());
+                    ref.setTaskKey(t.getTaskKey());
+                    return ref;
+                }).collect(Collectors.toList());
+        dto.setTasks(taskRefs);
+        dto.setAttributeValues(attrs == null ? Collections.emptyList()
+                : pullRequestAttributeValueMapper.toDTOList(attrs));
+        return dto;
+    }
+}

--- a/src/main/java/org/trackdev/api/repository/PullRequestAttributeValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/PullRequestAttributeValueRepository.java
@@ -2,12 +2,15 @@ package org.trackdev.api.repository;
 
 import org.trackdev.api.entity.PullRequestAttributeValue;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface PullRequestAttributeValueRepository extends BaseRepositoryLong<PullRequestAttributeValue> {
 
     List<PullRequestAttributeValue> findByPullRequestId(String pullRequestId);
+
+    List<PullRequestAttributeValue> findByPullRequestIdIn(Collection<String> pullRequestIds);
 
     Optional<PullRequestAttributeValue> findByPullRequestIdAndAttributeId(String pullRequestId, Long attributeId);
 

--- a/src/main/java/org/trackdev/api/repository/TaskAttributeValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/TaskAttributeValueRepository.java
@@ -2,12 +2,15 @@ package org.trackdev.api.repository;
 
 import org.trackdev.api.entity.TaskAttributeValue;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface TaskAttributeValueRepository extends BaseRepositoryLong<TaskAttributeValue> {
-    
+
     List<TaskAttributeValue> findByTaskId(Long taskId);
+
+    List<TaskAttributeValue> findByTaskIdIn(Collection<Long> taskIds);
     
     Optional<TaskAttributeValue> findByTaskIdAndAttributeId(Long taskId, Long attributeId);
     

--- a/src/main/java/org/trackdev/api/service/ProjectExportService.java
+++ b/src/main/java/org/trackdev/api/service/ProjectExportService.java
@@ -1,0 +1,142 @@
+package org.trackdev.api.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.dto.export.PullRequestExportDTO;
+import org.trackdev.api.dto.export.PullRequestsExportDTO;
+import org.trackdev.api.dto.export.TaskExportDTO;
+import org.trackdev.api.dto.export.TasksExportDTO;
+import org.trackdev.api.dto.export.TeamExportDTO;
+import org.trackdev.api.dto.export.TeamMemberExportDTO;
+import org.trackdev.api.entity.AttributeType;
+import org.trackdev.api.entity.Profile;
+import org.trackdev.api.entity.Project;
+import org.trackdev.api.entity.PullRequest;
+import org.trackdev.api.entity.PullRequestAttributeValue;
+import org.trackdev.api.entity.StudentAttributeValue;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.TaskAttributeValue;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.mapper.ProjectExportMapper;
+import org.trackdev.api.repository.PullRequestAttributeValueRepository;
+import org.trackdev.api.repository.StudentAttributeValueRepository;
+import org.trackdev.api.repository.TaskAttributeValueRepository;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class ProjectExportService {
+
+    @Autowired
+    ProjectService projectService;
+
+    @Autowired
+    AccessChecker accessChecker;
+
+    @Autowired
+    StudentAttributeValueRepository studentAttributeValueRepository;
+
+    @Autowired
+    TaskAttributeValueRepository taskAttributeValueRepository;
+
+    @Autowired
+    PullRequestAttributeValueRepository pullRequestAttributeValueRepository;
+
+    @Autowired
+    ProjectExportMapper exportMapper;
+
+    @Transactional(readOnly = true)
+    public TeamExportDTO exportTeam(Long projectId, String userId) {
+        Project project = projectService.get(projectId);
+        accessChecker.checkCanManageProject(project, userId);
+
+        Profile profile = project.getCourse() != null ? project.getCourse().getProfile() : null;
+        Long profileId = profile != null ? profile.getId() : null;
+
+        Set<User> members = project.getMembers();
+        List<TeamMemberExportDTO> memberDTOs = members.stream()
+                .map(user -> {
+                    List<StudentAttributeValue> attrs = Collections.emptyList();
+                    if (profileId != null) {
+                        attrs = studentAttributeValueRepository.findByUserId(user.getId()).stream()
+                                .filter(v -> v.getAttribute() != null
+                                        && profileId.equals(v.getAttribute().getProfileId()))
+                                .filter(v -> v.getAttribute().getType() != AttributeType.LIST)
+                                .collect(Collectors.toList());
+                    }
+                    return exportMapper.toTeamMemberExportDTO(user, attrs);
+                })
+                .collect(Collectors.toList());
+
+        TeamExportDTO dto = new TeamExportDTO();
+        dto.setProjectId(projectId);
+        dto.setMembers(memberDTOs);
+        return dto;
+    }
+
+    @Transactional(readOnly = true)
+    public TasksExportDTO exportTasks(Long projectId, String userId) {
+        Project project = projectService.get(projectId);
+        accessChecker.checkCanManageProject(project, userId);
+
+        Collection<Task> tasks = project.getAllTasks();
+
+        List<Long> taskIds = tasks.stream().map(Task::getId).collect(Collectors.toList());
+        Map<Long, List<TaskAttributeValue>> attrsByTaskId = taskIds.isEmpty()
+                ? Collections.emptyMap()
+                : taskAttributeValueRepository.findByTaskIdIn(taskIds).stream()
+                        .collect(Collectors.groupingBy(v -> v.getTask().getId()));
+
+        List<TaskExportDTO> taskDTOs = tasks.stream()
+                .map(t -> exportMapper.toTaskExportDTO(
+                        t,
+                        attrsByTaskId.getOrDefault(t.getId(), Collections.emptyList())))
+                .collect(Collectors.toList());
+
+        TasksExportDTO dto = new TasksExportDTO();
+        dto.setProjectId(projectId);
+        dto.setTasks(taskDTOs);
+        return dto;
+    }
+
+    @Transactional(readOnly = true)
+    public PullRequestsExportDTO exportPullRequests(Long projectId, String userId) {
+        Project project = projectService.get(projectId);
+        accessChecker.checkCanManageProject(project, userId);
+
+        // Deduplicate PRs: a PR may link to multiple tasks in the same project.
+        Map<String, PullRequest> uniquePRs = new LinkedHashMap<>();
+        for (Task task : project.getAllTasks()) {
+            if (task.getPullRequests() != null) {
+                for (PullRequest pr : task.getPullRequests()) {
+                    uniquePRs.putIfAbsent(pr.getId(), pr);
+                }
+            }
+        }
+
+        Set<String> prIds = new HashSet<>(uniquePRs.keySet());
+        Map<String, List<PullRequestAttributeValue>> attrsByPrId = prIds.isEmpty()
+                ? Collections.emptyMap()
+                : pullRequestAttributeValueRepository.findByPullRequestIdIn(prIds).stream()
+                        .collect(Collectors.groupingBy(v -> v.getPullRequest().getId()));
+
+        List<PullRequestExportDTO> prDTOs = uniquePRs.values().stream()
+                .map(pr -> exportMapper.toPullRequestExportDTO(
+                        pr,
+                        attrsByPrId.getOrDefault(pr.getId(), Collections.emptyList())))
+                .collect(Collectors.toList());
+
+        PullRequestsExportDTO dto = new PullRequestsExportDTO();
+        dto.setProjectId(projectId);
+        dto.setPullRequests(prDTOs);
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary

Adds three new GET endpoints to ProjectController for exporting project team members, tasks, and pull requests with their profile attribute values. Introduces export DTOs, a ProjectExportMapper, and a ProjectExportService to handle the data assembly. Extends task and PR attribute value repositories with bulk lookup methods to support efficient export queries.

## Commits

- `d0b199c` feat(controller): update project controller with export endpoints
- `c8bdb83` feat(repository): update pr attribute value repo with bulk lookup
- `86bfe6e` feat(repository): update task attribute value repo with bulk lookup
- `d973eed` feat(export): add pull request export dto with attribute values
- `2bd0948` feat(export): add pull requests export dto with project reference
- `d2510e3` feat(export): add task export dto with attribute values
- `0744fb2` feat(export): add tasks export dto with project reference
- `5d8e146` feat(export): add team export dto with project reference
- `26c0673` feat(export): add team member export dto with attribute values
- `304a004` feat(mapper): add project export mapper for team, tasks, and prs
- `b0a2eb9` feat(service): add project export service for team, tasks, and prs
