### PR TITLE
Add professor-controlled cascading USER_STORY transitions

### DIFF
--- a/src/main/java/org/trackdev/api/service/AccessChecker.java
+++ b/src/main/java/org/trackdev/api/service/AccessChecker.java
@@ -875,15 +875,34 @@ public class AccessChecker {
 
     /**
      * Compute canEditStatus permission.
-     * USER_STORY cannot have status changed manually.
+     * USER_STORY status is normally computed from subtasks, but a PROFESSOR can
+     * manually flip it when the cascade is unambiguous (TODO → DONE if all
+     * subtasks are DONE, or DONE → TODO to revert).
      * TASK/BUG in past sprint only cannot change status (unless professor).
      */
     public boolean canEditStatus(org.trackdev.api.entity.Task task, String userId) {
-        // USER_STORY status is computed from children, cannot be changed manually
+        boolean isProfessor = isProfessorForTask(task, userId);
         if (task.getTaskType() == TaskType.USER_STORY) {
+            // Students/non-professors never edit USER_STORY status — it cascades from subtasks
+            if (!isProfessor) {
+                return false;
+            }
+            // Professor can flip USER_STORY status only when the cascade is unambiguous:
+            //   TODO → DONE   (only if all subtasks are DONE — otherwise the cascade would just revert it)
+            //   DONE → TODO   (manual revert)
+            TaskStatus current = task.getStatus();
+            if (current == TaskStatus.DONE) {
+                return canEditTask(task, userId);
+            }
+            if (current == TaskStatus.TODO) {
+                Collection<org.trackdev.api.entity.Task> children = task.getChildTasks();
+                boolean hasChildren = children != null && !children.isEmpty();
+                if (hasChildren && task.areAllSubtasksDone()) {
+                    return canEditTask(task, userId);
+                }
+            }
             return false;
         }
-        boolean isProfessor = isProfessorForTask(task, userId);
         // If frozen, only professor can edit
         if (task.isFrozen() && !isProfessor) {
             return false;

--- a/src/main/java/org/trackdev/api/service/PullRequestService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestService.java
@@ -243,25 +243,20 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
                     task.forceSetStatus(TaskStatus.INPROGRESS);
                     log.info("Task {} reverted from DONE to INPROGRESS (DONE and VERIFY rules no longer met)", task.getTaskKey());
                 }
-                revertParentUserStoryIfNeeded(task);
+                // Centralized cascade — replaces ad-hoc revert logic that only ever
+                // demoted the parent. Routing through TaskService keeps a single
+                // source of truth for the USER_STORY ↔ subtasks invariant.
+                taskService.reconcileUserStoryStatus(task.getParentTask(), null, null);
             }
         } else if (currentStatus == TaskStatus.VERIFY) {
             if (!task.canMoveToVerify()) {
                 task.forceSetStatus(TaskStatus.INPROGRESS);
                 log.info("Task {} reverted from VERIFY to INPROGRESS (VERIFY rules no longer met)", task.getTaskKey());
+                // VERIFY → INPROGRESS doesn't leave DONE, but the subtask was already
+                // out of DONE before this branch ran. Still, run reconcile defensively
+                // in case stale data leaves the parent inconsistent.
+                taskService.reconcileUserStoryStatus(task.getParentTask(), null, null);
             }
-        }
-    }
-
-    /**
-     * If a subtask leaves DONE and its parent USER_STORY was DONE, revert parent to TODO.
-     */
-    private void revertParentUserStoryIfNeeded(Task task) {
-        Task parent = task.getParentTask();
-        if (parent != null && parent.getTaskType() == TaskType.USER_STORY
-                && parent.getStatus() == TaskStatus.DONE) {
-            parent.forceSetStatus(TaskStatus.TODO);
-            log.info("Parent USER_STORY {} reverted from DONE to TODO", parent.getTaskKey());
         }
     }
 

--- a/src/main/java/org/trackdev/api/service/TaskService.java
+++ b/src/main/java/org/trackdev/api/service/TaskService.java
@@ -488,6 +488,26 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             TaskStatus currentStatus = task.getStatus();
             boolean isProfessor = accessChecker.isProfessorForTask(task, userId);
 
