### PR TITLE
Add push notification token registration and management feature

### DIFF
--- a/src/main/java/org/trackdev/api/controller/UserPushTokenController.java
+++ b/src/main/java/org/trackdev/api/controller/UserPushTokenController.java
@@ -1,0 +1,82 @@
+package org.trackdev.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.trackdev.api.dto.UserPushTokenDTO;
+import org.trackdev.api.dto.UserPushTokensResponseDTO;
+import org.trackdev.api.entity.UserPushToken;
+import org.trackdev.api.model.RegisterPushTokenRequest;
+import org.trackdev.api.service.UserPushTokenService;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "1. Authentication")
+@RestController
+@RequestMapping(path = "/users/me/push-tokens")
+@PreAuthorize("isAuthenticated()")
+public class UserPushTokenController extends BaseController {
+
+    @Autowired
+    UserPushTokenService pushTokenService;
+
+    @Operation(summary = "Register a push notification token",
+               description = "Registers (or refreshes) a push notification token for the " +
+                             "authenticated user's device. Idempotent on token: if the same " +
+                             "token already exists, its owner, platform, deviceId and " +
+                             "lastSeenAt are updated.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserPushTokenDTO registerToken(
+            Principal principal,
+            @Valid @RequestBody RegisterPushTokenRequest request) {
+        String userId = super.getUserId(principal);
+        UserPushToken pt = pushTokenService.registerToken(
+            userId, request.token, request.platform, request.deviceId);
+        return toDTO(pt);
+    }
+
+    @Operation(summary = "List push notification tokens",
+               description = "Lists all push notification tokens registered for the " +
+                             "authenticated user.")
+    @GetMapping
+    public UserPushTokensResponseDTO listTokens(Principal principal) {
+        String userId = super.getUserId(principal);
+        List<UserPushToken> tokens = pushTokenService.listTokens(userId);
+        List<UserPushTokenDTO> dtos = tokens.stream()
+            .map(this::toDTO)
+            .collect(Collectors.toList());
+        return new UserPushTokensResponseDTO(dtos);
+    }
+
+    @Operation(summary = "Unregister a push notification token",
+               description = "Removes a push notification token for the authenticated user. " +
+                             "Returns 204 even if the token does not exist (idempotent).")
+    @DeleteMapping(path = "/{token}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unregisterToken(
+            Principal principal,
+            @PathVariable(name = "token") String token) {
+        String userId = super.getUserId(principal);
+        pushTokenService.unregisterToken(userId, token);
+    }
+
+    private UserPushTokenDTO toDTO(UserPushToken pt) {
+        UserPushTokenDTO dto = new UserPushTokenDTO();
+        dto.setId(pt.getId());
+        dto.setToken(pt.getToken());
+        dto.setPlatform(pt.getPlatform().name());
+        dto.setDeviceId(pt.getDeviceId());
+        dto.setCreatedAt(pt.getCreatedAt());
+        dto.setLastSeenAt(pt.getLastSeenAt());
+        return dto;
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/UserPushTokenDTO.java
+++ b/src/main/java/org/trackdev/api/dto/UserPushTokenDTO.java
@@ -1,0 +1,14 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+import java.time.ZonedDateTime;
+
+@Data
+public class UserPushTokenDTO {
+    private String id;
+    private String token;
+    private String platform;
+    private String deviceId;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime lastSeenAt;
+}

--- a/src/main/java/org/trackdev/api/dto/UserPushTokensResponseDTO.java
+++ b/src/main/java/org/trackdev/api/dto/UserPushTokensResponseDTO.java
@@ -1,0 +1,13 @@
+package org.trackdev.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPushTokensResponseDTO {
+    private List<UserPushTokenDTO> tokens;
+}

--- a/src/main/java/org/trackdev/api/entity/UserPushToken.java
+++ b/src/main/java/org/trackdev/api/entity/UserPushToken.java
@@ -1,0 +1,73 @@
+package org.trackdev.api.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "user_push_tokens")
+public class UserPushToken extends BaseEntityUUID {
+
+    public static final int TOKEN_LENGTH = 512;
+    public static final int DEVICE_ID_LENGTH = 128;
+
+    public enum Platform {
+        IOS, ANDROID, WEB
+    }
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull
+    @Column(unique = true, length = TOKEN_LENGTH)
+    private String token;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16)
+    private Platform platform;
+
+    @Column(name = "device_id", length = DEVICE_ID_LENGTH)
+    private String deviceId;
+
+    @NotNull
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private ZonedDateTime createdAt;
+
+    @NotNull
+    @Column(name = "last_seen_at", columnDefinition = "TIMESTAMP")
+    private ZonedDateTime lastSeenAt;
+
+    public UserPushToken() {}
+
+    public UserPushToken(User user, String token, Platform platform, String deviceId) {
+        this.user = user;
+        this.token = token;
+        this.platform = platform;
+        this.deviceId = deviceId;
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.createdAt = now;
+        this.lastSeenAt = now;
+    }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+    public Platform getPlatform() { return platform; }
+    public void setPlatform(Platform platform) { this.platform = platform; }
+
+    public String getDeviceId() { return deviceId; }
+    public void setDeviceId(String deviceId) { this.deviceId = deviceId; }
+
+    public ZonedDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(ZonedDateTime createdAt) { this.createdAt = createdAt; }
+
+    public ZonedDateTime getLastSeenAt() { return lastSeenAt; }
+    public void setLastSeenAt(ZonedDateTime lastSeenAt) { this.lastSeenAt = lastSeenAt; }
+}

