### PR TITLE
Add ENUM_PAIR attribute type support across the full stack

### DIFF
--- a/src/main/java/org/trackdev/api/controller/CourseController.java
+++ b/src/main/java/org/trackdev/api/controller/CourseController.java
@@ -297,7 +297,8 @@ public class CourseController extends BaseController {
             @PathVariable(name = "attributeId") Long attributeId,
             @RequestBody SetAttributeValueRequest request) {
         String requestingUserId = super.getUserId(principal);
-        StudentAttributeValue value = studentAttributeValueService.setStudentAttributeValue(courseId, userId, attributeId, request.value, request.textValue, requestingUserId);
+        StudentAttributeValue value = studentAttributeValueService.setStudentAttributeValue(
+                courseId, userId, attributeId, request.value, request.valueB, request.textValue, requestingUserId);
         return studentAttributeValueMapper.toDTO(value);
     }
 
@@ -370,6 +371,8 @@ public class CourseController extends BaseController {
 
     static class SetAttributeValueRequest {
         public String value;
+        /** Second value, used when the attribute type is ENUM_PAIR. */
+        public String valueB;
         public String textValue;
     }
 

--- a/src/main/java/org/trackdev/api/controller/TaskController.java
+++ b/src/main/java/org/trackdev/api/controller/TaskController.java
@@ -369,7 +369,8 @@ public class TaskController extends CrudController<Task, TaskService> {
             @PathVariable(name = "attributeId") Long attributeId,
             @RequestBody SetAttributeValueRequest request) {
         String userId = super.getUserId(principal);
-        TaskAttributeValue value = service.setTaskAttributeValue(taskId, attributeId, request.value, request.textValue, userId);
+        TaskAttributeValue value = service.setTaskAttributeValue(
+                taskId, attributeId, request.value, request.valueB, request.textValue, userId);
         return taskAttributeValueMapper.toDTO(value);
     }
 
@@ -404,6 +405,8 @@ public class TaskController extends CrudController<Task, TaskService> {
 
     static class SetAttributeValueRequest {
         public String value;
+        /** Second value, used when the attribute type is ENUM_PAIR. */
+        public String valueB;
         public String textValue;
     }
 }

--- a/src/main/java/org/trackdev/api/dto/ProfileAttributeDTO.java
+++ b/src/main/java/org/trackdev/api/dto/ProfileAttributeDTO.java
@@ -22,6 +22,10 @@ public class ProfileAttributeDTO {
     private Long enumRefId;
     private String enumRefName;
     private List<EnumValueEntryDTO> enumValues;
+    /** Second enum, only populated when type is ENUM_PAIR. */
+    private Long enumRef2Id;
+    private String enumRef2Name;
+    private List<EnumValueEntryDTO> enumValues2;
     private String defaultValue;
     private String minValue;
     private String maxValue;

--- a/src/main/java/org/trackdev/api/dto/StudentAttributeValueDTO.java
+++ b/src/main/java/org/trackdev/api/dto/StudentAttributeValueDTO.java
@@ -16,6 +16,10 @@ public class StudentAttributeValueDTO {
     private AttributeType attributeType;
     private AttributeAppliedBy attributeAppliedBy;
     private String value;
+    /** Second value, only populated when attributeType is ENUM_PAIR. */
+    private String valueB;
     private String textValue;
     private EnumValueEntryDTO[] enumValues;
+    /** Possible values for the second enum slot — populated only when attributeType is ENUM_PAIR. */
+    private EnumValueEntryDTO[] enumValues2;
 }

--- a/src/main/java/org/trackdev/api/dto/TaskAttributeValueDTO.java
+++ b/src/main/java/org/trackdev/api/dto/TaskAttributeValueDTO.java
@@ -16,8 +16,12 @@ public class TaskAttributeValueDTO {
     private AttributeType attributeType;
     private AttributeAppliedBy attributeAppliedBy;
     private String value;
+    /** Second value, only populated when attributeType is ENUM_PAIR. */
+    private String valueB;
     private String textValue;
 
     // For ENUM type, include the possible values with descriptions
     private EnumValueEntryDTO[] enumValues;
+    /** Possible values for the second enum slot — populated only when attributeType is ENUM_PAIR. */
+    private EnumValueEntryDTO[] enumValues2;
 }

--- a/src/main/java/org/trackdev/api/entity/AttributeType.java
+++ b/src/main/java/org/trackdev/api/entity/AttributeType.java
@@ -10,5 +10,6 @@ public enum AttributeType {
     FLOAT,
     LIST,
     TEXT,
-    NUMERIC_TEXT
+    NUMERIC_TEXT,
+    ENUM_PAIR
 }

--- a/src/main/java/org/trackdev/api/entity/ProfileAttribute.java
+++ b/src/main/java/org/trackdev/api/entity/ProfileAttribute.java
@@ -48,7 +48,7 @@ public class ProfileAttribute extends BaseEntityLong {
     private Long profileId;
 
     /**
-     * Reference to ProfileEnum when type is ENUM.
+     * Reference to ProfileEnum when type is ENUM, LIST (optional), or ENUM_PAIR (first slot).
      * Must belong to the same profile.
      */
     @ManyToOne(fetch = FetchType.LAZY)
@@ -57,6 +57,17 @@ public class ProfileAttribute extends BaseEntityLong {
 
     @Column(name = "enum_ref_id", insertable = false, updatable = false)
     private Long enumRefId;
+
+    /**
+     * Second enum reference, only used by ENUM_PAIR (second slot).
+     * Must belong to the same profile and be distinct from {@link #enumRef}.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "enum_ref_id_2")
+    private ProfileEnum enumRef2;
+
+    @Column(name = "enum_ref_id_2", insertable = false, updatable = false)
+    private Long enumRef2Id;
 
     /**
      * Default value for this attribute when not explicitly set.
@@ -148,6 +159,18 @@ public class ProfileAttribute extends BaseEntityLong {
 
     public Long getEnumRefId() {
         return enumRefId;
+    }
+
+    public ProfileEnum getEnumRef2() {
+        return enumRef2;
+    }
+
+    public void setEnumRef2(ProfileEnum enumRef2) {
+        this.enumRef2 = enumRef2;
+    }
+
+    public Long getEnumRef2Id() {
+        return enumRef2Id;
     }
 
     public String getDefaultValue() {

--- a/src/main/java/org/trackdev/api/entity/StudentAttributeValue.java
+++ b/src/main/java/org/trackdev/api/entity/StudentAttributeValue.java
@@ -33,9 +33,16 @@ public class StudentAttributeValue extends BaseEntityLong {
 
     /**
      * The actual value stored as a string.
+     * For ENUM_PAIR: stores the value of the FIRST enum (slot 1).
      */
     @Column(length = VALUE_LENGTH)
     private String value;
+
+    /**
+     * Second value, only used by ENUM_PAIR (slot 2).
+     */
+    @Column(name = "value_b", length = VALUE_LENGTH)
+    private String valueB;
 
     @Column(name = "text_value", columnDefinition = "TEXT")
     private String textValue;
@@ -78,6 +85,14 @@ public class StudentAttributeValue extends BaseEntityLong {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getValueB() {
+        return valueB;
+    }
+
+    public void setValueB(String valueB) {
+        this.valueB = valueB;
     }
 
     public String getTextValue() {

--- a/src/main/java/org/trackdev/api/entity/TaskAttributeValue.java
+++ b/src/main/java/org/trackdev/api/entity/TaskAttributeValue.java
@@ -37,9 +37,16 @@ public class TaskAttributeValue extends BaseEntityLong {
      * For STRING type: stores the string value
      * For INTEGER type: stores the integer as string
      * For FLOAT type: stores the float as string
+     * For ENUM_PAIR: stores the value of the FIRST enum (slot 1).
      */
     @Column(length = VALUE_LENGTH)
     private String value;
+
+    /**
+     * Second value, only used by ENUM_PAIR (slot 2).
+     */
+    @Column(name = "value_b", length = VALUE_LENGTH)
+    private String valueB;
 
     @Column(name = "text_value", columnDefinition = "TEXT")
     private String textValue;
@@ -82,6 +89,14 @@ public class TaskAttributeValue extends BaseEntityLong {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getValueB() {
+        return valueB;
+    }
+
+    public void setValueB(String valueB) {
+        this.valueB = valueB;
     }
 
     public String getTextValue() {

--- a/src/main/java/org/trackdev/api/mapper/ProfileMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/ProfileMapper.java
@@ -49,6 +49,8 @@ public interface ProfileMapper {
     @Named("attributeToDTO")
     @Mapping(target = "enumRefName", source = "enumRef.name")
     @Mapping(target = "enumValues", source = "attribute", qualifiedByName = "getEnumValuesFromAttribute")
+    @Mapping(target = "enumRef2Name", source = "enumRef2.name")
+    @Mapping(target = "enumValues2", source = "attribute", qualifiedByName = "getEnumValues2FromAttribute")
     ProfileAttributeDTO attributeToDTO(ProfileAttribute attribute);
 
     @Named("attributesToDTO")
@@ -59,6 +61,16 @@ public interface ProfileMapper {
     default List<EnumValueEntryDTO> getEnumValuesFromAttribute(ProfileAttribute attribute) {
         if (attribute.getEnumRef() != null) {
             return attribute.getEnumRef().getValues().stream()
+                    .map(this::enumValueEntryToDTO)
+                    .toList();
+        }
+        return Collections.emptyList();
+    }
+
+    @Named("getEnumValues2FromAttribute")
+    default List<EnumValueEntryDTO> getEnumValues2FromAttribute(ProfileAttribute attribute) {
+        if (attribute.getEnumRef2() != null) {
+            return attribute.getEnumRef2().getValues().stream()
                     .map(this::enumValueEntryToDTO)
                     .toList();
         }

--- a/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/StudentAttributeValueMapper.java
@@ -25,8 +25,10 @@ public interface StudentAttributeValueMapper {
     @Mapping(target = "attributeType", source = "attribute.type")
     @Mapping(target = "attributeAppliedBy", source = "attribute.appliedBy")
     @Mapping(target = "value", expression = "java(getEffectiveValue(entity))")
+    @Mapping(target = "valueB", source = "valueB")
     @Mapping(target = "textValue", expression = "java(getEffectiveTextValue(entity))")
     @Mapping(target = "enumValues", expression = "java(getEnumValues(entity))")
+    @Mapping(target = "enumValues2", expression = "java(getEnumValues2(entity))")
     StudentAttributeValueDTO toDTO(StudentAttributeValue entity);
 
     @IterableMapping(qualifiedByName = "toDTO")
@@ -50,6 +52,17 @@ public interface StudentAttributeValueMapper {
         if (entity.getAttribute() != null &&
             entity.getAttribute().getEnumRef() != null) {
             return entity.getAttribute().getEnumRef().getValues().stream()
+                    .map(this::toEnumValueEntryDTO)
+                    .toArray(EnumValueEntryDTO[]::new);
+        }
+        return null;
+    }
+
+    default EnumValueEntryDTO[] getEnumValues2(StudentAttributeValue entity) {
+        if (entity.getAttribute() != null &&
+            entity.getAttribute().getType() == AttributeType.ENUM_PAIR &&
+            entity.getAttribute().getEnumRef2() != null) {
+            return entity.getAttribute().getEnumRef2().getValues().stream()
                     .map(this::toEnumValueEntryDTO)
                     .toArray(EnumValueEntryDTO[]::new);
         }

--- a/src/main/java/org/trackdev/api/mapper/TaskAttributeValueMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/TaskAttributeValueMapper.java
@@ -20,8 +20,10 @@ public interface TaskAttributeValueMapper {
     @Mapping(target = "attributeType", source = "attribute.type")
     @Mapping(target = "attributeAppliedBy", source = "attribute.appliedBy")
     @Mapping(target = "value", expression = "java(getEffectiveValue(entity))")
+    @Mapping(target = "valueB", source = "valueB")
     @Mapping(target = "textValue", expression = "java(getEffectiveTextValue(entity))")
     @Mapping(target = "enumValues", expression = "java(getEnumValues(entity))")
+    @Mapping(target = "enumValues2", expression = "java(getEnumValues2(entity))")
     TaskAttributeValueDTO toDTO(TaskAttributeValue entity);
 
     @IterableMapping(qualifiedByName = "toDTO")
@@ -45,6 +47,17 @@ public interface TaskAttributeValueMapper {
         if (entity.getAttribute() != null &&
             entity.getAttribute().getEnumRef() != null) {
             return entity.getAttribute().getEnumRef().getValues().stream()
+                    .map(this::toEnumValueEntryDTO)
+                    .toArray(EnumValueEntryDTO[]::new);
+        }
+        return null;
+    }
+
+    default EnumValueEntryDTO[] getEnumValues2(TaskAttributeValue entity) {
+        if (entity.getAttribute() != null &&
+            entity.getAttribute().getType() == AttributeType.ENUM_PAIR &&
+            entity.getAttribute().getEnumRef2() != null) {
+            return entity.getAttribute().getEnumRef2().getValues().stream()
                     .map(this::toEnumValueEntryDTO)
                     .toArray(EnumValueEntryDTO[]::new);
         }

--- a/src/main/java/org/trackdev/api/model/ProfileRequest.java
+++ b/src/main/java/org/trackdev/api/model/ProfileRequest.java
@@ -79,9 +79,14 @@ public class ProfileRequest {
         public AttributeVisibility visibility;
 
         /**
-         * Reference to enum by name (required when type is ENUM)
+         * Reference to enum by name (required when type is ENUM, or first slot of ENUM_PAIR).
          */
         public String enumRefName;
+
+        /**
+         * Reference to second enum by name (required when type is ENUM_PAIR; must differ from enumRefName).
+         */
+        public String enumRefName2;
 
         /**
          * Default value for this attribute when not explicitly set on a task.

--- a/src/main/java/org/trackdev/api/repository/StudentAttributeValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/StudentAttributeValueRepository.java
@@ -19,6 +19,8 @@ public interface StudentAttributeValueRepository extends BaseRepositoryLong<Stud
 
     boolean existsByAttributeIdAndValue(Long attributeId, String value);
 
+    boolean existsByAttributeIdAndValueB(Long attributeId, String valueB);
+
     long countByAttributeId(Long attributeId);
 
     List<StudentAttributeValue> findByAttributeId(Long attributeId);

--- a/src/main/java/org/trackdev/api/repository/TaskAttributeValueRepository.java
+++ b/src/main/java/org/trackdev/api/repository/TaskAttributeValueRepository.java
@@ -1,30 +1,42 @@
 package org.trackdev.api.repository;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import org.trackdev.api.entity.TaskAttributeValue;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface TaskAttributeValueRepository extends BaseRepositoryLong<TaskAttributeValue> {
 
     List<TaskAttributeValue> findByTaskId(Long taskId);
 
-    List<TaskAttributeValue> findByTaskIdIn(Collection<Long> taskIds);
-    
+    List<TaskAttributeValue> findByTaskIdIn(List<Long> taskIds);
+
     Optional<TaskAttributeValue> findByTaskIdAndAttributeId(Long taskId, Long attributeId);
-    
-    void deleteByTaskIdAndAttributeId(Long taskId, Long attributeId);
-    
-    void deleteByTaskId(Long taskId);
+
+    @Modifying
+    @Query("DELETE FROM TaskAttributeValue v WHERE v.task.id = :taskId")
+    void deleteByTaskId(@Param("taskId") Long taskId);
+
+    @Modifying
+    @Query("DELETE FROM TaskAttributeValue v WHERE v.task.id = :taskId AND v.attribute.id = :attributeId")
+    void deleteByTaskIdAndAttributeId(@Param("taskId") Long taskId, @Param("attributeId") Long attributeId);
 
     boolean existsByAttributeId(Long attributeId);
 
     boolean existsByAttributeIdAndValue(Long attributeId, String value);
 
+    boolean existsByAttributeIdAndValueB(Long attributeId, String valueB);
+
     long countByAttributeId(Long attributeId);
 
     List<TaskAttributeValue> findByAttributeId(Long attributeId);
 
-    void deleteByAttributeId(Long attributeId);
+    @Modifying
+    @Query("DELETE FROM TaskAttributeValue v WHERE v.attribute.id = :attributeId")
+    void deleteByAttributeId(@Param("attributeId") Long attributeId);
 }

--- a/src/main/java/org/trackdev/api/service/ProfileService.java
+++ b/src/main/java/org/trackdev/api/service/ProfileService.java
@@ -149,13 +149,15 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
     /**
      * Check if an enum value string is referenced by any attribute value
      * across all attribute value tables for attributes that use the given enum.
+     * Considers both the primary enum slot (enumRef) and the second slot (enumRef2)
+     * used by ENUM_PAIR attributes.
      */
     private boolean enumValueIsInUse(Profile profile, Long enumId, String value) {
-        List<ProfileAttribute> referencingAttrs = profile.getAttributes().stream()
+        List<ProfileAttribute> primaryAttrs = profile.getAttributes().stream()
                 .filter(a -> a.getEnumRef() != null && a.getEnumRef().getId().equals(enumId))
                 .toList();
 
-        for (ProfileAttribute attr : referencingAttrs) {
+        for (ProfileAttribute attr : primaryAttrs) {
             Long attrId = attr.getId();
             if (attr.getType() == AttributeType.LIST) {
                 if (studentAttributeListValueRepository.existsByAttributeIdAndEnumValue(attrId, value)) {
@@ -167,6 +169,21 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                         || pullRequestAttributeValueRepository.existsByAttributeIdAndValue(attrId, value)) {
                     return true;
                 }
+            }
+        }
+
+        // Second slot of ENUM_PAIR
+        List<ProfileAttribute> secondaryAttrs = profile.getAttributes().stream()
+                .filter(a -> a.getType() == AttributeType.ENUM_PAIR
+                        && a.getEnumRef2() != null
+                        && a.getEnumRef2().getId().equals(enumId))
+                .toList();
+
+        for (ProfileAttribute attr : secondaryAttrs) {
+            Long attrId = attr.getId();
+            if (studentAttributeValueRepository.existsByAttributeIdAndValueB(attrId, value)
+                    || taskAttributeValueRepository.existsByAttributeIdAndValueB(attrId, value)) {
+                return true;
             }
         }
         return false;
@@ -253,7 +270,38 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
             return;
         }
 
-        // Handle enum reference
+        // Handle ENUM_PAIR type constraints
+        if (attrRequest.type == AttributeType.ENUM_PAIR) {
+            if (attrRequest.target != AttributeTarget.TASK && attrRequest.target != AttributeTarget.STUDENT) {
+                throw new ServiceException(ErrorConstants.PROFILE_ENUM_PAIR_INVALID_TARGET);
+            }
+            if (attrRequest.enumRefName == null || attrRequest.enumRefName.isBlank()
+                    || attrRequest.enumRefName2 == null || attrRequest.enumRefName2.isBlank()) {
+                throw new ServiceException(ErrorConstants.PROFILE_ENUM_PAIR_REQUIRES_TWO_ENUMS);
+            }
+            if (attrRequest.enumRefName.equals(attrRequest.enumRefName2)) {
+                throw new ServiceException(ErrorConstants.PROFILE_ENUM_PAIR_DISTINCT_REQUIRED);
+            }
+            ProfileEnum enumRef = findEnumByName(profile, attrRequest.enumRefName);
+            ProfileEnum enumRef2 = findEnumByName(profile, attrRequest.enumRefName2);
+            attribute.setEnumRef(enumRef);
+            attribute.setEnumRef2(enumRef2);
+
+            // Only TASK-targeted attributes can be applied by STUDENT
+            if (attrRequest.target != AttributeTarget.TASK) {
+                attribute.setAppliedBy(AttributeAppliedBy.PROFESSOR);
+            } else {
+                attribute.setAppliedBy(attrRequest.appliedBy != null ? attrRequest.appliedBy : AttributeAppliedBy.PROFESSOR);
+            }
+            attribute.setVisibility(attrRequest.visibility != null ? attrRequest.visibility : AttributeVisibility.PROFESSOR_ONLY);
+            attribute.setDefaultValue(null);
+            attribute.setMinValue(null);
+            attribute.setMaxValue(null);
+            profile.addAttribute(attribute);
+            return;
+        }
+
+        // Handle enum reference (single ENUM)
         if (attrRequest.type == AttributeType.ENUM) {
             if (attrRequest.enumRefName == null || attrRequest.enumRefName.isBlank()) {
                 throw new ServiceException(ErrorConstants.PROFILE_ENUM_REF_REQUIRED);
@@ -392,24 +440,30 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                     if (existing.getAppliedBy() != requestedAppliedBy) {
                         throw new ServiceException(ErrorConstants.PROFILE_ATTRIBUTE_IMMUTABLE_APPLIED_BY);
                     }
-                    if (existing.getType() == AttributeType.ENUM || existing.getType() == AttributeType.LIST) {
+                    if (existing.getType() == AttributeType.ENUM
+                            || existing.getType() == AttributeType.LIST
+                            || existing.getType() == AttributeType.ENUM_PAIR) {
                         String existingEnumName = existing.getEnumRef() != null ? existing.getEnumRef().getName() : null;
                         if (!Objects.equals(existingEnumName, attrRequest.enumRefName)) {
                             throw new ServiceException(ErrorConstants.PROFILE_ATTRIBUTE_IMMUTABLE_ENUM_REF);
+                        }
+                    }
+                    if (existing.getType() == AttributeType.ENUM_PAIR) {
+                        String existingEnum2Name = existing.getEnumRef2() != null ? existing.getEnumRef2().getName() : null;
+                        if (!Objects.equals(existingEnum2Name, attrRequest.enumRefName2)) {
+                            throw new ServiceException(ErrorConstants.PROFILE_ATTRIBUTE_IMMUTABLE_ENUM_REF_2);
                         }
                     }
                 }
 
                 // Update allowed fields (always allowed)
                 existing.setName(attrRequest.name);
-                // LIST attributes: force PROFESSOR_ONLY visibility, ignore other mutable fields
                 if (existing.getType() == AttributeType.LIST || attrRequest.type == AttributeType.LIST) {
                     existing.setVisibility(AttributeVisibility.PROFESSOR_ONLY);
                     existing.setDefaultValue(null);
                     existing.setMinValue(null);
                     existing.setMaxValue(null);
                 } else if (existing.getType() == AttributeType.NUMERIC_TEXT || attrRequest.type == AttributeType.NUMERIC_TEXT) {
-                    // NUMERIC_TEXT: enforce visibility and allow min/max
                     AttributeVisibility visibility = attrRequest.visibility != null ? attrRequest.visibility : existing.getVisibility();
                     if (visibility != AttributeVisibility.PROFESSOR_ONLY && visibility != AttributeVisibility.ASSIGNED_STUDENT) {
                         visibility = AttributeVisibility.PROFESSOR_ONLY;
@@ -418,6 +472,13 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                     existing.setMinValue(attrRequest.minValue);
                     existing.setMaxValue(attrRequest.maxValue);
                     existing.setDefaultValue(null);
+                } else if (existing.getType() == AttributeType.ENUM_PAIR || attrRequest.type == AttributeType.ENUM_PAIR) {
+                    if (attrRequest.visibility != null) {
+                        existing.setVisibility(attrRequest.visibility);
+                    }
+                    existing.setDefaultValue(null);
+                    existing.setMinValue(null);
+                    existing.setMaxValue(null);
                 } else {
                     existing.setDefaultValue(attrRequest.defaultValue);
                     existing.setMinValue(attrRequest.minValue);
@@ -432,7 +493,6 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                     existing.setType(attrRequest.type);
                     existing.setTarget(attrRequest.target);
 
-                    // LIST type enforcement
                     if (attrRequest.type == AttributeType.LIST) {
                         if (attrRequest.target != AttributeTarget.STUDENT) {
                             throw new ServiceException(ErrorConstants.LIST_ATTRIBUTE_MUST_TARGET_STUDENT);
@@ -445,6 +505,7 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                         } else {
                             existing.setEnumRef(null);
                         }
+                        existing.setEnumRef2(null);
                         existing.setDefaultValue(null);
                         existing.setMinValue(null);
                         existing.setMaxValue(null);
@@ -459,9 +520,33 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                         }
                         existing.setVisibility(visibility);
                         existing.setEnumRef(null);
+                        existing.setEnumRef2(null);
                         existing.setDefaultValue(null);
+                    } else if (attrRequest.type == AttributeType.ENUM_PAIR) {
+                        if (attrRequest.target != AttributeTarget.TASK && attrRequest.target != AttributeTarget.STUDENT) {
+                            throw new ServiceException(ErrorConstants.PROFILE_ENUM_PAIR_INVALID_TARGET);
+                        }
+                        if (attrRequest.enumRefName == null || attrRequest.enumRefName.isBlank()
+                                || attrRequest.enumRefName2 == null || attrRequest.enumRefName2.isBlank()) {
+                            throw new ServiceException(ErrorConstants.PROFILE_ENUM_PAIR_REQUIRES_TWO_ENUMS);
+                        }
+                        if (attrRequest.enumRefName.equals(attrRequest.enumRefName2)) {
+                            throw new ServiceException(ErrorConstants.PROFILE_ENUM_PAIR_DISTINCT_REQUIRED);
+                        }
+                        ProfileEnum enumRef = findEnumByName(profile, attrRequest.enumRefName);
+                        ProfileEnum enumRef2 = findEnumByName(profile, attrRequest.enumRefName2);
+                        existing.setEnumRef(enumRef);
+                        existing.setEnumRef2(enumRef2);
+                        if (attrRequest.target == AttributeTarget.TASK) {
+                            existing.setAppliedBy(attrRequest.appliedBy != null ? attrRequest.appliedBy : AttributeAppliedBy.PROFESSOR);
+                        } else {
+                            existing.setAppliedBy(AttributeAppliedBy.PROFESSOR);
+                        }
+                        existing.setVisibility(attrRequest.visibility != null ? attrRequest.visibility : AttributeVisibility.PROFESSOR_ONLY);
+                        existing.setDefaultValue(null);
+                        existing.setMinValue(null);
+                        existing.setMaxValue(null);
                     } else {
-                        // Only TASK-targeted attributes can have STUDENT appliedBy
                         if (attrRequest.target != AttributeTarget.TASK) {
                             existing.setAppliedBy(AttributeAppliedBy.PROFESSOR);
                         } else if (attrRequest.appliedBy != null) {
@@ -477,6 +562,7 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                         } else {
                             existing.setEnumRef(null);
                         }
+                        existing.setEnumRef2(null);
                     }
                 }
             } else {
@@ -505,7 +591,6 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
         long totalCount = 0;
         List<AttributeUsageDTO.AttributeUsageSampleDTO> samples = new ArrayList<>();
 
-        // Task attribute values
         long taskCount = taskAttributeValueRepository.countByAttributeId(attributeId);
         totalCount += taskCount;
         if (samples.size() < 10) {
@@ -514,12 +599,11 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                 if (samples.size() >= 10) break;
                 String entityName = tv.getTask().getTaskKey() != null
                         ? tv.getTask().getTaskKey() : tv.getTask().getName();
-                String value = attribute.getType() == AttributeType.TEXT ? tv.getTextValue() : tv.getValue();
+                String value = formatValueForUsage(attribute, tv.getValue(), tv.getValueB(), tv.getTextValue());
                 samples.add(new AttributeUsageDTO.AttributeUsageSampleDTO("TASK", entityName, value));
             }
         }
 
-        // Student attribute values
         long studentCount = studentAttributeValueRepository.countByAttributeId(attributeId);
         totalCount += studentCount;
         if (samples.size() < 10) {
@@ -528,12 +612,11 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
                 if (samples.size() >= 10) break;
                 String entityName = sv.getUser().getFullName() != null
                         ? sv.getUser().getFullName() : sv.getUser().getUsername();
-                String value = attribute.getType() == AttributeType.TEXT ? sv.getTextValue() : sv.getValue();
+                String value = formatValueForUsage(attribute, sv.getValue(), sv.getValueB(), sv.getTextValue());
                 samples.add(new AttributeUsageDTO.AttributeUsageSampleDTO("STUDENT", entityName, value));
             }
         }
 
-        // Pull request attribute values
         long prCount = pullRequestAttributeValueRepository.countByAttributeId(attributeId);
         totalCount += prCount;
         if (samples.size() < 10) {
@@ -548,11 +631,9 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
             }
         }
 
-        // Student list attribute values (count distinct users)
         long studentListCount = studentAttributeListValueRepository.countByAttributeId(attributeId);
         totalCount += studentListCount;
 
-        // Pull request list attribute values (count distinct PRs)
         long prListCount = pullRequestAttributeListValueRepository.countByAttributeId(attributeId);
         totalCount += prListCount;
 
@@ -560,6 +641,18 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
         dto.setTotalCount(totalCount);
         dto.setSamples(samples);
         return dto;
+    }
+
+    private String formatValueForUsage(ProfileAttribute attribute, String value, String valueB, String textValue) {
+        if (attribute.getType() == AttributeType.TEXT) {
+            return textValue;
+        }
+        if (attribute.getType() == AttributeType.ENUM_PAIR) {
+            String a = value == null ? "" : value;
+            String b = valueB == null ? "" : valueB;
+            return a + " / " + b;
+        }
+        return value;
     }
 
     /**
@@ -576,14 +669,12 @@ public class ProfileService extends BaseServiceLong<Profile, ProfileRepository> 
             throw new ServiceException("Attribute does not belong to this profile");
         }
 
-        // Delete all instantiated values first
         taskAttributeValueRepository.deleteByAttributeId(attributeId);
         studentAttributeValueRepository.deleteByAttributeId(attributeId);
         pullRequestAttributeValueRepository.deleteByAttributeId(attributeId);
         studentAttributeListValueRepository.deleteByAttributeId(attributeId);
         pullRequestAttributeListValueRepository.deleteByAttributeId(attributeId);
 
-        // Remove from profile and delete the attribute
         profile.getAttributes().removeIf(a -> a.getId().equals(attributeId));
         repo.save(profile);
     }

--- a/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
+++ b/src/main/java/org/trackdev/api/service/StudentAttributeValueService.java
@@ -153,7 +153,9 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
      * Set or update an attribute value for a student in a course.
      */
     @Transactional
-    public StudentAttributeValue setStudentAttributeValue(Long courseId, String targetUserId, Long attributeId, String value, String textValue, String requestingUserId) {
+    public StudentAttributeValue setStudentAttributeValue(Long courseId, String targetUserId, Long attributeId,
+                                                          String value, String valueB, String textValue,
+                                                          String requestingUserId) {
         Course course = courseService.getCourse(courseId, requestingUserId);
         User requestingUser = userService.get(requestingUserId);
 
@@ -183,8 +185,9 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         checkAuthorization(attribute, requestingUser, targetUserId);
         if (attribute.getType() != AttributeType.TEXT && attribute.getType() != AttributeType.NUMERIC_TEXT) {
             HtmlSanitizer.validate(value);
+            HtmlSanitizer.validate(valueB);
         }
-        validateAttributeValue(attribute, value);
+        validateAttributeValue(attribute, value, valueB);
 
         User targetUser = userService.get(targetUserId);
         Optional<StudentAttributeValue> existing = repo().findByUserIdAndAttributeId(targetUserId, attributeId);
@@ -200,12 +203,19 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         if (attribute.getType() == AttributeType.TEXT) {
             attributeValue.setTextValue(value);
             attributeValue.setValue(null);
+            attributeValue.setValueB(null);
         } else if (attribute.getType() == AttributeType.NUMERIC_TEXT) {
             attributeValue.setValue(value);
             attributeValue.setTextValue(textValue);
+            attributeValue.setValueB(null);
+        } else if (attribute.getType() == AttributeType.ENUM_PAIR) {
+            attributeValue.setValue(value);
+            attributeValue.setValueB(valueB);
+            attributeValue.setTextValue(null);
         } else {
             attributeValue.setValue(value);
             attributeValue.setTextValue(null);
+            attributeValue.setValueB(null);
         }
 
         return save(attributeValue);
@@ -374,7 +384,25 @@ public class StudentAttributeValueService extends BaseServiceLong<StudentAttribu
         }
     }
 
-    private void validateAttributeValue(ProfileAttribute attribute, String value) {
+    private void validateAttributeValue(ProfileAttribute attribute, String value, String valueB) {
+        if (attribute.getType() == AttributeType.ENUM_PAIR) {
+            if (value == null || value.isBlank() || valueB == null || valueB.isBlank()) {
+                // Allow clearing both halves at once (treat as delete intent at higher level)
+                if ((value == null || value.isBlank()) && (valueB == null || valueB.isBlank())) {
+                    return;
+                }
+                throw new ServiceException(ErrorConstants.ATTRIBUTE_ENUM_PAIR_VALUE_INVALID);
+            }
+            ProfileEnum first = attribute.getEnumRef();
+            ProfileEnum second = attribute.getEnumRef2();
+            if (first == null || second == null
+                    || !first.getValueStrings().contains(value)
+                    || !second.getValueStrings().contains(valueB)) {
+                throw new ServiceException(ErrorConstants.ATTRIBUTE_ENUM_PAIR_VALUE_INVALID);
+            }
+            return;
+        }
+
         if (value == null || value.isBlank()) {
             return;
         }

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -1207,7 +1207,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
      * Authorization depends on the attribute's appliedBy field.
      */
     @Transactional
-    public TaskAttributeValue setTaskAttributeValue(Long taskId, Long attributeId, String value, String textValue, String userId) {
+    public TaskAttributeValue setTaskAttributeValue(Long taskId, Long attributeId,
+                                                     String value, String valueB, String textValue,
+                                                     String userId) {
         Task task = get(taskId);
         User user = userService.get(userId);
 
@@ -1239,8 +1241,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         // Validate value based on type
         if (attribute.getType() != AttributeType.TEXT && attribute.getType() != AttributeType.NUMERIC_TEXT) {
             HtmlSanitizer.validate(value);
+            HtmlSanitizer.validate(valueB);
         }
-        validateAttributeValue(attribute, value);
+        validateAttributeValue(attribute, value, valueB);
 
         // Find or create the attribute value
         Optional<TaskAttributeValue> existingValue =
@@ -1257,12 +1260,19 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
         if (attribute.getType() == AttributeType.TEXT) {
             attributeValue.setTextValue(value);
             attributeValue.setValue(null);
+            attributeValue.setValueB(null);
         } else if (attribute.getType() == AttributeType.NUMERIC_TEXT) {
             attributeValue.setValue(value);
             attributeValue.setTextValue(textValue);
+            attributeValue.setValueB(null);
+        } else if (attribute.getType() == AttributeType.ENUM_PAIR) {
+            attributeValue.setValue(value);
+            attributeValue.setValueB(valueB);
+            attributeValue.setTextValue(null);
         } else {
             attributeValue.setValue(value);
             attributeValue.setTextValue(null);
+            attributeValue.setValueB(null);
         }
 
         return taskAttributeValueService.save(attributeValue);
@@ -1311,9 +1321,27 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
     }
 
     /**
-     * Validate the value based on attribute type, including min/max for numeric types.
+     * Validate the value based on attribute type, including min/max for numeric types
+     * and ENUM_PAIR pair validation.
      */
-    private void validateAttributeValue(ProfileAttribute attribute, String value) {
+    private void validateAttributeValue(ProfileAttribute attribute, String value, String valueB) {
+        if (attribute.getType() == AttributeType.ENUM_PAIR) {
+            if ((value == null || value.isBlank()) && (valueB == null || valueB.isBlank())) {
+                return; // both empty == clear
+            }
+            if (value == null || value.isBlank() || valueB == null || valueB.isBlank()) {
+                throw new ServiceException(ErrorConstants.ATTRIBUTE_ENUM_PAIR_VALUE_INVALID);
+            }
+            ProfileEnum first = attribute.getEnumRef();
+            ProfileEnum second = attribute.getEnumRef2();
+            if (first == null || second == null
+                    || !first.getValueStrings().contains(value)
+                    || !second.getValueStrings().contains(valueB)) {
+                throw new ServiceException(ErrorConstants.ATTRIBUTE_ENUM_PAIR_VALUE_INVALID);
+            }
+            return;
+        }
+
         if (value == null || value.isBlank()) {
             return; // Allow empty values
         }

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -163,6 +163,11 @@ public final class ErrorConstants {
     public static final String PROFILE_ATTRIBUTE_IMMUTABLE_TARGET = "error.profile.attribute.immutable.target";
     public static final String PROFILE_ATTRIBUTE_IMMUTABLE_APPLIED_BY = "error.profile.attribute.immutable.applied.by";
     public static final String PROFILE_ATTRIBUTE_IMMUTABLE_ENUM_REF = "error.profile.attribute.immutable.enum.ref";
+    public static final String PROFILE_ATTRIBUTE_IMMUTABLE_ENUM_REF_2 = "error.profile.attribute.immutable.enum.ref.2";
+    public static final String PROFILE_ENUM_PAIR_REQUIRES_TWO_ENUMS = "error.profile.attribute.enum.pair.requires.two.enums";
+    public static final String PROFILE_ENUM_PAIR_DISTINCT_REQUIRED = "error.profile.attribute.enum.pair.distinct.required";
+    public static final String PROFILE_ENUM_PAIR_INVALID_TARGET = "error.profile.attribute.enum.pair.invalid.target";
+    public static final String ATTRIBUTE_ENUM_PAIR_VALUE_INVALID = "error.attribute.enum.pair.value.invalid";
     public static final String ATTRIBUTE_VALUE_BELOW_MIN = "error.attribute.value.below.min";
     public static final String ATTRIBUTE_VALUE_ABOVE_MAX = "error.attribute.value.above.max";
     public static final String LIST_ATTRIBUTE_MUST_TARGET_STUDENT = "error.profile.attribute.list.must.target.student";

--- a/src/main/resources/db/migration/V20__enum_pair_attribute_type.sql
+++ b/src/main/resources/db/migration/V20__enum_pair_attribute_type.sql
@@ -1,0 +1,18 @@
+-- Add ENUM_PAIR to the AttributeType enum on profile_attributes.type
+ALTER TABLE profile_attributes
+    MODIFY COLUMN `type` enum('ENUM','FLOAT','INTEGER','STRING','LIST','TEXT','NUMERIC_TEXT','ENUM_PAIR') NOT NULL;
+
+-- Second enum reference column for ENUM_PAIR attributes
+ALTER TABLE profile_attributes
+    ADD COLUMN `enum_ref_id_2` bigint NULL AFTER `enum_ref_id`,
+    ADD KEY `FK_profile_attributes_enum_ref_2` (`enum_ref_id_2`),
+    ADD CONSTRAINT `FK_profile_attributes_enum_ref_2`
+        FOREIGN KEY (`enum_ref_id_2`) REFERENCES `profile_enums` (`id`);
+
+-- Second value column on task and student attribute value tables.
+-- Stores the second half of an ENUM_PAIR value.
+ALTER TABLE task_attribute_values
+    ADD COLUMN `value_b` varchar(500) NULL AFTER `value`;
+
+ALTER TABLE student_attribute_values
+    ADD COLUMN `value_b` varchar(500) NULL AFTER `value`;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -190,6 +190,11 @@ error.profile.attribute.name.exists=An attribute with this name already exists i
 error.profile.enum.ref.not.found=Referenced enum not found in profile
 error.profile.enum.ref.required=Enum reference is required when attribute type is ENUM
 error.profile.enum.value.in.use=Cannot remove enum value "{0}" because it is in use by existing attribute data
+error.profile.attribute.enum.pair.requires.two.enums=ENUM_PAIR attributes require both first and second enum references
+error.profile.attribute.enum.pair.distinct.required=The two enum references of an ENUM_PAIR attribute must be different
+error.profile.attribute.enum.pair.invalid.target=ENUM_PAIR attributes can only target TASK or STUDENT
+error.profile.attribute.immutable.enum.ref.2=The second enum reference cannot be changed once the attribute has values
+error.attribute.enum.pair.value.invalid=Invalid value for ENUM_PAIR attribute. Both halves must belong to their respective enum
 
 # Backlog movement errors
 error.task.begun.cannot.move.to.backlog=A task that has begun cannot go back to the backlog

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -190,6 +190,11 @@ error.profile.attribute.name.exists=Ja existeix un atribut amb aquest nom al per
 error.profile.enum.ref.not.found=No s'ha trobat la referència a l'enumeració al perfil
 error.profile.enum.ref.required=La referència a l'enumeració és obligatòria quan el tipus d'atribut és ENUM
 error.profile.enum.value.in.use=No es pot eliminar el valor d''enumeració "{0}" perquè s''està utilitzant en dades d''atributs existents
+error.profile.attribute.enum.pair.requires.two.enums=Els atributs ENUM_PAIR requereixen les referències a la primera i segona enumeració
+error.profile.attribute.enum.pair.distinct.required=Les dues referències d'un atribut ENUM_PAIR han de ser diferents
+error.profile.attribute.enum.pair.invalid.target=Els atributs ENUM_PAIR només es poden aplicar a TASK o STUDENT
+error.profile.attribute.immutable.enum.ref.2=La segona referència d'enumeració no es pot modificar una vegada l'atribut té valors
+error.attribute.enum.pair.value.invalid=Valor invàlid per a l'atribut ENUM_PAIR. Les dues meitats han de pertànyer a la seva enumeració corresponent
 
 # Errors de moviment al backlog
 error.task.begun.cannot.move.to.backlog=Una tasca que ha començat no pot tornar al backlog

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -190,6 +190,11 @@ error.profile.attribute.name.exists=Ya existe un atributo con este nombre en el 
 error.profile.enum.ref.not.found=No se encontró la referencia a la enumeración en el perfil
 error.profile.enum.ref.required=La referencia a la enumeración es obligatoria cuando el tipo de atributo es ENUM
 error.profile.enum.value.in.use=No se puede eliminar el valor de enumeración "{0}" porque está en uso en datos de atributos existentes
+error.profile.attribute.enum.pair.requires.two.enums=Los atributos ENUM_PAIR requieren las referencias a la primera y segunda enumeración
+error.profile.attribute.enum.pair.distinct.required=Las dos referencias de un atributo ENUM_PAIR deben ser diferentes
+error.profile.attribute.enum.pair.invalid.target=Los atributos ENUM_PAIR sólo pueden aplicarse a TASK o STUDENT
+error.profile.attribute.immutable.enum.ref.2=La segunda referencia de enumeración no puede modificarse una vez que el atributo tiene valores
+error.attribute.enum.pair.value.invalid=Valor inválido para el atributo ENUM_PAIR. Ambas mitades deben pertenecer a su enumeración correspondiente
 
 # Errores de movimiento al backlog
 error.task.begun.cannot.move.to.backlog=Una tarea que ha comenzado no puede volver al backlog


### PR DESCRIPTION
## Summary

Introduces a new ENUM_PAIR attribute type that pairs two distinct enum references, storing a value for each slot on task and student attribute values. Changes span entities, DTOs, mappers, repositories, services, controllers, error messages in three languages, and a Flyway migration adding the required schema columns and enum variant.

## Commits

- `e4f03eb` feat(controller): update set attribute value to pass enum pair second value
- `4f0dad6` feat(controller): update set attribute value to pass enum pair second value
- `022a9ab` feat(dto): update profile attribute dto to include second enum pair fields
- `640ae2b` feat(dto): update student attribute value dto to add enum pair fields
- `0fd8e8b` feat(dto): update task attribute value dto to add enum pair fields
- `9089c80` feat(entity): update attribute type enum to add enum_pair value
- `8ff6d1b` feat(entity): update profile attribute to add second enum ref for enum_pair
- `dfea110` feat(entity): update student attribute value to add value_b for enum_pair
- `31ad7e6` feat(entity): update task attribute value to add value_b for enum_pair
- `1c0dd8d` feat(mapper): update profile mapper to map second enum ref for enum_pair
- `c8293b0` feat(mapper): update student attribute value mapper to add enum pair fields
- `1b8c6f6` feat(mapper): update task attribute value mapper to add enum pair fields
- `a2a3c23` feat(model): update profile request to add second enum ref for enum_pair
- `61f20df` feat(repository): update student attribute value repo to add value_b exists check
- `a1154dd` feat(repository): update task attribute value repo with explicit delete queries and value_b check
- `5ac3e84` feat(service): update profile service to support enum_pair attribute type
- `ce86214` feat(service): update student attribute value service to support enum_pair
- `d9f410d` feat(service): update task service to support enum_pair attribute values
- `7d801f1` feat(utils): update error constants to add enum_pair validation keys
- `8a18dfe` chore(resources): update messages to add enum_pair error strings
- `a1b120f` chore(resources): update catalan messages to add enum_pair error strings
- `9cae818` chore(resources): update spanish messages to add enum_pair error strings
- `255c556` chore(migration): add schema changes for enum_pair attribute type support