+            // USER_STORY status is normally cascade-driven from subtasks. Allow only
+            // the two manual professor transitions that mirror the cascade:
+            //   TODO → DONE  (only if every subtask is already DONE)
+            //   DONE → TODO  (revert)
+            // Anything else (including any student attempt) is rejected here so that
+            // the generic forceSetStatus below cannot bypass the rule.
+            if (task.getTaskType() == TaskType.USER_STORY && currentStatus != status) {
+                if (!isProfessor) {
+                    throw new ServiceException(ErrorConstants.USER_STORY_STATUS_NOT_EDITABLE);
+                }
+                boolean validProfessorTransition =
+                        (currentStatus == TaskStatus.DONE && status == TaskStatus.TODO)
+                        || (currentStatus == TaskStatus.TODO && status == TaskStatus.DONE
+                            && task.getChildTasks() != null && !task.getChildTasks().isEmpty()
+                            && task.areAllSubtasksDone());
+                if (!validProfessorTransition) {
+                    throw new ServiceException(ErrorConstants.USER_STORY_STATUS_NOT_EDITABLE);
+                }
+            }
+
             // Students only: cannot change status from TODO if task is in a future sprint
             if (!isProfessor && currentStatus == TaskStatus.TODO && status != TaskStatus.TODO) {
                 Collection<Sprint> activeSprints = task.getActiveSprints();
@@ -535,30 +555,11 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
                 fcmNotificationService.notifyTaskDone(task, user);
             }
 
