### PR TITLE
Add email notifications for points review conversations

### DIFF
--- a/src/main/java/org/trackdev/api/service/EmailNotificationService.java
+++ b/src/main/java/org/trackdev/api/service/EmailNotificationService.java
@@ -1,0 +1,154 @@
+package org.trackdev.api.service;
+
+import org.springframework.stereotype.Service;
+import org.trackdev.api.entity.Course;
+import org.trackdev.api.entity.PointsReviewConversation;
+import org.trackdev.api.entity.PointsReviewMessage;
+import org.trackdev.api.entity.Project;
+import org.trackdev.api.entity.Task;
+import org.trackdev.api.entity.User;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Domain-level email notifications.
+ *
+ * Mirrors {@link FcmNotificationService} for the email channel: resolves the
+ * relevant recipients for a domain event, filters them by their per-user
+ * notification preference, and delegates the actual templating + sending to
+ * {@link EmailSenderService}.
+ */
+@Service
+public class EmailNotificationService {
+
+    private static final int BODY_PREVIEW_MAX = 240;
+
+    private final EmailSenderService emailSenderService;
+
+    public EmailNotificationService(EmailSenderService emailSenderService) {
+        this.emailSenderService = emailSenderService;
+    }
+
+    /**
+     * Notify the points-review recipients (initiator + participants + course owner, minus the actor)
+     * that a new conversation has been opened on a task. Honors notifyPointsReview.
+     */
+    public void notifyPointsReviewCreated(PointsReviewConversation conversation, User actor) {
+        if (conversation == null) return;
+        Task task = conversation.getTask();
+        if (task == null) return;
+        Set<User> recipients = pointsReviewRecipients(conversation, actor);
+        if (recipients.isEmpty()) return;
+
+        String actorName = actor != null ? actor.getFullName() : "A team member";
+        String taskKey = task.getTaskKey();
+        String taskName = task.getName();
+        Long taskId = task.getId();
+        String language = courseLanguage(task);
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyPointsReview())) continue;
+            if (r.getEmail() == null || r.getEmail().isBlank()) continue;
+            emailSenderService.sendPointsReviewCreatedEmail(
+                r.getEmail(), taskKey, taskName, actorName, taskId, language);
+        }
+    }
+
+    /**
+     * Notify all current points-review recipients (minus the message author) of a new message.
+     * Honors notifyPointsReview.
+     */
+    public void notifyPointsReviewMessage(PointsReviewConversation conversation,
+                                          PointsReviewMessage message) {
+        if (conversation == null || message == null) return;
+        Task task = conversation.getTask();
+        if (task == null) return;
+        User author = message.getAuthor();
+        Set<User> recipients = pointsReviewRecipients(conversation, author);
+        if (recipients.isEmpty()) return;
+
+        String authorName = author != null ? author.getFullName() : "Someone";
+        String taskKey = task.getTaskKey();
+        String taskName = task.getName();
+        Long taskId = task.getId();
+        String language = courseLanguage(task);
+        String preview = preview(message.getContent());
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyPointsReview())) continue;
+            if (r.getEmail() == null || r.getEmail().isBlank()) continue;
+            emailSenderService.sendPointsReviewMessageEmail(
+                r.getEmail(), taskKey, taskName, authorName, preview, taskId, language);
+        }
+    }
+
+    /**
+     * Notify all current points-review recipients (minus the editor) that a message
+     * in the conversation has been edited. Honors notifyPointsReview.
+     */
+    public void notifyPointsReviewMessageEdited(PointsReviewConversation conversation,
+                                                PointsReviewMessage message,
+                                                User editor) {
+        if (conversation == null || message == null) return;
+        Task task = conversation.getTask();
+        if (task == null) return;
+        User actor = editor != null ? editor : message.getAuthor();
+        Set<User> recipients = pointsReviewRecipients(conversation, actor);
+        if (recipients.isEmpty()) return;
+
+        String authorName = actor != null ? actor.getFullName() : "Someone";
+        String taskKey = task.getTaskKey();
+        String taskName = task.getName();
+        Long taskId = task.getId();
+        String language = courseLanguage(task);
+        String preview = preview(message.getContent());
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyPointsReview())) continue;
+            if (r.getEmail() == null || r.getEmail().isBlank()) continue;
+            emailSenderService.sendPointsReviewMessageEditedEmail(
+                r.getEmail(), taskKey, taskName, authorName, preview, taskId, language);
+        }
+    }
+
+    // -- helpers ------------------------------------------------------------
+
+    private Set<User> pointsReviewRecipients(PointsReviewConversation conversation, User actor) {
+        Set<User> recipients = new LinkedHashSet<>();
+        if (conversation.getInitiator() != null) {
+            recipients.add(conversation.getInitiator());
+        }
+        if (conversation.getParticipants() != null) {
+            recipients.addAll(conversation.getParticipants());
+        }
+        Task task = conversation.getTask();
+        if (task != null && task.getProject() != null && task.getProject().getCourse() != null) {
+            User professor = task.getProject().getCourse().getOwner();
+            if (professor != null) {
+                recipients.add(professor);
+            }
+        }
+        if (actor != null) {
+            recipients.removeIf(u -> u != null && u.getId() != null && u.getId().equals(actor.getId()));
+        }
+        recipients.removeIf(u -> u == null || u.getId() == null);
+        return recipients;
+    }
+
+    private static String courseLanguage(Task task) {
+        if (task == null) return "en";
+        Project project = task.getProject();
+        if (project == null) return "en";
+        Course course = project.getCourse();
+        if (course == null || course.getLanguage() == null) return "en";
+        return course.getLanguage();
+    }
+
+    private static String preview(String html) {
+        if (html == null) return "";
+        String stripped = html.replaceAll("<[^>]*>", "").trim();
+        if (stripped.length() <= BODY_PREVIEW_MAX) return stripped;
+        return stripped.substring(0, BODY_PREVIEW_MAX - 1) + "…";
+    }
+}

