### PR TITLE
Add active points review conversations overview endpoint

### DIFF
--- a/src/main/java/org/trackdev/api/controller/PointsReviewOverviewController.java
+++ b/src/main/java/org/trackdev/api/controller/PointsReviewOverviewController.java
@@ -1,0 +1,47 @@
+package org.trackdev.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.trackdev.api.dto.PointsReviewActiveConversationDTO;
+import org.trackdev.api.entity.PointsReviewConversation;
+import org.trackdev.api.mapper.PointsReviewConversationMapper;
+import org.trackdev.api.service.PointsReviewConversationService;
+
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * Cross-project points-review queries. Endpoints here are not scoped to a single
+ * task so they cannot live under {@code /tasks/{taskId}/points-reviews}.
+ */
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "10. Points Review")
+@RestController
+@RequestMapping(path = "/points-reviews")
+public class PointsReviewOverviewController extends BaseController {
+
+    @Autowired
+    private PointsReviewConversationService conversationService;
+
+    @Autowired
+    private PointsReviewConversationMapper mapper;
+
+    @Operation(
+        summary = "List active points review conversations visible to the current user",
+        description = "Returns every points review conversation the caller can view, "
+            + "with embedded task / project / course context. Intended for the "
+            + "dashboard overview, where the client groups by project."
+    )
+    @GetMapping("/active")
+    public List<PointsReviewActiveConversationDTO> listActive(Principal principal) {
+        String userId = getUserId(principal);
+        List<PointsReviewConversation> conversations =
+            conversationService.getActiveConversationsForUser(userId);
+        return mapper.toActiveDTOList(conversations);
+    }
+}

--- a/src/main/java/org/trackdev/api/dto/PointsReviewActiveConversationDTO.java
+++ b/src/main/java/org/trackdev/api/dto/PointsReviewActiveConversationDTO.java
@@ -1,0 +1,33 @@
+package org.trackdev.api.dto;
+
+import lombok.Data;
+
+import java.time.ZonedDateTime;
+
+/**
+ * List item for the cross-project "active points reviews" overview.
+ * Carries enough task and project context for the dashboard to render the
+ * conversation in a grouped list without extra lookups.
+ */
+@Data
+public class PointsReviewActiveConversationDTO {
+    private Long id;
+    private UserSummaryDTO initiator;
+    private Integer proposedPoints;
+    private int messageCount;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime lastMessageAt;
+
+    private Long taskId;
+    private String taskKey;
+    private String taskName;
+
+    private Long projectId;
+    private String projectSlug;
+    private String projectName;
+
+    private Long courseId;
+    private Integer courseStartYear;
+    private String subjectName;
+    private String subjectAcronym;
+}

--- a/src/main/java/org/trackdev/api/mapper/PointsReviewConversationMapper.java
+++ b/src/main/java/org/trackdev/api/mapper/PointsReviewConversationMapper.java
@@ -109,4 +109,49 @@ public class PointsReviewConversationMapper {
             .map(this::toSummaryDTO)
             .collect(Collectors.toList());
     }
