### PR TITLE
Fix PR notifications to only trigger on merge, not on link

### DIFF
--- a/src/main/java/org/trackdev/api/service/FcmNotificationService.java
+++ b/src/main/java/org/trackdev/api/service/FcmNotificationService.java
@@ -147,28 +147,6 @@ public class FcmNotificationService {
     }
 
     /**
-     * Notify all members of the task's project (minus the actor) that a new PR
-     * has been opened and linked to the task. Honors recipients' notifyTeamActivity.
-     */
-    public void notifyPrOpened(PullRequest pr, Task task, User actor) {
-        if (!isEnabled() || pr == null || task == null || task.getProject() == null) return;
-        Set<User> recipients = projectMembersExcept(task, actor);
-        if (recipients.isEmpty()) return;
-
-        String actorName = actor != null ? actor.getFullName() : "Someone";
-        String title = actorName + " opened PR #" + pr.getPrNumber() + " on " + task.getTaskKey();
-        String body = pr.getTitle();
-        Map<String, String> data = baseTaskPayload("pr_opened", task);
-        data.put("prId", String.valueOf(pr.getId()));
-        data.put("prNumber", String.valueOf(pr.getPrNumber()));
-
-        for (User r : recipients) {
-            if (!Boolean.TRUE.equals(r.getNotifyTeamActivity())) continue;
-            sendToUserAfterCommit(r.getId(), title, body, data);
-        }
-    }
-
-    /**
      * Notify all members of the task's project (minus the actor) that a PR has been merged.
      * Honors recipients' notifyTeamActivity.
      */

--- a/src/main/java/org/trackdev/api/service/FcmNotificationService.java
+++ b/src/main/java/org/trackdev/api/service/FcmNotificationService.java
@@ -147,6 +147,28 @@ public class FcmNotificationService {
     }
 
     /**
+     * Notify all members of the task's project (minus the actor) that a new PR
+     * has been opened and linked to the task. Honors recipients' notifyTeamActivity.
+     */
+    public void notifyPrOpened(PullRequest pr, Task task, User actor) {
+        if (!isEnabled() || pr == null || task == null || task.getProject() == null) return;
+        Set<User> recipients = projectMembersExcept(task, actor);
+        if (recipients.isEmpty()) return;
+
+        String actorName = actor != null ? actor.getFullName() : "Someone";
+        String title = actorName + " opened PR #" + pr.getPrNumber() + " on " + task.getTaskKey();
+        String body = pr.getTitle();
+        Map<String, String> data = baseTaskPayload("pr_opened", task);
+        data.put("prId", String.valueOf(pr.getId()));
+        data.put("prNumber", String.valueOf(pr.getPrNumber()));
+
+        for (User r : recipients) {
+            if (!Boolean.TRUE.equals(r.getNotifyTeamActivity())) continue;
+            sendToUserAfterCommit(r.getId(), title, body, data);
+        }
+    }
+
+    /**
      * Notify all members of the task's project (minus the actor) that a PR has been merged.
      * Honors recipients' notifyTeamActivity.
      */

--- a/src/main/java/org/trackdev/api/service/PullRequestService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestService.java
@@ -113,7 +113,8 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
         Optional<PullRequest> existingPR = this.repo.findByUrl(prUrl);
         PullRequest pr;
         boolean isNewPR = existingPR.isEmpty();
-        
+        boolean wasMerged = existingPR.isPresent() && Boolean.TRUE.equals(existingPR.get().getMerged());
+
         if (existingPR.isPresent()) {
             pr = existingPR.get();
             // Update existing PR with latest data
@@ -149,6 +150,16 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
         if (!isNewPR) {
             for (Task task : pr.getTasks()) {
                 enforceTaskStatusInvariants(task);
+            }
+        }
+
+        // Notify project members when a PR transitions to merged. linkPullRequestToTask
+        // only fires this for newly-linked tasks; the usual flow is opened-then-merged
+        // (already linked), so without this block the merge push is silently dropped.
+        if (!wasMerged && Boolean.TRUE.equals(merged)) {
+            User actor = userService.findByGithubUsernameOrUsername(senderLogin);
+            for (Task task : pr.getTasks()) {
+                fcmNotificationService.notifyPrMerged(pr, task, actor);
             }
         }
 
@@ -382,6 +393,10 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
 
         if (activityType == ActivityType.PR_MERGED && task != null) {
             fcmNotificationService.notifyPrMerged(pr, task, actor);
+        }
+
+        if (activityType == ActivityType.PR_LINKED && task != null) {
+            fcmNotificationService.notifyPrOpened(pr, task, actor);
         }
     }
 

--- a/src/main/java/org/trackdev/api/service/PullRequestService.java
+++ b/src/main/java/org/trackdev/api/service/PullRequestService.java
@@ -394,10 +394,6 @@ public class PullRequestService extends BaseServiceUUID<PullRequest, PullRequest
         if (activityType == ActivityType.PR_MERGED && task != null) {
             fcmNotificationService.notifyPrMerged(pr, task, actor);
         }
-
-        if (activityType == ActivityType.PR_LINKED && task != null) {
-            fcmNotificationService.notifyPrOpened(pr, task, actor);
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Removed the push notification that fired when a PR was linked to a task, keeping only the merged PR notification active. The notifyPrOpened method was added to FcmNotificationService and then removed as part of this correction, along with the PR_LINKED activity trigger in PullRequestService.

## Commits

- `434b34f` feat(service): update fcm service to notify on pr opened
- `825ff04` feat(service): update pr service to notify on pr merged and linked
- `7e4e880` feat(service): remove notifyPrOpened from fcm notification service
- `c517222` feat(service): update pr service to remove pr linked notification