-            // If this is a subtask being set to DONE, check if parent USER_STORY should auto-complete
-            if (status == TaskStatus.DONE && task.getParentTask() != null) {
-                Task parentTask = task.getParentTask();
-                if (parentTask.getTaskType() == TaskType.USER_STORY && parentTask.areAllSubtasksDone()) {
-                    TaskStatus parentOldStatus = parentTask.getStatus();
-                    if (parentOldStatus != TaskStatus.DONE) {
-                        parentTask.setStatus(TaskStatus.DONE);
-                        changes.add(new TaskStatusChange(user, parentTask,
-                                parentOldStatus.toString(), TaskStatus.DONE.toString()));
-                        repo.save(parentTask);
-                    }
-                }
-            }
-
-            // If this is a subtask moving AWAY from DONE, revert parent USER_STORY from DONE to TODO
-            if (oldStatus == TaskStatus.DONE && status != TaskStatus.DONE && task.getParentTask() != null) {
-                Task parentTask = task.getParentTask();
-                if (parentTask.getTaskType() == TaskType.USER_STORY && parentTask.getStatus() == TaskStatus.DONE) {
-                    parentTask.setStatus(TaskStatus.TODO);
-                    changes.add(new TaskStatusChange(user, parentTask,
-                            TaskStatus.DONE.toString(), TaskStatus.TODO.toString()));
-                    repo.save(parentTask);
-                }
-            }
+            // Single reconciliation entry point: covers both auto-promotion to DONE
+            // (when this subtask was the last non-DONE) and auto-revert from DONE
+            // (when this subtask leaves DONE). Replaces two separate inline blocks
+            // that diverged in subtle ways and could silently drop the cascade.
+            reconcileUserStoryStatus(task.getParentTask(), user, changes);
         }
         if(editTask.rank != null) {
             Integer newRank = editTask.rank.orElseThrow(
@@ -922,19 +923,77 @@ public class TaskService extends BaseServiceLong<Task, TaskRepository> {
             repo.deleteAll(removeTask);
         }
 
+        // Detach from parent's in-memory collection BEFORE the reconcile check.
+        // Otherwise areAllSubtasksDone could still see this (non-DONE) task in the
+        // parent's already-initialized childTasks list and skip the promotion.
+        if (parentTask != null && parentTask.getChildTasks() != null) {
+            parentTask.getChildTasks().remove(task);
+        }
+
         // Finally, delete the task itself
         repo.delete(task);
 
-        // If deleting a subtask, check if parent USER_STORY should auto-complete
-        if (parentTask != null && parentTask.getTaskType() == TaskType.USER_STORY
-                && parentTask.getStatus() != TaskStatus.DONE && parentTask.areAllSubtasksDone()) {
-            TaskStatus parentOldStatus = parentTask.getStatus();
-            parentTask.setStatus(TaskStatus.DONE);
-            repo.save(parentTask);
-            TaskChange change = new TaskStatusChange(actor, parentTask,
-                    parentOldStatus.toString(), TaskStatus.DONE.toString());
+        // Removing a subtask can flip whether the parent's invariant is met
+        // (e.g. last non-DONE child gone → promote, or all children gone → leave alone).
+        reconcileUserStoryStatus(parentTask, actor, null);
+    }
+
+    /**
+     * Reconcile a USER_STORY parent's status against its current children.
+     *
+     * Domain invariants enforced here:
+     *   - All children DONE  → parent must be DONE
+     *   - Any child not DONE → parent must NOT be DONE (revert to TODO)
+     *
+     * This is the single source of truth for the auto-cascade between subtasks
+     * and their parent USER_STORY. Callers MUST invoke it after any change that
+     * could affect a USER_STORY's children: subtask status change, subtask
+     * sprint change, subtask creation, subtask deletion, and PR-driven
+     * subtask demotions. Using it everywhere prevents the parent from drifting
+     * into states like "all subtasks DONE but parent still TODO".
+     *
+     * Uses {@link Task#forceSetStatus} on purpose: this is a system-driven
+     * reconciliation, not a user-issued transition, so the validation graph
+     * (which forbids e.g. BACKLOG → DONE for USER_STORY) must NOT short-circuit
+     * the cascade — that earlier behaviour was the source of the silently
+     * dropped promotion in edge cases.
+     *
+     * @param parent the candidate parent task; no-op if null or not USER_STORY
+     * @param actor  user attributed to any recorded TaskStatusChange (may be null)
+     * @param changes optional list to append a TaskStatusChange to (may be null)
+     * @return true if the parent's status was actually changed
+     */
+    boolean reconcileUserStoryStatus(Task parent, User actor, List<TaskChange> changes) {
+        if (parent == null || parent.getTaskType() != TaskType.USER_STORY) {
+            return false;
+        }
+        Collection<Task> children = parent.getChildTasks();
+        boolean hasChildren = children != null && !children.isEmpty();
+        TaskStatus oldStatus = parent.getStatus();
+        TaskStatus newStatus = oldStatus;
+
+        if (hasChildren && parent.areAllSubtasksDone()) {
+            if (oldStatus != TaskStatus.DONE) {
+                newStatus = TaskStatus.DONE;
+            }
+        } else if (oldStatus == TaskStatus.DONE) {
+            // Parent is DONE but at least one child is not — revert.
+            newStatus = TaskStatus.TODO;
+        }
+
+        if (newStatus == oldStatus) {
+            return false;
+        }
+        parent.forceSetStatus(newStatus);
+        repo.save(parent);
+        TaskStatusChange change = new TaskStatusChange(actor, parent,
+                oldStatus.toString(), newStatus.toString());
+        if (changes != null) {
+            changes.add(change);
+        } else {
             taskChangeService.store(change);
         }
+        return true;
     }
 
     /**

--- a/src/main/java/org/trackdev/api/utils/ErrorConstants.java
+++ b/src/main/java/org/trackdev/api/utils/ErrorConstants.java
@@ -47,6 +47,7 @@ public final class ErrorConstants {
     public static final String ONLY_PROFESSOR_CAN_CHANGE_REPORTER = "error.task.reporter.professor.only";
     public static final String ONLY_USER_STORY_CAN_HAVE_SUBTASKS = "error.task.subtasks.user.story.only";
     public static final String USER_STORY_CANNOT_BE_DONE_WITH_PENDING_SUBTASKS = "error.task.user.story.pending.subtasks";
+    public static final String USER_STORY_STATUS_NOT_EDITABLE = "error.task.user.story.status.not.editable";
     public static final String TASK_CANNOT_BE_DONE_WITHOUT_ESTIMATION = "error.task.done.requires.estimation";
     public static final String TASK_CANNOT_BE_DONE_WITHOUT_MERGED_PR = "error.task.done.requires.merged.pr";
     public static final String TASK_CANNOT_BE_DONE_WITH_OPEN_PRS = "error.task.done.has.open.prs";

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -83,6 +83,7 @@ error.task.assignee.professor.only=Only a professor can change the task assignee
 error.task.reporter.professor.only=Only a professor can change the task reporter
 error.task.subtasks.user.story.only=Only tasks of type USER_STORY can have subtasks
 error.task.user.story.pending.subtasks=A USER_STORY cannot be marked as DONE while it has subtasks that are not DONE
+error.task.user.story.status.not.editable=The status of a USER_STORY cannot be set manually for this transition
 error.task.done.requires.estimation=A task cannot be marked as DONE without estimation points
 error.task.done.requires.merged.pr=A task cannot be marked as DONE without at least one merged Pull Request
 error.task.done.has.open.prs=A task cannot be marked as DONE while it has open Pull Requests

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -83,6 +83,7 @@ error.task.assignee.professor.only=Només un professor pot canviar l'assignat de
 error.task.reporter.professor.only=Només un professor pot canviar el reporter de la tasca
 error.task.subtasks.user.story.only=Només les tasques de tipus USER_STORY poden tenir subtasques
 error.task.user.story.pending.subtasks=Una USER_STORY no es pot marcar com a DONE mentre té subtasques que no estan DONE
+error.task.user.story.status.not.editable=L'estat d'una USER_STORY no es pot establir manualment per a aquesta transició
 error.task.done.requires.estimation=Una tasca no es pot marcar com a DONE sense punts d'estimació
 error.task.done.requires.merged.pr=Una tasca no es pot marcar com a DONE sense almenys una Pull Request fusionada
 error.task.done.has.open.prs=Una tasca no es pot marcar com a DONE mentre tingui Pull Requests obertes

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -83,6 +83,7 @@ error.task.assignee.professor.only=Solo un profesor puede cambiar el asignado de
 error.task.reporter.professor.only=Solo un profesor puede cambiar el reporter de la tarea
 error.task.subtasks.user.story.only=Solo las tareas de tipo USER_STORY pueden tener subtareas
 error.task.user.story.pending.subtasks=Una USER_STORY no se puede marcar como DONE mientras tiene subtareas que no están DONE
+error.task.user.story.status.not.editable=El estado de una USER_STORY no se puede establecer manualmente para esta transición
 error.task.done.requires.estimation=Una tarea no se puede marcar como DONE sin puntos de estimación
 error.task.done.requires.merged.pr=Una tarea no se puede marcar como DONE sin al menos una Pull Request fusionada
 error.task.done.has.open.prs=Una tarea no se puede marcar como DONE mientras tenga Pull Requests abiertas

--- a/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
+++ b/src/test/java/org/trackdev/api/service/AccessCheckerTaskPermissionsTest.java
@@ -247,11 +247,51 @@ class AccessCheckerTaskPermissionsTest {
     class CanEditStatusTests {
 
         @Test
-        @DisplayName("USER_STORY status should NOT be editable by anyone")
+        @DisplayName("USER_STORY in TODO with no children: status NOT editable")
         void userStory_statusShouldNotBeEditable() {
             assertFalse(accessChecker.canEditStatus(userStoryTask, "student-id"));
             assertFalse(accessChecker.canEditStatus(userStoryTask, "professor-id"));
             assertFalse(accessChecker.canEditStatus(userStoryTask, "admin-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY in TODO with all subtasks DONE: editable by professor only (TODO → DONE)")
+        void userStoryAllSubtasksDone_statusEditableByProfessorOnly() {
+            Task done1 = createTask(101L, "done-1", TaskType.TASK, TaskStatus.DONE);
+            Task done2 = createTask(102L, "done-2", TaskType.TASK, TaskStatus.DONE);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(done1, done2));
+
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "student-id"));
+            assertTrue(accessChecker.canEditStatus(userStoryTask, "professor-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY in TODO with mixed subtasks: NOT editable even by professor")
+        void userStoryMixedSubtasks_statusNotEditableByProfessor() {
+            Task done = createTask(101L, "done", TaskType.TASK, TaskStatus.DONE);
+            Task pending = createTask(102L, "pending", TaskType.TASK, TaskStatus.INPROGRESS);
+            ReflectionTestUtils.setField(userStoryTask, "childTasks", List.of(done, pending));
+
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "professor-id"));
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY in DONE: editable by professor only (DONE → TODO revert)")
+        void userStoryInDone_statusEditableByProfessorOnly() {
+            ReflectionTestUtils.setField(userStoryTask, "status", TaskStatus.DONE);
+
+            assertTrue(accessChecker.canEditStatus(userStoryTask, "professor-id"));
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "student-id"));
+        }
+
+        @Test
+        @DisplayName("USER_STORY in BACKLOG: NOT editable even by professor")
+        void userStoryInBacklog_statusNotEditable() {
+            ReflectionTestUtils.setField(userStoryTask, "status", TaskStatus.BACKLOG);
+
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "professor-id"));
+            assertFalse(accessChecker.canEditStatus(userStoryTask, "student-id"));
         }
 
         @Test
@@ -1033,7 +1073,7 @@ class AccessCheckerTaskPermissionsTest {
         @Test
         @DisplayName("USER_STORY constraints cannot be bypassed")
         void userStoryConstraints_cannotBeBypassed() {
-            // Status never editable
+            // Status not editable in TODO with no children (cascade preconditions not met)
             assertFalse(accessChecker.canEditStatus(userStoryTask, "admin-id"));
             
             // Type never editable

--- a/src/test/java/org/trackdev/api/service/TaskServiceStatusTransitionTest.java
+++ b/src/test/java/org/trackdev/api/service/TaskServiceStatusTransitionTest.java
@@ -197,5 +197,130 @@ class TaskServiceStatusTransitionTest {
             assertEquals(TaskStatus.INPROGRESS, task.getStatus(), "task should be INPROGRESS");
             assertEquals(TaskStatus.TODO, story.getStatus(), "parent USER_STORY should revert to TODO");
         }
+
+        @Test
+        @DisplayName("Cascade promotes parent in BACKLOG once last subtask reaches DONE")
+        void cascade_promotesParentEvenIfBacklog() {
+            // Reproduces the silent-cascade bug: parent in BACKLOG with all children
+            // DONE used to throw INVALID_STATUS_TRANSITION (BACKLOG → DONE not in
+            // the USER_STORY graph) and roll back the whole transaction. The
+            // centralized reconcile now uses forceSetStatus, so the cascade lands.
+            Task task = makeTask(10L, TaskType.TASK, TaskStatus.VERIFY);
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.BACKLOG);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(task)));
+            task.setParentTask(story);
+
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(task));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);
+
+            taskService.editTask(10L, patch, "professor-id");
+
+            assertEquals(TaskStatus.DONE, task.getStatus(), "subtask should reach DONE");
+            assertEquals(TaskStatus.DONE, story.getStatus(),
+                    "parent USER_STORY should be promoted regardless of starting state");
+        }
+
+        @Test
+        @DisplayName("Re-saving a DONE subtask reconciles a stale parent stuck in TODO")
+        void cascade_reconcilesStaleParentOnDoneNoOp() {
+            // Defensive scenario: the parent somehow drifted out of sync (e.g. a
+            // historical bug or partial rollback) so it sits in TODO while every
+            // child is already DONE. The cascade has to fire even when this
+            // subtask's status is unchanged, so re-submitting DONE on a child
+            // brings the user story back into compliance.
+            Task done1 = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+            Task done2 = makeTask(10L, TaskType.TASK, TaskStatus.DONE);
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.TODO);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(done1, done2)));
+            done1.setParentTask(story);
+            done2.setParentTask(story);
+
+            when(taskRepository.findById(10L)).thenReturn(Optional.of(done2));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);  // no-op for the child
+
+            taskService.editTask(10L, patch, "professor-id");
+
+            assertEquals(TaskStatus.DONE, story.getStatus(),
+                    "stale parent in TODO should be reconciled to DONE on re-save");
+        }
+    }
+
+    // =========================================================================
+    // Professor manual USER_STORY transitions
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Professor manual USER_STORY status transitions")
+    class UserStoryManualTransitionTests {
+
+        @Test
+        @DisplayName("Professor can set USER_STORY TODO → DONE when all subtasks are DONE")
+        void professor_canFlipUserStoryToDoneWhenChildrenDone() {
+            Task done1 = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+            Task done2 = makeTask(12L, TaskType.TASK, TaskStatus.DONE);
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.TODO);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(done1, done2)));
+
+            when(taskRepository.findById(20L)).thenReturn(Optional.of(story));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);
+
+            assertDoesNotThrow(() -> taskService.editTask(20L, patch, "professor-id"));
+            assertEquals(TaskStatus.DONE, story.getStatus());
+        }
+
+        @Test
+        @DisplayName("Professor cannot flip USER_STORY to DONE while children are still pending")
+        void professor_cannotFlipUserStoryToDoneWithPendingChildren() {
+            Task done = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+            Task pending = makeTask(12L, TaskType.TASK, TaskStatus.INPROGRESS);
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.TODO);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(done, pending)));
+
+            when(taskRepository.findById(20L)).thenReturn(Optional.of(story));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);
+
+            assertThrows(Exception.class, () -> taskService.editTask(20L, patch, "professor-id"));
+            assertEquals(TaskStatus.TODO, story.getStatus(), "story status must not change");
+        }
+
+        @Test
+        @DisplayName("Professor can revert USER_STORY DONE → TODO")
+        void professor_canRevertUserStoryFromDone() {
+            Task done = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.DONE);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(done)));
+
+            when(taskRepository.findById(20L)).thenReturn(Optional.of(story));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.TODO);
+
+            assertDoesNotThrow(() -> taskService.editTask(20L, patch, "professor-id"));
+            assertEquals(TaskStatus.TODO, story.getStatus());
+        }
+
+        @Test
+        @DisplayName("Professor cannot flip USER_STORY directly from BACKLOG (must add a sprint first)")
+        void professor_cannotFlipUserStoryFromBacklog() {
+            Task done = makeTask(11L, TaskType.TASK, TaskStatus.DONE);
+            Task story = makeTask(20L, TaskType.USER_STORY, TaskStatus.BACKLOG);
+            ReflectionTestUtils.setField(story, "childTasks", new ArrayList<>(List.of(done)));
+
+            when(taskRepository.findById(20L)).thenReturn(Optional.of(story));
+
+            MergePatchTask patch = new MergePatchTask();
+            patch.status = Optional.of(TaskStatus.DONE);
+
+            assertThrows(Exception.class, () -> taskService.editTask(20L, patch, "professor-id"));
+            assertEquals(TaskStatus.BACKLOG, story.getStatus());
+        }
     }
 }


### PR DESCRIPTION
## Summary

USER_STORY status changes are now validated so students cannot edit them manually while professors can perform two explicit transitions: TODO to DONE when all subtasks are done, and DONE to TODO as a revert. PR status revert logic was updated to delegate parent story reconciliation to a centralized method in TaskService, replacing ad-hoc per-caller logic. Error constants and i18n messages were added for the new validation, and tests were updated to cover the new permission and cascade rules.

## Commits

- `2a05b50` feat(service): update user story status edit permission for professors
- `27cf051` feat(service): update pr status revert to use centralized story cascade
- `c7725cc` feat(service): update story status transitions with professor validation
- `761b229` feat(utils): update error constants with user story status error key
- `09db445` chore(resources): update messages with user story status error key
- `ed80b9a` chore(resources): update catalan messages with user story status key
- `c792f37` chore(resources): update spanish messages with user story status key
- `2342436` test(service): update access checker tests for user story status rules
- `0d45ae6` test(service): update task status transition tests for story cascade rules