+
+    /**
+     * Map a conversation to the cross-project "active reviews" list DTO,
+     * including task / project / course identifiers.
+     */
+    public PointsReviewActiveConversationDTO toActiveDTO(PointsReviewConversation conv) {
+        PointsReviewActiveConversationDTO dto = new PointsReviewActiveConversationDTO();
+        dto.setId(conv.getId());
+        dto.setInitiator(userMapper.toSummaryDTO(conv.getInitiator()));
+        dto.setProposedPoints(conv.getProposedPoints());
+        dto.setMessageCount(conv.getMessageCount());
+        dto.setCreatedAt(conv.getCreatedAt());
+        dto.setLastMessageAt(conv.getLastMessageAt());
+
+        org.trackdev.api.entity.Task task = conv.getTask();
+        if (task != null) {
+            dto.setTaskId(task.getId());
+            dto.setTaskKey(task.getTaskKey());
+            dto.setTaskName(task.getName());
+
+            org.trackdev.api.entity.Project project = task.getProject();
+            if (project != null) {
+                dto.setProjectId(project.getId());
+                dto.setProjectSlug(project.getSlug());
+                dto.setProjectName(project.getName());
+
+                org.trackdev.api.entity.Course course = project.getCourse();
+                if (course != null) {
+                    dto.setCourseId(course.getId());
+                    dto.setCourseStartYear(course.getStartYear());
+                    if (course.getSubject() != null) {
+                        dto.setSubjectName(course.getSubject().getName());
+                        dto.setSubjectAcronym(course.getSubject().getAcronym());
+                    }
+                }
+            }
+        }
+        return dto;
+    }
+
+    public List<PointsReviewActiveConversationDTO> toActiveDTOList(List<PointsReviewConversation> conversations) {
+        return conversations.stream()
+            .map(this::toActiveDTO)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/trackdev/api/repository/PointsReviewConversationRepository.java
+++ b/src/main/java/org/trackdev/api/repository/PointsReviewConversationRepository.java
@@ -1,5 +1,7 @@
 package org.trackdev.api.repository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 import org.trackdev.api.entity.PointsReviewConversation;
 
@@ -12,4 +14,24 @@ public interface PointsReviewConversationRepository extends BaseRepositoryLong<P
     Optional<PointsReviewConversation> findByTaskIdAndInitiatorId(Long taskId, String initiatorId);
     boolean existsByTaskIdAndInitiatorId(Long taskId, String initiatorId);
     int countByTaskId(Long taskId);
+
+    /**
+     * All conversations a user can view: they are the initiator, a participant,
+     * or own the course / subject the task belongs to. Used to power the
+     * "active points reviews" overview. Ordered most-recently-updated first.
+     */
+    @Query("SELECT DISTINCT c FROM PointsReviewConversation c " +
+           "LEFT JOIN c.participants p " +
+           "WHERE c.initiator.id = :userId " +
+           "   OR p.id = :userId " +
+           "   OR c.task.project.course.owner.id = :userId " +
+           "   OR c.task.project.course.subject.owner.id = :userId " +
+           "ORDER BY c.updatedAt DESC")
+    List<PointsReviewConversation> findVisibleToUser(@Param("userId") String userId);
+
+    /**
+     * All conversations (admin view). Ordered most-recently-updated first.
+     */
+    @Query("SELECT c FROM PointsReviewConversation c ORDER BY c.updatedAt DESC")
+    List<PointsReviewConversation> findAllOrderByUpdatedAtDesc();
 }

--- a/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
+++ b/src/main/java/org/trackdev/api/service/PointsReviewConversationService.java
@@ -270,6 +270,25 @@ public class PointsReviewConversationService extends BaseServiceLong<PointsRevie
     }
 
     /**
+     * Return all points review conversations the user can view, across every task they
+     * have access to. Used to power the "active reviews" overview.
+     * Admin sees every conversation; everyone else sees conversations they initiated,
+     * participate in, or own (via course / subject).
+     */
+    @Transactional(readOnly = true)
+    public List<PointsReviewConversation> getActiveConversationsForUser(String userId) {
+        User user = userService.get(userId);
+        List<PointsReviewConversation> conversations = accessChecker.isUserAdmin(user)
+            ? repo.findAllOrderByUpdatedAtDesc()
+            : repo.findVisibleToUser(userId);
+
+        for (PointsReviewConversation conv : conversations) {
+            conv.getMessages().size();
+        }
+        return conversations;
+    }
+
+    /**
      * Check if user already has a conversation on this task.
      */
     public boolean hasExistingConversation(Long taskId, String userId) {


### PR DESCRIPTION
## Summary

Adds a cross-project GET /points-reviews/active endpoint that returns all points review conversations visible to the current user, with embedded task, project, and course context. Introduces a new DTO, repository queries for visible and admin views, a service method with role-based dispatch, and a dedicated overview controller.

## Commits

- `4beea4f` feat(mapper): update mapper with active conversation dto mapping
- `0a0405d` feat(repository): update repo with visible and admin overview queries
- `341d1af` feat(service): update service with active conversations overview query
- `16c6564` feat(controller): add overview controller for active points reviews
- `0954211` feat(dto): add dto for active points review conversation overview