--- a/src/main/java/org/trackdev/api/service/EmailSenderService.java
+++ b/src/main/java/org/trackdev/api/service/EmailSenderService.java
@@ -95,17 +95,70 @@ public class EmailSenderService extends BaseServiceUUID<Email, EmailRepository> 
      * Runs asynchronously - caller will not wait for email to be sent.
      */
     @Async
-    public void sendCourseInviteEmail(String email, String token, String courseName, 
+    public void sendCourseInviteEmail(String email, String token, String courseName,
                                        Integer startYear, String inviterName, String language) {
         Locale locale = Locale.forLanguageTag(language != null ? language : "en");
         String inviteLink = frontendUrl + "/invite/" + token;
-        
-        String subject = messageSource.getMessage("email.invite.subject", 
+
+        String subject = messageSource.getMessage("email.invite.subject",
             new Object[]{courseName, startYear, startYear + 1}, locale);
-        String body = messageSource.getMessage("email.invite.body", 
+        String body = messageSource.getMessage("email.invite.body",
             new Object[]{inviterName, courseName, startYear, startYear + 1, inviteLink}, locale);
 
         sendEmail(email, subject, body, "course-invite");
+    }
+
+    /**
+     * Send notification when a new points review conversation has been opened on a task.
+     * Runs asynchronously - caller will not wait for email to be sent.
+     */
+    @Async
+    public void sendPointsReviewCreatedEmail(String to, String taskKey, String taskName,
+                                             String actorName, Long taskId, String language) {
+        Locale locale = Locale.forLanguageTag(language != null ? language : "en");
+        String taskUrl = frontendUrl + "/dashboard/tasks/" + taskId;
+        String subject = messageSource.getMessage("email.pointsReview.created.subject",
+            new Object[]{taskKey}, locale);
+        String body = messageSource.getMessage("email.pointsReview.created.body",
+            new Object[]{actorName, taskKey, taskName, taskUrl}, locale);
+
+        sendEmail(to, subject, body, "points-review-created");
+    }
+
+    /**
+     * Send notification when a new message has been added to a points review conversation.
+     * Runs asynchronously - caller will not wait for email to be sent.
+     */
+    @Async
+    public void sendPointsReviewMessageEmail(String to, String taskKey, String taskName,
+                                             String authorName, String messagePreview,
+                                             Long taskId, String language) {
+        Locale locale = Locale.forLanguageTag(language != null ? language : "en");
+        String taskUrl = frontendUrl + "/dashboard/tasks/" + taskId;
+        String subject = messageSource.getMessage("email.pointsReview.message.subject",
+            new Object[]{authorName, taskKey}, locale);
+        String body = messageSource.getMessage("email.pointsReview.message.body",
+            new Object[]{authorName, taskKey, taskName, messagePreview, taskUrl}, locale);
+
+        sendEmail(to, subject, body, "points-review-message");
+    }
+
+    /**
+     * Send notification when an existing message in a points review conversation has been edited.
+     * Runs asynchronously - caller will not wait for email to be sent.
+     */
+    @Async
+    public void sendPointsReviewMessageEditedEmail(String to, String taskKey, String taskName,
+                                                   String authorName, String messagePreview,
+                                                   Long taskId, String language) {
+        Locale locale = Locale.forLanguageTag(language != null ? language : "en");
+        String taskUrl = frontendUrl + "/dashboard/tasks/" + taskId;
+        String subject = messageSource.getMessage("email.pointsReview.messageEdited.subject",
+            new Object[]{authorName, taskKey}, locale);
+        String body = messageSource.getMessage("email.pointsReview.messageEdited.body",
+            new Object[]{authorName, taskKey, taskName, messagePreview, taskUrl}, locale);
+
+        sendEmail(to, subject, body, "points-review-message-edited");
     }
 
     /**

--- a/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
+++ b/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
@@ -32,6 +32,9 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
     @Autowired
     FcmNotificationService fcmNotificationService;
 
+    @Autowired
+    EmailNotificationService emailNotificationService;
+
     /**
      * Create a new points review conversation on a task.
      */
@@ -68,6 +71,7 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         messageRepository.save(firstMessage);
 
         fcmNotificationService.notifyPointsReviewCreated(conversation, initiator);
+        emailNotificationService.notifyPointsReviewCreated(conversation, initiator);
 
         return conversation;
     }
@@ -167,6 +171,7 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
         messageRepository.save(message);
 
         fcmNotificationService.notifyPointsReviewMessage(conversation, message);
+        emailNotificationService.notifyPointsReviewMessage(conversation, message);
 
         return message;
     }
@@ -185,7 +190,12 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
 
         HtmlSanitizer.validate(content);
         message.setContent(content);
-        return messageRepository.save(message);
+        PointsReviewMessage saved = messageRepository.save(message);
+
+        User editor = userService.get(userId);
+        emailNotificationService.notifyPointsReviewMessageEdited(saved.getConversation(), saved, editor);
+
+        return saved;
     }
 
     /**

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -38,6 +38,20 @@ email.recovery.body=Hello!<br><br>You have requested to recover your <b>TrackDev
 email.passwordReset.subject=TRACKDEV - Reset Your Password
 email.passwordReset.body=Hello!<br><br>You have requested to reset your <b>TrackDev</b> password. If this wasn't you, please ignore this message.<br><br>Click the link below to reset your password:<br><a href="{0}">Reset Password</a><br><br>This link will expire in {1} hours.<br><br>If the button doesn't work, copy and paste this URL into your browser:<br>{0}<br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>
 
+# Email messages - Points Review Conversation
+# {0}=taskKey
+email.pointsReview.created.subject=TRACKDEV - New points review on {0}
+# {0}=actorName, {1}=taskKey, {2}=taskName, {3}=taskUrl
+email.pointsReview.created.body=Hello!<br><br><b>{0}</b> has opened a points review conversation on task <b>{1} - {2}</b>.<br><br>Open the task to see the proposed points and join the discussion:<br><a href="{3}">View task</a><br><br>You can disable these notifications from your profile settings.<br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>
+# {0}=authorName, {1}=taskKey
+email.pointsReview.message.subject=TRACKDEV - {0} replied on the points review for {1}
+# {0}=authorName, {1}=taskKey, {2}=taskName, {3}=messagePreview, {4}=taskUrl
+email.pointsReview.message.body=Hello!<br><br><b>{0}</b> has posted a new message in the points review conversation on task <b>{1} - {2}</b>.<br><br><i>"{3}"</i><br><br><a href="{4}">View task</a><br><br>You can disable these notifications from your profile settings.<br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>
+# {0}=authorName, {1}=taskKey
+email.pointsReview.messageEdited.subject=TRACKDEV - {0} edited a message in the points review for {1}
+# {0}=authorName, {1}=taskKey, {2}=taskName, {3}=messagePreview, {4}=taskUrl
+email.pointsReview.messageEdited.body=Hello!<br><br><b>{0}</b> has edited a message in the points review conversation on task <b>{1} - {2}</b>.<br><br>Updated content:<br><i>"{3}"</i><br><br><a href="{4}">View task</a><br><br>You can disable these notifications from your profile settings.<br><br>Please do not reply to this message, it is an automatic email.<br><br><b>TrackDev</b>
+
 # ============================================
 # Error Messages - English
 # ============================================

--- a/src/main/resources/messages_ca.properties
+++ b/src/main/resources/messages_ca.properties
@@ -38,6 +38,20 @@ email.recovery.body=Hola!<br><br>Has demanat recuperar la teva contrasenya de <b
 email.passwordReset.subject=TRACKDEV - Restableix la Contrasenya
 email.passwordReset.body=Hola!<br><br>Has demanat restablir la teva contrasenya de <b>TrackDev</b>. Si no has estat tu, si us plau ignora aquest missatge.<br><br>Fes clic al següent enllaç per restablir la teva contrasenya:<br><a href="{0}">Restablir Contrasenya</a><br><br>Aquest enllaç expirarà en {1} hores.<br><br>Si el botó no funciona, copia i enganxa aquesta URL al teu navegador:<br>{0}<br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>
 
+# Email messages - Conversa de Revisió de Punts
+# {0}=taskKey
+email.pointsReview.created.subject=TRACKDEV - Nova revisió de punts a {0}
+# {0}=actorName, {1}=taskKey, {2}=taskName, {3}=taskUrl
+email.pointsReview.created.body=Hola!<br><br><b>{0}</b> ha obert una conversa de revisió de punts sobre la tasca <b>{1} - {2}</b>.<br><br>Obre la tasca per veure els punts proposats i unir-te a la discussió:<br><a href="{3}">Veure la tasca</a><br><br>Pots desactivar aquestes notificacions des de la configuració del teu perfil.<br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>
+# {0}=authorName, {1}=taskKey
+email.pointsReview.message.subject=TRACKDEV - {0} ha respost a la revisió de punts de {1}
+# {0}=authorName, {1}=taskKey, {2}=taskName, {3}=messagePreview, {4}=taskUrl
+email.pointsReview.message.body=Hola!<br><br><b>{0}</b> ha publicat un nou missatge a la conversa de revisió de punts sobre la tasca <b>{1} - {2}</b>.<br><br><i>"{3}"</i><br><br><a href="{4}">Veure la tasca</a><br><br>Pots desactivar aquestes notificacions des de la configuració del teu perfil.<br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>
+# {0}=authorName, {1}=taskKey
+email.pointsReview.messageEdited.subject=TRACKDEV - {0} ha editat un missatge a la revisió de punts de {1}
+# {0}=authorName, {1}=taskKey, {2}=taskName, {3}=messagePreview, {4}=taskUrl
+email.pointsReview.messageEdited.body=Hola!<br><br><b>{0}</b> ha editat un missatge a la conversa de revisió de punts sobre la tasca <b>{1} - {2}</b>.<br><br>Contingut actualitzat:<br><i>"{3}"</i><br><br><a href="{4}">Veure la tasca</a><br><br>Pots desactivar aquestes notificacions des de la configuració del teu perfil.<br><br>Si us plau, no responguis aquest missatge, és un enviament automàtic.<br><br><b>TrackDev</b>
+
 # ============================================
 # Missatges d'Error - Català
 # ============================================

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -38,6 +38,20 @@ email.recovery.body=¡Hola!<br><br>Has solicitado recuperar tu contraseña de <b
 email.passwordReset.subject=TRACKDEV - Restablecer Contraseña
 email.passwordReset.body=¡Hola!<br><br>Has solicitado restablecer tu contraseña de <b>TrackDev</b>. Si no fuiste tú, por favor ignora este mensaje.<br><br>Haz clic en el siguiente enlace para restablecer tu contraseña:<br><a href="{0}">Restablecer Contraseña</a><br><br>Este enlace expirará en {1} horas.<br><br>Si el botón no funciona, copia y pega esta URL en tu navegador:<br>{0}<br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>
 
+# Email messages - Conversación de Revisión de Puntos
+# {0}=taskKey
+email.pointsReview.created.subject=TRACKDEV - Nueva revisión de puntos en {0}
+# {0}=actorName, {1}=taskKey, {2}=taskName, {3}=taskUrl
+email.pointsReview.created.body=¡Hola!<br><br><b>{0}</b> ha abierto una conversación de revisión de puntos sobre la tarea <b>{1} - {2}</b>.<br><br>Abre la tarea para ver los puntos propuestos y unirte a la discusión:<br><a href="{3}">Ver tarea</a><br><br>Puedes deshabilitar estas notificaciones desde la configuración de tu perfil.<br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>
+# {0}=authorName, {1}=taskKey
+email.pointsReview.message.subject=TRACKDEV - {0} ha respondido en la revisión de puntos de {1}
+# {0}=authorName, {1}=taskKey, {2}=taskName, {3}=messagePreview, {4}=taskUrl
+email.pointsReview.message.body=¡Hola!<br><br><b>{0}</b> ha publicado un nuevo mensaje en la conversación de revisión de puntos sobre la tarea <b>{1} - {2}</b>.<br><br><i>"{3}"</i><br><br><a href="{4}">Ver tarea</a><br><br>Puedes deshabilitar estas notificaciones desde la configuración de tu perfil.<br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>
+# {0}=authorName, {1}=taskKey
+email.pointsReview.messageEdited.subject=TRACKDEV - {0} ha editado un mensaje en la revisión de puntos de {1}
+# {0}=authorName, {1}=taskKey, {2}=taskName, {3}=messagePreview, {4}=taskUrl
+email.pointsReview.messageEdited.body=¡Hola!<br><br><b>{0}</b> ha editado un mensaje en la conversación de revisión de puntos sobre la tarea <b>{1} - {2}</b>.<br><br>Contenido actualizado:<br><i>"{3}"</i><br><br><a href="{4}">Ver tarea</a><br><br>Puedes deshabilitar estas notificaciones desde la configuración de tu perfil.<br><br>Por favor, no respondas a este mensaje, es un correo automático.<br><br><b>TrackDev</b>
+
 # ============================================
 # Mensajes de Error - Español
 # ============================================


### PR DESCRIPTION
## Summary

Introduced a new EmailNotificationService that sends email alerts when points review conversations are created, replied to, or edited. Extended EmailSenderService with the corresponding email methods and wired the new service into PointsReviewConversationService. Added email message templates in English, Catalan, and Spanish.

## Commits

- `273b2d0` feat(service): update email sender with points review notifications
- `616807a` feat(service): update points review to trigger email notifications
- `48cc0f2` chore(resources): update messages with points review email templates
- `116dad1` chore(resources): update catalan messages with points review templates
- `4463711` chore(resources): update spanish messages with points review templates
- `671a541` feat(service): add email notification service for points review events