--- a/src/main/java/org/trackdev/api/model/RegisterPushTokenRequest.java
+++ b/src/main/java/org/trackdev/api/model/RegisterPushTokenRequest.java
@@ -1,0 +1,19 @@
+package org.trackdev.api.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.trackdev.api.entity.UserPushToken;
+
+public class RegisterPushTokenRequest {
+
+    @NotBlank
+    @Size(min = 1, max = UserPushToken.TOKEN_LENGTH)
+    public String token;
+
+    @NotNull
+    public UserPushToken.Platform platform;
+
+    @Size(max = UserPushToken.DEVICE_ID_LENGTH)
+    public String deviceId;
+}

--- a/src/main/java/org/trackdev/api/repository/UserPushTokenRepository.java
+++ b/src/main/java/org/trackdev/api/repository/UserPushTokenRepository.java
@@ -1,0 +1,18 @@
+package org.trackdev.api.repository;
+
+import org.trackdev.api.entity.User;
+import org.trackdev.api.entity.UserPushToken;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserPushTokenRepository extends BaseRepositoryUUID<UserPushToken> {
+
+    Optional<UserPushToken> findByToken(String token);
+
+    List<UserPushToken> findByUserOrderByLastSeenAtDesc(User user);
+
+    void deleteByToken(String token);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/org/trackdev/api/service/UserPushTokenService.java
+++ b/src/main/java/org/trackdev/api/service/UserPushTokenService.java
@@ -1,0 +1,66 @@
+package org.trackdev.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.entity.UserPushToken;
+import org.trackdev.api.repository.UserPushTokenRepository;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserPushTokenService
+        extends BaseServiceUUID<UserPushToken, UserPushTokenRepository> {
+
+    private static final Logger log = LoggerFactory.getLogger(UserPushTokenService.class);
+
+    @Autowired
+    private UserService userService;
+
+    @Transactional
+    public UserPushToken registerToken(String userId, String token,
+                                       UserPushToken.Platform platform, String deviceId) {
+        User user = userService.get(userId);
+
+        Optional<UserPushToken> existing = repo().findByToken(token);
+        if (existing.isPresent()) {
+            UserPushToken pt = existing.get();
+            pt.setUser(user);
+            pt.setPlatform(platform);
+            pt.setDeviceId(deviceId);
+            pt.setLastSeenAt(ZonedDateTime.now(ZoneId.of("UTC")));
+            return repo().save(pt);
+        }
+
+        UserPushToken pt = new UserPushToken(user, token, platform, deviceId);
+        repo().save(pt);
+        log.info("Push token registered for user: {}, platform: {}", userId, platform);
+        return pt;
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserPushToken> listTokens(String userId) {
+        User user = userService.get(userId);
+        return repo().findByUserOrderByLastSeenAtDesc(user);
+    }
+
+    @Transactional
+    public void unregisterToken(String userId, String token) {
+        Optional<UserPushToken> existing = repo().findByToken(token);
+        if (existing.isEmpty()) {
+            return;
+        }
+        UserPushToken pt = existing.get();
+        if (!pt.getUser().getId().equals(userId)) {
+            return;
+        }
+        repo().deleteByToken(token);
+        log.info("Push token unregistered for user: {}", userId);
+    }
+}

--- a/src/main/java/org/trackdev/api/service/UserService.java
+++ b/src/main/java/org/trackdev/api/service/UserService.java
@@ -16,6 +16,7 @@ import org.trackdev.api.entity.GithubInfo;
 import org.trackdev.api.entity.Project;
 import org.trackdev.api.entity.Role;
 import org.trackdev.api.entity.User;
+import org.trackdev.api.repository.UserPushTokenRepository;
 import org.trackdev.api.repository.UserRepository;
 import org.trackdev.api.utils.ErrorConstants;
 
@@ -48,7 +49,11 @@ public class UserService extends BaseServiceUUID<User, UserRepository> {
     @Autowired
     @Lazy
     private CourseService courseService;
-    
+
+    @Autowired
+    private UserPushTokenRepository userPushTokenRepository;
+
+
     public User matchPassword(String email, String password) {
         User user = this.getByEmail(email);
 
@@ -281,7 +286,14 @@ public class UserService extends BaseServiceUUID<User, UserRepository> {
         if(color != null) color.ifPresent(user::setColor);
         if(capitalLetters != null) capitalLetters.ifPresent(user::setCapitalLetters);
         if(changePassword != null && !modifier.getId().equals(user.getId())) changePassword.ifPresent(user::setChangePassword);
-        if(enabled != null && modifier.isUserType(UserType.ADMIN)) enabled.ifPresent(user::setEnabled);
+        if(enabled != null && modifier.isUserType(UserType.ADMIN)) {
+            enabled.ifPresent(newEnabled -> {
+                user.setEnabled(newEnabled);
+                if (Boolean.FALSE.equals(newEnabled)) {
+                    userPushTokenRepository.deleteByUser(user);
+                }
+            });
+        }
         if(timezone != null) timezone.ifPresent(user::setTimezone);
         
         // Handle githubUsername - allow manual setting without token
@@ -448,12 +460,15 @@ public class UserService extends BaseServiceUUID<User, UserRepository> {
             throw new ServiceException(ErrorConstants.CANNOT_DELETE_USER_HAS_OWNED_COURSES);
         }
         
+        // Remove all push notification tokens for this user
+        userPushTokenRepository.deleteByUser(user);
+
         // Remove from all project memberships (ManyToMany will handle)
         for (Project project : user.getProjects()) {
             project.getMembers().remove(user);
         }
         user.getProjects().clear();
-        
+
         // Delete the user (cascade will handle GithubInfo, PointsReview)
         repo().delete(user);
     }

--- a/src/main/resources/db/migration/V21__user_push_tokens.sql
+++ b/src/main/resources/db/migration/V21__user_push_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `user_push_tokens` (
+    `id` varchar(36) NOT NULL,
+    `user_id` varchar(36) NOT NULL,
+    `token` varchar(512) NOT NULL,
+    `platform` varchar(16) NOT NULL,
+    `device_id` varchar(128) NULL,
+    `created_at` timestamp NOT NULL,
+    `last_seen_at` timestamp NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_upt_token` (`token`),
+    KEY `IDX_upt_user` (`user_id`),
+    CONSTRAINT `FK_upt_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
## Summary

Adds a new UserPushToken entity, repository, service, and REST endpoint under /users/me/push-tokens for registering and listing device push tokens. The registration is idempotent, updating existing tokens on re-registration. Push tokens are automatically deleted when a user is disabled or deleted.

## Commits

- `aada72c` feat(service): update user service to delete push tokens on disable/delete
- `0444adc` feat(controller): add push token registration and listing endpoint
- `3b4095b` feat(dto): add push token dto with device and timestamp fields
- `897706a` feat(dto): add push tokens list response wrapper dto
- `adcd8e6` feat(entity): add user push token entity with platform and device fields
- `1a813f4` feat(model): add push token registration request model with validation
- `99ad5f8` feat(repository): add push token repository with user and token queries
- `1eacd5b` feat(service): add push token service with register and list operations
- `c6d29f3` chore(migration): add user push tokens table with platform and token fields
