### PR TITLE
Add FCM push notification support with user notification preferences

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.14.1'
 
+    // Firebase Admin SDK for Cloud Messaging (FCM)
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -64,6 +64,7 @@ if [ ! -f "$ENV_FILE" ]; then
     echo "  DISCORD_GUILD_ID=your_discord_guild_id"
     echo "  DISCORD_VERIFIED_ROLE_ID=your_discord_verified_role_id"
     echo "  DISCORD_REDIRECT_URI=http://localhost:8080/api/discord/callback"
+    echo "  FIREBASE_SERVICE_ACCOUNT_JSON=/absolute/path/to/firebase-service-account.json  # leave unset to disable FCM"
     exit 1
 fi
 

--- a/src/main/java/org/trackdev/api/configuration/FirebaseConfiguration.java
+++ b/src/main/java/org/trackdev/api/configuration/FirebaseConfiguration.java
@@ -1,0 +1,84 @@
+package org.trackdev.api.configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Configuration
+public class FirebaseConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(FirebaseConfiguration.class);
+
+    private final TrackDevProperties properties;
+
+    public FirebaseConfiguration(TrackDevProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        TrackDevProperties.Firebase cfg = properties.getFirebase();
+        if (!cfg.isConfigured()) {
+            return null;
+        }
+
+        Path path = Paths.get(cfg.getServiceAccountPath());
+        if (!Files.isRegularFile(path)) {
+            log.error("Firebase service account file not found at '{}' — FCM will be disabled", path);
+            return null;
+        }
+
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+
+        try (FileInputStream stream = new FileInputStream(path.toFile())) {
+            GoogleCredentials credentials = GoogleCredentials.fromStream(stream);
+            String projectId = credentials instanceof ServiceAccountCredentials sa
+                    ? sa.getProjectId()
+                    : null;
+
+            FirebaseOptions.Builder optionsBuilder = FirebaseOptions.builder()
+                    .setCredentials(credentials);
+            if (projectId != null) {
+                optionsBuilder.setProjectId(projectId);
+            }
+
+            FirebaseApp app = FirebaseApp.initializeApp(optionsBuilder.build());
+            log.info("Firebase Admin SDK initialized from {} (project: {})",
+                    path, projectId != null ? projectId : "<unknown>");
+            return app;
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        if (firebaseApp == null) {
+            return null;
+        }
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+    @Bean
+    public ApplicationListener<ApplicationReadyEvent> firebaseStartupWarning() {
+        return event -> {
+            if (!properties.getFirebase().isConfigured()) {
+                log.warn("FIREBASE_SERVICE_ACCOUNT_JSON not set — FCM push notifications disabled");
+            }
+        };
+    }
+}

--- a/src/main/java/org/trackdev/api/configuration/TrackDevProperties.java
+++ b/src/main/java/org/trackdev/api/configuration/TrackDevProperties.java
@@ -15,6 +15,7 @@ public class TrackDevProperties {
     private final Discord discord = new Discord();
     private final Sse sse = new Sse();
     private final StressTest stressTest = new StressTest();
+    private final Firebase firebase = new Firebase();
 
     public Auth getAuth() {
         return auth;
@@ -46,6 +47,10 @@ public class TrackDevProperties {
 
     public StressTest getStressTest() {
         return stressTest;
+    }
+
+    public Firebase getFirebase() {
+        return firebase;
     }
 
     public static class Auth {
@@ -294,6 +299,25 @@ public class TrackDevProperties {
         }
     }
 
+    public static class Firebase {
+        private String serviceAccountPath;
+
+        public String getServiceAccountPath() { return serviceAccountPath; }
+        public void setServiceAccountPath(String serviceAccountPath) {
+            this.serviceAccountPath = serviceAccountPath;
+        }
+
+        public boolean isConfigured() {
+            return serviceAccountPath != null && !serviceAccountPath.isBlank();
+        }
+
+        @Override
+        public String toString() {
+            return "Firebase{configured=" + isConfigured()
+                    + ", serviceAccountPath='" + serviceAccountPath + "'}";
+        }
+    }
+
     @Override
     public String toString() {
         return "TrackDevProperties{" +
@@ -305,6 +329,7 @@ public class TrackDevProperties {
                 ",\n  discord=" + discord +
                 ",\n  sse=" + sse +
                 ",\n  stressTest=" + stressTest +
+                ",\n  firebase=" + firebase +
                 "\n}";
     }
 }

--- a/src/main/java/org/trackdev/api/controller/UserController.java
+++ b/src/main/java/org/trackdev/api/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.trackdev.api.controller.exceptions.ControllerException;
 import org.trackdev.api.controller.exceptions.ServiceException;
+import org.trackdev.api.dto.NotificationPreferencesDTO;
 import org.trackdev.api.dto.UserWithGithubTokenDTO;
 import org.trackdev.api.dto.UserWithProjectsDTO;
 import org.trackdev.api.dto.UsersResponseDTO;
@@ -184,6 +185,39 @@ public class UserController extends BaseController {
         String userId = super.getUserId(principal);
         // All operations in a single transaction
         return new AdminCheckResponse(userService.isUserAdmin(userId));
+    }
+
+    @Operation(summary = "Get my notification preferences",
+               description = "Returns the authenticated user's push-notification preference flags.")
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping(path = "/me/notification-preferences")
+    public NotificationPreferencesDTO getMyNotificationPreferences(Principal principal) {
+        String userId = super.getUserId(principal);
+        User user = userService.get(userId);
+        return new NotificationPreferencesDTO(
+                user.getNotifyComments(),
+                user.getNotifyPointsReview(),
+                user.getNotifyTeamActivity());
+    }
+
+    @Operation(summary = "Update my notification preferences",
+               description = "Updates one or more push-notification preference flags. " +
+                             "Null fields are left unchanged.")
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping(path = "/me/notification-preferences")
+    public NotificationPreferencesDTO updateMyNotificationPreferences(
+            Principal principal,
+            @RequestBody NotificationPreferencesDTO request) {
+        String userId = super.getUserId(principal);
+        User updated = userService.updateNotificationPreferences(
+                userId,
+                request.getNotifyComments(),
+                request.getNotifyPointsReview(),
+                request.getNotifyTeamActivity());
+        return new NotificationPreferencesDTO(
+                updated.getNotifyComments(),
+                updated.getNotifyPointsReview(),
+                updated.getNotifyTeamActivity());
     }
 
     static class RegisterU {

--- a/src/main/java/org/trackdev/api/dto/NotificationPreferencesDTO.java
+++ b/src/main/java/org/trackdev/api/dto/NotificationPreferencesDTO.java
@@ -1,0 +1,27 @@
+package org.trackdev.api.dto;
+
+public class NotificationPreferencesDTO {
+
+    private Boolean notifyComments;
+    private Boolean notifyPointsReview;
+    private Boolean notifyTeamActivity;
+
+    public NotificationPreferencesDTO() {}
+
+    public NotificationPreferencesDTO(Boolean notifyComments,
+                                      Boolean notifyPointsReview,
+                                      Boolean notifyTeamActivity) {
+        this.notifyComments = notifyComments;
+        this.notifyPointsReview = notifyPointsReview;
+        this.notifyTeamActivity = notifyTeamActivity;
+    }
+
+    public Boolean getNotifyComments() { return notifyComments; }
+    public void setNotifyComments(Boolean notifyComments) { this.notifyComments = notifyComments; }
+
+    public Boolean getNotifyPointsReview() { return notifyPointsReview; }
+    public void setNotifyPointsReview(Boolean notifyPointsReview) { this.notifyPointsReview = notifyPointsReview; }
+
+    public Boolean getNotifyTeamActivity() { return notifyTeamActivity; }
+    public void setNotifyTeamActivity(Boolean notifyTeamActivity) { this.notifyTeamActivity = notifyTeamActivity; }
+}

--- a/src/main/java/org/trackdev/api/entity/User.java
+++ b/src/main/java/org/trackdev/api/entity/User.java
@@ -112,6 +112,18 @@ public class User extends BaseEntityUUID {
   @Column(length = TIMEZONE_LENGTH)
   private String timezone = DEFAULT_TIMEZONE;
 
+  @NotNull
+  @Column(name = "notify_comments", nullable = false)
+  private Boolean notifyComments = true;
+
+  @NotNull
+  @Column(name = "notify_points_review", nullable = false)
+  private Boolean notifyPointsReview = true;
+
+  @NotNull
+  @Column(name = "notify_team_activity", nullable = false)
+  private Boolean notifyTeamActivity = true;
+
   @Transient
   private Random random = new Random();
 
@@ -194,6 +206,21 @@ public class User extends BaseEntityUUID {
   public String getTimezone() { return timezone != null ? timezone : DEFAULT_TIMEZONE; }
 
   public void setTimezone(String timezone) { this.timezone = timezone != null ? timezone : DEFAULT_TIMEZONE; }
+
+  public Boolean getNotifyComments() { return notifyComments != null ? notifyComments : Boolean.TRUE; }
+  public void setNotifyComments(Boolean notifyComments) {
+    this.notifyComments = notifyComments != null ? notifyComments : Boolean.TRUE;
+  }
+
+  public Boolean getNotifyPointsReview() { return notifyPointsReview != null ? notifyPointsReview : Boolean.TRUE; }
+  public void setNotifyPointsReview(Boolean notifyPointsReview) {
+    this.notifyPointsReview = notifyPointsReview != null ? notifyPointsReview : Boolean.TRUE;
+  }
+
+  public Boolean getNotifyTeamActivity() { return notifyTeamActivity != null ? notifyTeamActivity : Boolean.TRUE; }
+  public void setNotifyTeamActivity(Boolean notifyTeamActivity) {
+    this.notifyTeamActivity = notifyTeamActivity != null ? notifyTeamActivity : Boolean.TRUE;
+  }
 
   public String setGithubToken(String githubToken) { return githubInfo.setGithubToken(githubToken); }
 

--- a/src/main/java/org/trackdev/api/service/CommentService.java
+++ b/src/main/java/org/trackdev/api/service/CommentService.java
@@ -23,11 +23,15 @@ public class CommentService extends BaseServiceLong<Comment, CommentRepository>{
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private FcmNotificationService fcmNotificationService;
+
     public Comment addComment(String content, User author, Task task) {
         // Validate content to prevent XSS attacks
         HtmlSanitizer.validate(content);
         Comment comment = new Comment(content, author, task);
         repo.save(comment);
+        fcmNotificationService.notifyComment(comment);
         return comment;
     }
 

--- a/src/main/java/org/trackdev/api/service/FcmNotificationService.java
+++ b/src/main/java/org/trackdev/api/service/FcmNotificationService.java
@@ -1,0 +1,385 @@
+package org.trackdev.api.service;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.trackdev.api.entity.Comment;
+import org.trackdev.api.entity.PointsReviewConversation;
+import org.trackdev.api.entity.PointsReviewMessage;
+import org.trackdev.api.entity.PullRequest;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.User;
+import org.trackdev.api.entity.UserPushToken;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class FcmNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(FcmNotificationService.class);
+    private static final int BODY_PREVIEW_MAX = 140;
+
+    private final ObjectProvider<FirebaseMessaging> firebaseMessagingProvider;
+    private final UserService userService;
+    private final UserPushTokenService userPushTokenService;
+
+    public FcmNotificationService(ObjectProvider<FirebaseMessaging> firebaseMessagingProvider,
+                                  UserService userService,
+                                  UserPushTokenService userPushTokenService) {
+        this.firebaseMessagingProvider = firebaseMessagingProvider;
+        this.userService = userService;
+        this.userPushTokenService = userPushTokenService;
+    }
+
+    public boolean isEnabled() {
+        return firebaseMessagingProvider.getIfAvailable() != null;
+    }
+
+    // -- Domain-specific notification entry points --------------------------
+
+    /**
+     * Notify the task assignee (if any, and not the comment author) of a new comment.
+     * Honors the recipient's notifyComments preference.
+     */
+    public void notifyComment(Comment comment) {
+        if (!isEnabled() || comment == null) return;
+        Task task = comment.getTask();
+        User author = comment.getAuthor();
+        if (task == null || task.getAssignee() == null) return;
+        User assignee = task.getAssignee();
+        if (author != null && author.getId().equals(assignee.getId())) return;
+        if (!Boolean.TRUE.equals(assignee.getNotifyComments())) return;
+
+        String authorName = author != null ? author.getFullName() : "Someone";
+        String title = authorName + " commented on " + task.getTaskKey();
+        String body = preview(comment.getContent());
+        Map<String, String> data = baseTaskPayload("comment", task);
+        data.put("commentId", String.valueOf(comment.getId()));
+        sendToUserAfterCommit(assignee.getId(), title, body, data);
+    }
+
+    /**
+     * Notify the points-review recipients (initiator + participants + course owner, minus the actor)
+     * when a new conversation is created. Honors notifyPointsReview.
+     */
+    public void notifyPointsReviewCreated(PointsReviewConversation conversation, User actor) {
+        if (!isEnabled() || conversation == null) return;
+        Task task = conversation.getTask();
+        if (task == null) return;
+        Set<User> recipients = pointsReviewRecipients(conversation, actor);
+        if (recipients.isEmpty()) return;
+
+        String actorName = actor != null ? actor.getFullName() : "A team member";
+        String title = "Points review on " + task.getTaskKey();
+        String body = actorName + " disagrees with the estimation";
+        Map<String, String> data = baseTaskPayload("points_review_created", task);
+        data.put("conversationId", String.valueOf(conversation.getId()));
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyPointsReview())) continue;
+            sendToUserAfterCommit(r.getId(), title, body, data);
+        }
+    }
+
+    /**
+     * Notify all current points-review recipients (minus the message author) of a new message.
+     * Honors notifyPointsReview.
+     */
+    public void notifyPointsReviewMessage(PointsReviewConversation conversation,
+                                          PointsReviewMessage message) {
+        if (!isEnabled() || conversation == null || message == null) return;
+        Task task = conversation.getTask();
+        if (task == null) return;
+        User author = message.getAuthor();
+        Set<User> recipients = pointsReviewRecipients(conversation, author);
+        if (recipients.isEmpty()) return;
+
+        String authorName = author != null ? author.getFullName() : "Someone";
+        String title = authorName + " replied on " + task.getTaskKey();
+        String body = preview(message.getContent());
+        Map<String, String> data = baseTaskPayload("points_review_message", task);
+        data.put("conversationId", String.valueOf(conversation.getId()));
+        data.put("messageId", String.valueOf(message.getId()));
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyPointsReview())) continue;
+            sendToUserAfterCommit(r.getId(), title, body, data);
+        }
+    }
+
+    /**
+     * Notify a user just added to a points-review conversation.
+     * Honors notifyPointsReview.
+     */
+    public void notifyPointsReviewParticipantAdded(PointsReviewConversation conversation,
+                                                   User addedUser,
+                                                   User actor) {
+        if (!isEnabled() || conversation == null || addedUser == null) return;
+        if (!Boolean.TRUE.equals(addedUser.getNotifyPointsReview())) return;
+        Task task = conversation.getTask();
+        if (task == null) return;
+
+        String actorName = actor != null ? actor.getFullName() : "A professor";
+        String title = "Added to points review on " + task.getTaskKey();
+        String body = actorName + " added you to the discussion";
+        Map<String, String> data = baseTaskPayload("points_review_added", task);
+        data.put("conversationId", String.valueOf(conversation.getId()));
+        sendToUserAfterCommit(addedUser.getId(), title, body, data);
+    }
+
+    /**
+     * Notify all members of the task's project (minus the actor) that a PR has been merged.
+     * Honors recipients' notifyTeamActivity.
+     */
+    public void notifyPrMerged(PullRequest pr, Task task, User actor) {
+        if (!isEnabled() || pr == null || task == null || task.getProject() == null) return;
+        Set<User> recipients = projectMembersExcept(task, actor);
+        if (recipients.isEmpty()) return;
+
+        String actorName = actor != null ? actor.getFullName() : "Someone";
+        String title = actorName + " merged PR #" + pr.getPrNumber();
+        String body = pr.getTitle();
+        Map<String, String> data = baseTaskPayload("pr_merged", task);
+        data.put("prId", String.valueOf(pr.getId()));
+        data.put("prNumber", String.valueOf(pr.getPrNumber()));
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyTeamActivity())) continue;
+            sendToUserAfterCommit(r.getId(), title, body, data);
+        }
+    }
+
+    /**
+     * Notify all members of the task's project (minus the actor) that a task transitioned to DONE.
+     * Honors recipients' notifyTeamActivity.
+     */
+    public void notifyTaskDone(Task task, User actor) {
+        if (!isEnabled() || task == null || task.getProject() == null) return;
+        Set<User> recipients = projectMembersExcept(task, actor);
+        if (recipients.isEmpty()) return;
+
+        String actorName = actor != null ? actor.getFullName() : "Someone";
+        String title = actorName + " completed " + task.getTaskKey();
+        String body = task.getName();
+        Map<String, String> data = baseTaskPayload("task_done", task);
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyTeamActivity())) continue;
+            sendToUserAfterCommit(r.getId(), title, body, data);
+        }
+    }
+
+    // -- Low-level send API -------------------------------------------------
+
+    public BatchResponse sendToUser(String userId,
+                                    String title,
+                                    String body,
+                                    Map<String, String> data) {
+        FirebaseMessaging messaging = firebaseMessagingProvider.getIfAvailable();
+        if (messaging == null) {
+            log.debug("FCM disabled — skipping sendToUser({})", userId);
+            return null;
+        }
+
+        User user = userService.get(userId);
+        List<UserPushToken> tokens = userPushTokenService.findByUser(user);
+        if (tokens.isEmpty()) {
+            log.debug("User {} has no registered push tokens", userId);
+            return null;
+        }
+
+        List<String> tokenStrings = tokens.stream().map(UserPushToken::getToken).toList();
+        MulticastMessage message = buildMulticastMessage(tokenStrings, title, body, data);
+
+        try {
+            BatchResponse response = messaging.sendEachForMulticast(message);
+            handleStaleTokens(tokenStrings, response);
+            log.info("FCM multicast for user {}: success={}, failure={}",
+                    userId, response.getSuccessCount(), response.getFailureCount());
+            return response;
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM multicast failed for user {}: {}", userId, e.getMessage());
+            return null;
+        }
+    }
+
+    public String sendToToken(String token,
+                              String title,
+                              String body,
+                              Map<String, String> data) {
+        FirebaseMessaging messaging = firebaseMessagingProvider.getIfAvailable();
+        if (messaging == null) {
+            log.debug("FCM disabled — skipping sendToToken");
+            return null;
+        }
+
+        Message message = buildMessage(token, title, body, data);
+
+        try {
+            return messaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            MessagingErrorCode code = e.getMessagingErrorCode();
+            if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                userPushTokenService.deleteStaleTokens(Collections.singletonList(token));
+            }
+            log.error("FCM send failed (code={}): {}", code, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Schedule a push send to fire after the current transaction commits, so we never
+     * deliver a notification for work that ends up rolled back. Falls back to immediate
+     * send when called outside a transaction.
+     */
+    public void sendToUserAfterCommit(String userId,
+                                      String title,
+                                      String body,
+                                      Map<String, String> data) {
+        if (!isEnabled()) return;
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    try {
+                        sendToUser(userId, title, body, data);
+                    } catch (RuntimeException ex) {
+                        log.warn("FCM after-commit send failed for user {}: {}", userId, ex.getMessage());
+                    }
+                }
+            });
+        } else {
+            sendToUser(userId, title, body, data);
+        }
+    }
+
+    // -- Internal helpers ---------------------------------------------------
+
+    private Set<User> pointsReviewRecipients(PointsReviewConversation conversation, User actor) {
+        Set<User> recipients = new LinkedHashSet<>();
+        if (conversation.getInitiator() != null) {
+            recipients.add(conversation.getInitiator());
+        }
+        if (conversation.getParticipants() != null) {
+            recipients.addAll(conversation.getParticipants());
+        }
+        // Course owner (the professor) is implicitly part of every conversation.
+        Task task = conversation.getTask();
+        if (task != null && task.getProject() != null && task.getProject().getCourse() != null) {
+            User professor = task.getProject().getCourse().getOwner();
+            if (professor != null) {
+                recipients.add(professor);
+            }
+        }
+        if (actor != null) {
+            recipients.removeIf(u -> u != null && u.getId().equals(actor.getId()));
+        }
+        recipients.removeIf(u -> u == null || u.getId() == null);
+        return recipients;
+    }
+
+    private Set<User> projectMembersExcept(Task task, User actor) {
+        Collection<User> members = task.getProject().getMembers();
+        if (members == null || members.isEmpty()) return Collections.emptySet();
+        Set<User> result = new HashSet<>(members);
+        if (actor != null) {
+            result.removeIf(u -> u != null && u.getId().equals(actor.getId()));
+        }
+        result.removeIf(u -> u == null || u.getId() == null);
+        return result;
+    }
+
+    private Map<String, String> baseTaskPayload(String type, Task task) {
+        Map<String, String> data = new HashMap<>();
+        data.put("type", type);
+        if (task != null) {
+            data.put("taskId", String.valueOf(task.getId()));
+            if (task.getTaskKey() != null) data.put("taskKey", task.getTaskKey());
+            if (task.getProject() != null && task.getProject().getId() != null) {
+                data.put("projectId", String.valueOf(task.getProject().getId()));
+            }
+        }
+        return data;
+    }
+
+    private static String preview(String html) {
+        if (html == null) return "";
+        String stripped = html.replaceAll("<[^>]*>", "").trim();
+        if (stripped.length() <= BODY_PREVIEW_MAX) return stripped;
+        return stripped.substring(0, BODY_PREVIEW_MAX - 1) + "…";
+    }
+
+    private MulticastMessage buildMulticastMessage(List<String> tokens,
+                                                   String title,
+                                                   String body,
+                                                   Map<String, String> data) {
+        MulticastMessage.Builder builder = MulticastMessage.builder().addAllTokens(tokens);
+        if (title != null || body != null) {
+            builder.setNotification(Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build());
+        }
+        if (data != null && !data.isEmpty()) {
+            builder.putAllData(data);
+        }
+        return builder.build();
+    }
+
+    private Message buildMessage(String token,
+                                 String title,
+                                 String body,
+                                 Map<String, String> data) {
+        Message.Builder builder = Message.builder().setToken(token);
+        if (title != null || body != null) {
+            builder.setNotification(Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build());
+        }
+        if (data != null && !data.isEmpty()) {
+            builder.putAllData(data);
+        }
+        return builder.build();
+    }
+
+    private void handleStaleTokens(List<String> tokens, BatchResponse response) {
+        List<SendResponse> responses = response.getResponses();
+        List<String> stale = new ArrayList<>();
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse r = responses.get(i);
+            if (r.isSuccessful()) {
+                continue;
+            }
+            FirebaseMessagingException ex = r.getException();
+            MessagingErrorCode code = ex != null ? ex.getMessagingErrorCode() : null;
+            if (code == MessagingErrorCode.UNREGISTERED || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                stale.add(tokens.get(i));
+            } else {
+                log.warn("FCM send failed (code={}): {}", code, ex != null ? ex.getMessage() : "unknown");
+            }
+        }
+        if (!stale.isEmpty()) {
+            userPushTokenService.deleteStaleTokens(stale);
+        }
+    }
+}

