### PR TITLE
Fix sprint assignment race condition with per-row join writes

### DIFF
--- a/src/main/java/org/trackdev/api/repository/SprintRepository.java
+++ b/src/main/java/org/trackdev/api/repository/SprintRepository.java
@@ -1,5 +1,6 @@
 package org.trackdev.api.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
@@ -10,6 +11,25 @@ import java.util.List;
 
 @Component
 public interface SprintRepository extends BaseRepositoryLong<Sprint> {
+
+    /**
+     * Remove all sprint assignments for a single task by writing only that task's
+     * rows in the join table. Avoids Hibernate's collection-rewrite strategy on
+     * Sprint.activeTasks, which races under concurrent task updates that target
+     * the same sprint.
+     */
+    @Modifying
+    @Query(nativeQuery = true, value = "DELETE FROM sprints_active_tasks WHERE task_id = :taskId")
+    void clearSprintAssignmentsForTask(@Param("taskId") Long taskId);
+
+    /**
+     * Add a single (sprint, task) row to the join table. Per-row write so two
+     * concurrent task moves into the same sprint don't collide.
+     */
+    @Modifying
+    @Query(nativeQuery = true, value = "INSERT INTO sprints_active_tasks (sprint_id, task_id) VALUES (:sprintId, :taskId)")
+    void addSprintAssignmentForTask(@Param("sprintId") Long sprintId, @Param("taskId") Long taskId);
+
 
     @Query(nativeQuery = true, value = "SELECT * FROM sprints WHERE end_date < sysdate() AND status != 2")
     Collection<Sprint> sprintsToClose();

--- a/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
+++ b/src/main/java/org/trackdev/api/service/DemoDataSeeder.java
@@ -1083,11 +1083,27 @@ public class DemoDataSeeder {
         // Used to manually verify the new "Change sprint" bulk action on the
         // filtered task list. Created before closeSprint so they remain in a
         // CLOSED sprint with non-DONE statuses, exercising the past-sprint
-        // escape rule.
+        // escape rule. Multiple stories so several non-DONE subtasks can be
+        // multi-selected and moved to another sprint in one go.
         createHardcodedStory(project, sprint1, alice, professor,
             "Bulk sprint test - sprint 1",
             new String[]{"Bulk-test sprint 1 task A", "Bulk-test sprint 1 task B"},
             new TaskStatus[]{TaskStatus.TODO, TaskStatus.INPROGRESS},
+            new int[]{0, 0});
+        createHardcodedStory(project, sprint1, alice, professor,
+            "Bulk sprint test - sprint 1 (alice extra)",
+            new String[]{"Bulk-test sprint 1 task C", "Bulk-test sprint 1 task D"},
+            new TaskStatus[]{TaskStatus.TODO, TaskStatus.TODO},
+            new int[]{0, 0});
+        createHardcodedStory(project, sprint1, bob, professor,
+            "Bulk sprint test - sprint 1 (bob)",
+            new String[]{"Bulk-test sprint 1 task E", "Bulk-test sprint 1 task F"},
+            new TaskStatus[]{TaskStatus.TODO, TaskStatus.INPROGRESS},
+            new int[]{0, 0});
+        createHardcodedStory(project, sprint1, carol, professor,
+            "Bulk sprint test - sprint 1 (carol)",
+            new String[]{"Bulk-test sprint 1 task G", "Bulk-test sprint 1 task H"},
+            new TaskStatus[]{TaskStatus.TODO, TaskStatus.TODO},
             new int[]{0, 0});
         closeSprint(sprint1, professor.getId());
 

--- a/src/main/java/org/trackdev/api/service/SprintService.java
+++ b/src/main/java/org/trackdev/api/service/SprintService.java
@@ -257,4 +257,18 @@ public class SprintService extends BaseServiceLong<Sprint, SprintRepository> {
         repo().save(sprint);
         return sprint;
     }
+
+    /**
+     * Replace the sprint assignments for a single task by writing only that task's
+     * rows in the join table. Avoids Hibernate's collection-rewrite strategy on
+     * Sprint.activeTasks (the owning side of the @ManyToMany), which races under
+     * concurrent task updates that target the same sprint.
+     */
+    @Transactional
+    public void replaceSprintAssignmentsForTask(Long taskId, Collection<Long> sprintIds) {
+        repo().clearSprintAssignmentsForTask(taskId);
+        for (Long sprintId : sprintIds) {
+            repo().addSprintAssignmentForTask(sprintId, taskId);
+        }
+    }
 }

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -638,9 +638,11 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
 
             String oldValues = task.getActiveSprints().stream().map(Sprint::getName).collect(Collectors.joining(","));
             String newValues = sprints.stream().map(Sprint::getName).collect(Collectors.joining(","));
-            task.getActiveSprints().stream().forEach(sprint -> sprint.removeTask(task));
+            // Write only this task's rows in the join table. Mutating Sprint.activeTasks
+            // (the owning side of the @ManyToMany) instead would race under concurrent
+            // bulk moves into the same sprint — Hibernate rewrites the whole collection.
+            sprintService.replaceSprintAssignmentsForTask(task.getId(), sprintsIds);
             task.setActiveSprints(sprints);
-            sprints.stream().forEach(sprint -> sprint.addTask(task, user));
             changes.add(new TaskActiveSprintsChange(user, task, oldValues, newValues));
 
             // Auto-transition BACKLOG → TODO when assigning to a sprint
@@ -652,11 +654,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             // For USER_STORY: cascade sprint assignment to all subtasks
             if (task.getTaskType() == TaskType.USER_STORY && task.getChildTasks() != null) {
                 for (Task subtask : task.getChildTasks()) {
-                    // Remove from old sprints
-                    subtask.getActiveSprints().stream().forEach(sprint -> sprint.removeTask(subtask));
-                    // Assign to new sprints
+                    // Per-row writes for the same reason as above.
+                    sprintService.replaceSprintAssignmentsForTask(subtask.getId(), sprintsIds);
                     subtask.setActiveSprints(new ArrayList<>(sprints));
-                    sprints.stream().forEach(sprint -> sprint.addTask(subtask, user));
                     // Auto-transition subtasks BACKLOG → TODO
                     if (subtask.getStatus() == TaskStatus.BACKLOG) {
                         subtask.forceSetStatus(TaskStatus.TODO);


### PR DESCRIPTION
## Summary

Replaced Hibernate collection-rewrite strategy for Sprint.activeTasks with direct native SQL insert/delete on the join table to prevent concurrent bulk sprint moves from colliding. Added clearSprintAssignmentsForTask and addSprintAssignmentForTask to SprintRepository, wired them through SprintService, and updated TaskService to use the new per-row approach for both tasks and subtasks. Extended the demo seeder with additional bulk sprint test stories to cover multi-user scenarios.

## Commits

- `95ff5a6` feat(repository): update sprint repo with direct join table mutations
- `e5d3f0c` feat(service): update demo seeder with extra bulk sprint test stories
- `2df7977` feat(service): update sprint service with direct join table assignment
- `896957b` feat(service): update task service to use per-row sprint assignment