--- a/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
+++ b/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
@@ -29,6 +29,9 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
     @Autowired
     PointsReviewMessageRepository messageRepository;
 
+    @Autowired
+    FcmNotificationService fcmNotificationService;
+
     /**
      * Create a new points review conversation on a task.
      */
@@ -63,6 +66,8 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         PointsReviewMessage firstMessage = new PointsReviewMessage(message, initiator, conversation);
         conversation.addMessage(firstMessage);
         messageRepository.save(firstMessage);
+
+        fcmNotificationService.notifyPointsReviewCreated(conversation, initiator);
 
         return conversation;
     }
@@ -161,6 +166,8 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         conversation.addMessage(message);
         messageRepository.save(message);
 
+        fcmNotificationService.notifyPointsReviewMessage(conversation, message);
+
         return message;
     }
 
@@ -224,7 +231,12 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         }
 
         conversation.addParticipant(participant);
-        return repo.save(conversation);
+        PointsReviewConversation saved = repo.save(conversation);
+
+        User actor = userService.get(userId);
+        fcmNotificationService.notifyPointsReviewParticipantAdded(saved, participant, actor);
+
+        return saved;
     }
 
     /**

--- a/src/main/java/org/trackdev/api/service/PullRequestService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestService.java
@@ -64,6 +64,9 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
     @Autowired
     GitHubRepoService gitHubRepoService;
 
+    @Autowired
+    FcmNotificationService fcmNotificationService;
+
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
@@ -378,8 +381,12 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
         }
         
         if (activityType != null && task != null) {
-            activityService.recordActivity(activityType, actor, task.getProject(), task, 
+            activityService.recordActivity(activityType, actor, task.getProject(), task,
                     message, null, action);
+        }
+
+        if (activityType == ActivityType.PR_MERGED && task != null) {
+            fcmNotificationService.notifyPrMerged(pr, task, actor);
         }
     }
 

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -64,6 +64,9 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
     @Autowired
     SseEmitterService sseEmitterService;
 
+    @Autowired
+    FcmNotificationService fcmNotificationService;
+
     @Transactional
     public Task createTask(Long projectId, String name, String description, TaskType type, String assigneeId, String userId) {
         Project project = projectService.get(projectId);
@@ -527,6 +530,10 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
                 task.setStatus(status);
             }
             changes.add(new TaskStatusChange(user, task, oldStatus.toString(), status.toString()));
+
+            if (oldStatus != TaskStatus.DONE && status == TaskStatus.DONE) {
+                fcmNotificationService.notifyTaskDone(task, user);
+            }
 
             // If this is a subtask being set to DONE, check if parent USER_STORY should auto-complete
             if (status == TaskStatus.DONE && task.getParentTask() != null) {

--- a/src/main/java/org/trackdev/api/service/UserPushTokenService.java
+++ b/src/main/java/org/trackdev/api/service/UserPushTokenService.java
@@ -11,6 +11,7 @@ import org.trackdev.api.repository.UserPushTokenRepository;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,5 +63,20 @@ public class UserPushTokenService
         }
         repo().deleteByToken(token);
         log.info("Push token unregistered for user: {}", userId);
+    }
+
+    @Transactional
+    public void deleteStaleTokens(Collection<String> tokens) {
+        for (String t : tokens) {
+            repo().deleteByToken(t);
+        }
+        if (!tokens.isEmpty()) {
+            log.info("Removed {} stale push token(s) reported by FCM", tokens.size());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserPushToken> findByUser(User user) {
+        return repo().findByUserOrderByLastSeenAtDesc(user);
     }
 }

--- a/src/main/java/org/trackdev/api/service/UserService.java
+++ b/src/main/java/org/trackdev/api/service/UserService.java
@@ -473,4 +473,22 @@ public class UserService extends BaseServiceUUID<User, UserRepository> {
         repo().delete(user);
     }
 
+    @Transactional
+    public User updateNotificationPreferences(String userId,
+                                              Boolean notifyComments,
+                                              Boolean notifyPointsReview,
+                                              Boolean notifyTeamActivity) {
+        User user = get(userId);
+        if (notifyComments != null) {
+            user.setNotifyComments(notifyComments);
+        }
+        if (notifyPointsReview != null) {
+            user.setNotifyPointsReview(notifyPointsReview);
+        }
+        if (notifyTeamActivity != null) {
+            user.setNotifyTeamActivity(notifyTeamActivity);
+        }
+        return repo().save(user);
+    }
+
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -97,6 +97,10 @@ trackdev:
     user-count: ${STRESS_TEST_USERS:80}
     project-count: ${STRESS_TEST_PROJECTS:15}
     password: ${STRESS_TEST_PASSWORD:stress}
+  # Firebase Cloud Messaging configuration. FIREBASE_SERVICE_ACCOUNT_JSON must be the
+  # filesystem path to the admin SDK service-account JSON file. Empty = FCM disabled.
+  firebase:
+    service-account-path: ${FIREBASE_SERVICE_ACCOUNT_JSON:}
 
 management:
   server:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -91,6 +91,10 @@ trackdev:
     max-connections-per-user: ${SSE_MAX_CONNECTIONS_PER_USER:3}
     thread-pool-size: ${SSE_THREAD_POOL_SIZE:2}
     async-pool-size: ${SSE_ASYNC_POOL_SIZE:5}
+  # Firebase Cloud Messaging configuration. FIREBASE_SERVICE_ACCOUNT_JSON must be the
+  # filesystem path to the admin SDK service-account JSON file. Empty = FCM disabled.
+  firebase:
+    service-account-path: ${FIREBASE_SERVICE_ACCOUNT_JSON:}
 
 management:
   server:

--- a/src/main/resources/db/migration/V22__user_notification_preferences.sql
+++ b/src/main/resources/db/migration/V22__user_notification_preferences.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `users`
+    ADD COLUMN `notify_comments` BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN `notify_points_review` BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN `notify_team_activity` BOOLEAN NOT NULL DEFAULT TRUE;

--- a/src/test/java/org/trackdev/api/service/TaskServiceStatusTransitionTest.java
+++ b/src/test/java/org/trackdev/api/service/TaskServiceStatusTransitionTest.java
@@ -35,6 +35,7 @@ class TaskServiceStatusTransitionTest {
     @Mock private TaskChangeService taskChangeService;
     @Mock private ActivityService activityService;
     @Mock private SseEmitterService sseEmitterService;
+    @Mock private FcmNotificationService fcmNotificationService;
 
     private TaskService taskService;
 
@@ -51,6 +52,7 @@ class TaskServiceStatusTransitionTest {
         ReflectionTestUtils.setField(taskService, "taskChangeService", taskChangeService);
         ReflectionTestUtils.setField(taskService, "activityService", activityService);
         ReflectionTestUtils.setField(taskService, "sseEmitterService", sseEmitterService);
+        ReflectionTestUtils.setField(taskService, "fcmNotificationService", fcmNotificationService);
 
         professor = new User();
         ReflectionTestUtils.setField(professor, "id", "professor-id");


### PR DESCRIPTION
## Summary

Integrates Firebase Cloud Messaging to deliver push notifications when comments are added, pull requests are merged, tasks reach done status, and points review events occur. Adds per-user notification preference flags controllable via a new API endpoint, backed by a Flyway migration and Firebase Admin SDK configuration.

## Commits

- `d69aa4e` chore(build): update dependencies to add firebase admin sdk
- `8cd65bc` chore(scripts): update server script to document fcm env variable
- `4c1c6f4` feat(configuration): update properties to add firebase config support
- `63ce7ef` feat(controller): update user controller to add notification preference endpoints
- `047c07b` feat(entity): update user entity to add notification preference fields
- `5dd3cba` feat(service): update comment service to send fcm notification on comment
- `4efb34b` feat(service): update points review service to send fcm notifications
- `cf3d92d` feat(service): update pull request service to send fcm notification on merge
- `099030a` feat(service): update task service to send fcm notification on task done
- `abe1b8a` feat(service): update push token service to add stale token cleanup
- `f958886` feat(service): update user service to add notification preferences update
- `e6dc917` chore(resources): update dev config to add firebase service account path
- `2860779` chore(resources): update prod config to add firebase service account path
- `60f511f` test(service): update task service tests to mock fcm notification service
- `f747bb5` feat(configuration): add firebase app configuration bean for fcm
- `9c8998e` feat(dto): add notification preferences dto with comment and review flags
- `20904f5` feat(service): add fcm notification service for push notification delivery
- `f9b6a22` chore(migration): add user notification preference columns to users table
